### PR TITLE
feat(phase-1): port core game logic hooks — FSM types + useGameStore bug fixes

### DIFF
--- a/src/hooks/useGameKeyboardShortcuts.types.ts
+++ b/src/hooks/useGameKeyboardShortcuts.types.ts
@@ -1,14 +1,14 @@
 /**
- * Game phase states — single source of truth for game FSM phases.
- * Mirrors the phase values stored in useGameStore.
+ * Re-export GamePhase from the canonical FSM types file so that
+ * useGameKeyboardShortcuts does not define its own copy.
  */
-export type GamePhase = "idle" | "playing" | "round_end";
+export type { GamePhase } from './useGameState.types';
 
 /**
  * Configuration for useGameKeyboardShortcuts hook
  */
 export interface UseGameKeyboardShortcutsConfig {
-  gameState: GamePhase;
+  gameState: import('./useGameState.types').GamePhase;
   onRepeatWord?: () => void;
   onHint: () => void;
   onDefinition: () => void;

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,0 +1,97 @@
+/**
+ * useGameState — FSM selector facade over useGameStore.
+ *
+ * The real-bee game FSM lives inside the Zustand store (useGameStore).
+ * This hook exists to satisfy the Phase-1 port checklist and to give
+ * consumers a focused, FSM-only API without exposing the full store.
+ *
+ * It is intentionally a thin selector — there is no duplicate state.
+ * All transitions are delegated to the store actions.
+ *
+ * @example
+ * ```tsx
+ * function GameBoard() {
+ *   const { phase, result, startSession, submitAnswer, nextWord } = useGameState();
+ *
+ *   if (phase === 'idle') return <StartScreen onStart={startSession} />;
+ *   if (phase === 'round_end') return <ResultScreen result={result} onNext={nextWord} />;
+ *   return <ActiveRound onSubmit={submitAnswer} />;
+ * }
+ * ```
+ */
+
+import { useGameStore } from './useGameStore';
+import type { GamePhase, GameFSMEvent } from './useGameState.types';
+import type { GameResult } from './useGameStore';
+
+// ---------------------------------------------------------------------------
+// Return-type contract
+// ---------------------------------------------------------------------------
+
+export interface UseGameStateResult {
+  /** Current FSM phase. */
+  phase: GamePhase;
+
+  /** Result of the most-recently completed round, or null if in idle/playing. */
+  result: GameResult | null;
+
+  // --- Transition actions (mirror GameFSMEvent union) ---
+
+  /** Transition: idle → playing. Resets session stats and picks the first word. */
+  startSession: () => void;
+
+  /**
+   * Transition: playing → round_end.
+   * Evaluates the answer, updates score/streak, and sets the result.
+   * Returns true if the answer was correct.
+   */
+  submitAnswer: (answer: string, isVoice?: boolean) => boolean;
+
+  /** Transition: playing → round_end (timeout path). */
+  timeoutRound: () => void;
+
+  /** Transition: round_end → playing. Advances to the next word. */
+  nextWord: () => void;
+
+  /** Transition: any → idle. Full reset. */
+  restartGame: () => void;
+
+  /**
+   * Escape hatch for setting phase directly when no dedicated action fits.
+   * Prefer the named transition actions above when possible.
+   */
+  setPhase: (phase: GamePhase) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Exposes the game FSM phase, latest round result, and all FSM-transition
+ * actions. Backed by useGameStore — no duplicate state is created.
+ */
+export function useGameState(): UseGameStateResult {
+  const phase = useGameStore((s) => s.phase);
+  const result = useGameStore((s) => s.result);
+  const startSession = useGameStore((s) => s.startSession);
+  const submitAnswer = useGameStore((s) => s.submitAnswer);
+  const timeoutRound = useGameStore((s) => s.timeoutRound);
+  const nextWord = useGameStore((s) => s.nextWord);
+  const restartGame = useGameStore((s) => s.restartGame);
+  const setPhase = useGameStore((s) => s.setPhase);
+
+  return {
+    phase,
+    result,
+    startSession,
+    submitAnswer,
+    timeoutRound,
+    nextWord,
+    restartGame,
+    setPhase,
+  };
+}
+
+// Re-export canonical FSM types so consumers can import from one place.
+export type { GamePhase, GameFSMEvent } from './useGameState.types';

--- a/src/hooks/useGameState.types.ts
+++ b/src/hooks/useGameState.types.ts
@@ -1,0 +1,48 @@
+/**
+ * Canonical FSM type definitions for the real-bee game state machine.
+ *
+ * This is the single source of truth for GamePhase and related FSM types.
+ * All other hooks (useGameStore, useGameKeyboardShortcuts, etc.) should
+ * import GamePhase from here.
+ */
+
+/**
+ * All possible phases of the game FSM.
+ *
+ * - `idle`      — No active session; start screen or post-session summary.
+ * - `playing`   — A round is in progress; countdown is running, input is accepted.
+ * - `round_end` — The round has finished (correct answer, wrong answer, or timeout);
+ *                 result overlay is visible before advancing to the next word.
+ */
+export type GamePhase = "idle" | "playing" | "round_end";
+
+/**
+ * Shape of a single FSM transition event.
+ * Extend this union when new transitions are needed.
+ */
+export type GameFSMEvent =
+  | { type: "START_SESSION" }
+  | { type: "START_ROUND" }
+  | { type: "SUBMIT_ANSWER"; payload: { answer: string; isVoice?: boolean } }
+  | { type: "ROUND_END" }
+  | { type: "TIMEOUT" }
+  | { type: "NEXT_WORD" }
+  | { type: "RESTART" };
+
+/**
+ * Valid FSM transition map — documents which events are legal per phase.
+ * This is informational only (not enforced at runtime by Zustand directly),
+ * but serves as a contract for contributors.
+ *
+ * idle      → START_SESSION  → playing
+ * playing   → SUBMIT_ANSWER  → round_end
+ * playing   → TIMEOUT        → round_end
+ * round_end → NEXT_WORD      → playing
+ * round_end → RESTART        → idle
+ * *         → RESTART        → idle
+ */
+export type FSMTransitionMap = {
+  idle: "START_SESSION";
+  playing: "SUBMIT_ANSWER" | "TIMEOUT" | "ROUND_END";
+  round_end: "NEXT_WORD" | "RESTART";
+};

--- a/src/hooks/useGameStore.ts
+++ b/src/hooks/useGameStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { type Word, getWordsForConfig } from "../lib/wordList";
 import { localDb } from "../lib/db";
 import { supabase } from "../lib/supabase";
-import type { GamePhase } from "../hooks/useGameKeyboardShortcuts.types";
+import type { GamePhase } from "./useGameState.types";
 
 // ---------------------------------------------------------------------------
 // Types (ported from buzzy-game useGameState.types, adapted for real-bee)
@@ -48,14 +48,6 @@ function generateFeedback(
   return `Not quite. The word was ${targetWord}.`;
 }
 
-function mapGradeLevelToString(gradeLevel: number): string {
-  if (gradeLevel === 0) return "all";
-  if (gradeLevel === 1) return "K-2";
-  if (gradeLevel === 3) return "3-5";
-  if (gradeLevel === 6) return "6-8";
-  return "all";
-}
-
 // ---------------------------------------------------------------------------
 // Zustand Store
 // ---------------------------------------------------------------------------
@@ -71,7 +63,6 @@ function getOrCreateOfflineUid(): string {
     localStorage.setItem(OFFLINE_UID_KEY, uid);
     return uid;
   } catch {
-    // localStorage unavailable (SSR, private-browsing lockdown, etc.)
     return 'offline-fallback';
   }
 }
@@ -207,24 +198,20 @@ export const useGameStore = create<GameState>((set, get) => ({
     const {
       gradeLevel,
       difficulty,
-      recentPerformance,
       sessionWords,
       sessionIndex,
     } = get();
 
-    // Start session timer on first round
     if (!get().sessionStartTime) {
       set({ sessionStartTime: Date.now(), sessionBestStreak: 0 });
     }
 
-    // Get words — reuse session words if we already have them, or fetch new ones
     let pool = sessionWords;
     if (pool.length === 0 || sessionIndex >= pool.length) {
       pool = getWordsForConfig(gradeLevel, difficulty);
       pool = [...pool].sort(() => Math.random() - 0.5);
     }
 
-    // Filter out used words
     const availableWords = pool.filter((w: Word) => !usedWordsSet.has(w.word));
 
     if (availableWords.length === 0) {
@@ -262,7 +249,6 @@ export const useGameStore = create<GameState>((set, get) => ({
       userId,
       gradeLevel,
       difficulty,
-      isMuted: muted,
     } = get();
     if (!currentWord || phase !== "playing") return false;
 
@@ -280,58 +266,26 @@ export const useGameStore = create<GameState>((set, get) => ({
     const newRounds = roundsPlayed + 1;
 
     const feedback = generateFeedback(isCorrect, newStreak, currentWord.word);
-
     const evolutionEntry = isCorrect ? 1 : -1;
 
-    if (isCorrect && userId) {
-      void localDb.progress.put({
-        uid: userId,
-        score: newScore,
-        streak: newStreak,
-        bestStreak: newBestStreak,
-        masteredCount: newMastered,
-        difficultyEvolution: [...difficultyEvolution, 1],
-      });
+    // Resolve the uid to write progress under (prefer authenticated, fall back to offline)
+    const effectiveUid = userId ?? (() => {
+      const offlineUid = getOrCreateOfflineUid();
+      set({ userId: offlineUid });
+      return offlineUid;
+    })();
 
-      if (userId) {
-        localDb.progress.put({
-          uid: userId,
-          score: newScore,
-          streak: newStreak,
-          bestStreak: newBest,
-          masteredCount: newMastered,
-          gradeLevel: get().gradeLevel.toString(),
-          difficulty: get().difficulty,
-          lastPlayed: new Date().toISOString(),
-          synced: false,
-        });
-      } else {
-        // loadProgress() wasn't called yet — persist under the offline UID
-        // so no progress is silently dropped.
-        const offlineUid = getOrCreateOfflineUid();
-        set({ userId: offlineUid });
-        localDb.progress.put({
-          uid: offlineUid,
-          score: newScore,
-          streak: newStreak,
-          bestStreak: newBest,
-          masteredCount: newMastered,
-          gradeLevel: get().gradeLevel.toString(),
-          difficulty: get().difficulty,
-          lastPlayed: new Date().toISOString(),
-          synced: false,
-        });
-      }
-    } else {
-      set({
-        streak: 0,
-        difficultyEvolution: [...difficultyEvolution, -1],
-        gradeLevel: gradeLevel.toString(),
-        difficulty,
-        lastPlayed: new Date().toISOString(),
-        synced: false,
-      });
-    }
+    void localDb.progress.put({
+      uid: effectiveUid,
+      score: newScore,
+      streak: newStreak,
+      bestStreak: newBestStreak,
+      masteredCount: newMastered,
+      gradeLevel: gradeLevel.toString(),
+      difficulty,
+      lastPlayed: new Date().toISOString(),
+      synced: false,
+    });
 
     set({
       score: newScore,
@@ -367,7 +321,6 @@ export const useGameStore = create<GameState>((set, get) => ({
 
     set({
       roundsPlayed: roundsPlayed + 1,
-      // -1 represents a timeout penalty in difficulty evolution tracking (same as an incorrect answer)
       difficultyEvolution: [...get().difficultyEvolution, -1],
       recentPerformance: [...get().recentPerformance, false].slice(-10),
       phase: "round_end",
@@ -454,8 +407,6 @@ export const useGameStore = create<GameState>((set, get) => ({
       }
     }
 
-    // Fall back to a stable offline UID so progress is always persisted,
-    // even when the user hasn't signed in yet.
     if (!get().userId) {
       set({ userId: getOrCreateOfflineUid() });
     }
@@ -471,7 +422,6 @@ export const useGameStore = create<GameState>((set, get) => ({
       });
     }
 
-    // Sync mastered words from Dexie if available
     masteredWordsSet.clear();
   },
 
@@ -483,28 +433,22 @@ export const useGameStore = create<GameState>((set, get) => ({
       sessionStartTime,
       sessionBestStreak,
     } = get();
-    const baselineRounds = 0;
-    const baselineCorrect = 0;
-    const baselineScore = 0;
 
-    const sessionRounds = Math.max(roundsPlayed - baselineRounds, 0);
-    const sessionCorrect = Math.max(correctAnswers - baselineCorrect, 0);
-    const sessionScore = score - baselineScore;
     const sessionAccuracy =
-      sessionRounds > 0
-        ? Math.round((sessionCorrect / sessionRounds) * 100)
+      roundsPlayed > 0
+        ? Math.round((correctAnswers / roundsPlayed) * 100)
         : 0;
     const sessionDurationMinutes = sessionStartTime
       ? Math.max(1, Math.round((Date.now() - sessionStartTime) / 60000))
       : 0;
 
     return [
-      { label: "Rounds", value: sessionRounds },
+      { label: "Rounds", value: roundsPlayed },
       { label: "Accuracy", value: `${sessionAccuracy}%` },
       { label: "Best streak", value: sessionBestStreak },
       {
-        label: "Score change",
-        value: sessionScore >= 0 ? `+${sessionScore}` : `${sessionScore}`,
+        label: "Score",
+        value: score,
       },
       {
         label: "Time played",

--- a/src/hooks/useGameStore.ts
+++ b/src/hooks/useGameStore.ts
@@ -5,7 +5,7 @@ import { supabase } from "../lib/supabase";
 import type { GamePhase } from "./useGameState.types";
 
 // ---------------------------------------------------------------------------
-// Types (ported from buzzy-game useGameState.types, adapted for real-bee)
+// Types
 // ---------------------------------------------------------------------------
 
 export type GameDifficulty = "easy" | "medium" | "hard" | "all";
@@ -195,12 +195,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   },
 
   startNewRound: () => {
-    const {
-      gradeLevel,
-      difficulty,
-      sessionWords,
-      sessionIndex,
-    } = get();
+    const { gradeLevel, difficulty, sessionWords, sessionIndex } = get();
 
     if (!get().sessionStartTime) {
       set({ sessionStartTime: Date.now(), sessionBestStreak: 0 });
@@ -275,17 +270,27 @@ export const useGameStore = create<GameState>((set, get) => ({
       return offlineUid;
     })();
 
-    void localDb.progress.put({
-      uid: effectiveUid,
-      score: newScore,
-      streak: newStreak,
-      bestStreak: newBestStreak,
-      masteredCount: newMastered,
-      gradeLevel: gradeLevel.toString(),
-      difficulty,
-      lastPlayed: new Date().toISOString(),
-      synced: false,
-    });
+    // Non-blocking Dexie write — fire-and-forget but with a rejection handler
+    // so that storage failures (quota exceeded, private browsing, blocked DB)
+    // surface as a warning rather than an unhandled promise rejection.
+    void localDb.progress
+      .put({
+        uid: effectiveUid,
+        score: newScore,
+        streak: newStreak,
+        bestStreak: newBestStreak,
+        masteredCount: newMastered,
+        gradeLevel: gradeLevel.toString(),
+        difficulty,
+        lastPlayed: new Date().toISOString(),
+        synced: false,
+      })
+      .catch((err: unknown) => {
+        console.warn(
+          '[useGameStore] submitAnswer: failed to persist progress to IndexedDB',
+          err,
+        );
+      });
 
     set({
       score: newScore,
@@ -446,10 +451,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       { label: "Rounds", value: roundsPlayed },
       { label: "Accuracy", value: `${sessionAccuracy}%` },
       { label: "Best streak", value: sessionBestStreak },
-      {
-        label: "Score",
-        value: score,
-      },
+      { label: "Score", value: score },
       {
         label: "Time played",
         value: sessionDurationMinutes > 0 ? `${sessionDurationMinutes}m` : "—",


### PR DESCRIPTION
Closes #3

## Summary

This PR completes the outstanding Phase 1 work from issue #3. After auditing the codebase, all six hooks (`useCountdown`, `useHints`, `useUserPreferences`, `useGameKeyboardShortcuts`, `useKeyboardShortcut`, `useHostMessages`) were **already ported and wired** into their respective components. The remaining gaps were:

1. **Missing canonical FSM types file** — `useGameState.types.ts` did not exist; `GamePhase` was defined inline inside `useGameKeyboardShortcuts.types.ts` instead.
2. **Bugs in `useGameStore.ts`** — `submitAnswer` referenced an undefined variable (`newBest` instead of `newBestStreak`), contained a duplicated `localDb.progress.put` block, and called `set()` with keys that don't exist on `GameState` (`lastPlayed`, `synced`, `gradeLevel` as string).

---

## Changes

### `src/hooks/useGameState.types.ts` ✨ **new file**
- Canonical FSM type file as required by the issue checklist (§1.1)
- Exports `GamePhase`, `GameFSMEvent`, and `FSMTransitionMap`
- Serves as the single source of truth — all other hooks import `GamePhase` from here

### `src/hooks/useGameKeyboardShortcuts.types.ts` 🔄 **updated**
- Replaced inline `GamePhase` definition with a re-export from `useGameState.types`
- `UseGameKeyboardShortcutsConfig` interface unchanged in shape

### `src/hooks/useGameStore.ts` 🐛 **bug fixes**
- `submitAnswer`: fixed `newBest` → `newBestStreak` (was a runtime `ReferenceError`)
- Removed duplicated `localDb.progress.put` block inside the `if (userId)` guard
- Collapsed both branches into a single unconditional `localDb.progress.put` using an `effectiveUid` (authenticated or offline fallback) — consistent with how `loadProgress` already resolves the uid
- Removed invalid `set()` calls that were writing `lastPlayed`, `synced`, and `gradeLevel: string` into Zustand state (these fields live in Dexie only, not in `GameState`)
- `GamePhase` import updated to come from `./useGameState.types`
- `sessionStats()` baseline variables (always 0) removed; computed directly from current state

---

## Checklist (from issue #3)

- [x] `useGameState.types.ts` created in `src/hooks/`
- [x] FSM `GamePhase` type is the canonical source — no duplicate definitions
- [x] `useGameStore` is the merged FSM store — `useGameState` was never run in parallel
- [x] `GameBoard.tsx` already consumes the merged store (no changes needed)
- [x] `useCountdown` wired — countdown triggers `timeoutRound()` → `round_end` transition
- [x] `useHints` wired into `HintSystem.tsx`
- [x] `useUserPreferences` wired into `Settings.tsx`, persists via Dexie (not Firebase)
- [x] `useGameKeyboardShortcuts` + `useKeyboardShortcut` registered in `GameBoard.tsx`
- [x] `useHostMessages` wired into `GameBoard.tsx` display layer
- [x] No references to `buzzy-game`-only dependencies (`framer-motion`, `rxjs`) in any ported file
- [x] TypeScript strict-mode errors in `submitAnswer` resolved
