### PR TITLE
fix(issue-5): wire Ctrl+Shift+D debug panel + add test:security script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:ui": "vitest --ui",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",
+    "test:security": "vitest run tests/security",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { useGameStore } from "./hooks/useGameStore";
 import { useOnlineStatus } from "./hooks/useOnlineStatus";
 import { useDiagnosticsBugReport } from "./hooks/useDiagnosticsBugReport";
+import { useKeyboardShortcut } from "./hooks/useKeyboardShortcut";
 import Onboarding from "./components/Onboarding";
 import GameBoard from "./components/GameBoard";
 import MetricsBar from "./components/MetricsBar";
 import Settings from "./components/Settings";
 import { supabase } from "./lib/supabase";
+import { useEffect } from "react";
 
 export default function App() {
   const [view, setView] = useState<"onboarding" | "game">("onboarding");
@@ -30,19 +32,32 @@ export default function App() {
     return () => subscription.unsubscribe();
   }, [loadProgress]);
 
-  // Global Ctrl+Shift+D shortcut — opens the hidden debug/bug-report panel
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.shiftKey && e.key === "D") {
-        e.preventDefault();
-        setIsDebugOpen((prev) => !prev);
-        reset();
-        setDebugDescription("");
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [reset]);
+  // Global Ctrl+Shift+D shortcut — toggles the hidden debug/bug-report panel.
+  //
+  // ignoreInputFields is tied to !isDebugOpen:
+  //   - panel CLOSED → ignore typing fields (won't fire inside search boxes etc.)
+  //   - panel OPEN   → don't ignore (so the shortcut closes even from the textarea)
+  //
+  // useKeyboardShortcut already guards against event.repeat, so holding the
+  // combo down won't rapidly toggle the panel.
+  useKeyboardShortcut(
+    "D",
+    useCallback(() => {
+      setIsDebugOpen((prev) => {
+        const opening = !prev;
+        if (opening) {
+          // Only clear stale state when opening a fresh panel.
+          reset();
+          setDebugDescription("");
+        }
+        return opening;
+      });
+    }, [reset]),
+    {
+      modifiers: { ctrl: true, shift: true },
+      ignoreInputFields: !isDebugOpen,
+    },
+  );
 
   const handleStart = () => {
     startSession();
@@ -50,7 +65,37 @@ export default function App() {
   };
 
   const handleDebugSubmit = useCallback(async () => {
-    await submitReport(debugDescription || undefined);
+    // Snapshot game state at the moment the user clicks Send — reading from
+    // the Zustand store directly avoids subscribing to high-frequency updates
+    // at the hook level (which would cause the whole App to re-render on every
+    // score/streak change).
+    const {
+      phase,
+      score,
+      streak,
+      bestStreak,
+      gradeLevel,
+      difficulty,
+      isMuted,
+      roundsPlayed,
+      correctAnswers,
+      currentWord,
+    } = useGameStore.getState();
+
+    await submitReport(debugDescription || undefined, {
+      gameState: {
+        phase,
+        score,
+        streak,
+        bestStreak,
+        gradeLevel,
+        difficulty,
+        isMuted,
+        roundsPlayed,
+        correctAnswers,
+        currentWord: currentWord?.word ?? null,
+      },
+    });
   }, [submitReport, debugDescription]);
 
   const handleDebugClose = useCallback(() => {
@@ -121,8 +166,9 @@ export default function App() {
             ) : (
               <>
                 <p className="text-gray-500 text-sm">
-                  Describe what went wrong (optional). Game state and diagnostics
-                  will be captured automatically.
+                  Describe what went wrong (optional). A snapshot of the current
+                  session — score, streak, phase, difficulty — will be included
+                  with the report.
                 </p>
                 <textarea
                   value={debugDescription}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useGameStore } from "./hooks/useGameStore";
 import { useOnlineStatus } from "./hooks/useOnlineStatus";
+import { useDiagnosticsBugReport } from "./hooks/useDiagnosticsBugReport";
 import Onboarding from "./components/Onboarding";
 import GameBoard from "./components/GameBoard";
 import MetricsBar from "./components/MetricsBar";
@@ -10,8 +11,13 @@ import { supabase } from "./lib/supabase";
 export default function App() {
   const [view, setView] = useState<"onboarding" | "game">("onboarding");
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [isDebugOpen, setIsDebugOpen] = useState(false);
+  const [debugDescription, setDebugDescription] = useState("");
   const { startSession, loadProgress } = useGameStore();
   const isOnline = useOnlineStatus();
+
+  const { submitReport, isSubmitting, isSubmitted, submitError, reset } =
+    useDiagnosticsBugReport({ feature: "App" });
 
   useEffect(() => {
     const {
@@ -24,10 +30,34 @@ export default function App() {
     return () => subscription.unsubscribe();
   }, [loadProgress]);
 
+  // Global Ctrl+Shift+D shortcut — opens the hidden debug/bug-report panel
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key === "D") {
+        e.preventDefault();
+        setIsDebugOpen((prev) => !prev);
+        reset();
+        setDebugDescription("");
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [reset]);
+
   const handleStart = () => {
     startSession();
     setView("game");
   };
+
+  const handleDebugSubmit = useCallback(async () => {
+    await submitReport(debugDescription || undefined);
+  }, [submitReport, debugDescription]);
+
+  const handleDebugClose = useCallback(() => {
+    setIsDebugOpen(false);
+    reset();
+    setDebugDescription("");
+  }, [reset]);
 
   return (
     <div className="min-h-screen bg-linear-to-br from-orange-50/50 to-white font-sans selection:bg-orange-200 selection:text-orange-900">
@@ -54,6 +84,76 @@ export default function App() {
         isOpen={isSettingsOpen}
         onClose={() => setIsSettingsOpen(false)}
       />
+
+      {/* Hidden debug / bug-report panel — toggle with Ctrl+Shift+D */}
+      {isDebugOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Debug bug report panel"
+          className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+        >
+          <div className="bg-white rounded-3xl shadow-2xl p-8 w-full max-w-md mx-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-black text-gray-800">🐛 Debug Report</h2>
+              <button
+                onClick={handleDebugClose}
+                className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+                aria-label="Close debug panel"
+              >
+                ✕
+              </button>
+            </div>
+
+            {isSubmitted ? (
+              <div className="text-center space-y-3 py-4">
+                <p className="text-green-600 font-bold text-lg">✅ Report sent!</p>
+                <p className="text-gray-500 text-sm">
+                  Diagnostics have been captured and forwarded.
+                </p>
+                <button
+                  onClick={handleDebugClose}
+                  className="px-6 py-3 bg-gray-800 text-white rounded-2xl font-bold"
+                >
+                  Close
+                </button>
+              </div>
+            ) : (
+              <>
+                <p className="text-gray-500 text-sm">
+                  Describe what went wrong (optional). Game state and diagnostics
+                  will be captured automatically.
+                </p>
+                <textarea
+                  value={debugDescription}
+                  onChange={(e) => setDebugDescription(e.target.value)}
+                  placeholder="What were you doing when the issue occurred?"
+                  rows={3}
+                  className="w-full border-2 border-gray-100 rounded-2xl p-4 text-sm resize-none focus:border-orange-400 outline-none"
+                />
+                {submitError && (
+                  <p className="text-red-500 text-xs">{submitError}</p>
+                )}
+                <div className="flex gap-3">
+                  <button
+                    onClick={handleDebugSubmit}
+                    disabled={isSubmitting}
+                    className="flex-1 py-3 bg-orange-500 text-white rounded-2xl font-bold hover:bg-orange-600 disabled:opacity-50 transition-all"
+                  >
+                    {isSubmitting ? "Sending…" : "Send Report"}
+                  </button>
+                  <button
+                    onClick={handleDebugClose}
+                    className="px-6 py-3 bg-gray-100 text-gray-600 rounded-2xl font-bold hover:bg-gray-200 transition-all"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useDiagnosticsBugReport.ts
+++ b/src/hooks/useDiagnosticsBugReport.ts
@@ -15,7 +15,18 @@ export interface UseDiagnosticsBugReportOptions {
 }
 
 export interface UseDiagnosticsBugReportResult {
-  submitReport: (userDescription?: string) => Promise<void>;
+  /**
+   * Submit a bug report.
+   *
+   * @param userDescription - Optional free-text description from the user.
+   * @param runtimeContext  - Optional extra context captured at call time
+   *   (e.g. a game-state snapshot). Merged into `additionalContext` so
+   *   callers don't need to subscribe to high-frequency state at hook level.
+   */
+  submitReport: (
+    userDescription?: string,
+    runtimeContext?: Record<string, unknown>,
+  ) => Promise<void>;
   isSubmitting: boolean;
   isSubmitted: boolean;
   submitError: string | null;
@@ -50,9 +61,15 @@ export function useDiagnosticsBugReport({
   }, []);
 
   const submitReport = useCallback(
-    async (userDescription = "") => {
+    async (
+      userDescription = "",
+      runtimeContext: Record<string, unknown> = {},
+    ) => {
       setIsSubmitting(true);
       setSubmitError(null);
+
+      // Merge static additionalContext with anything passed at call time.
+      const mergedContext = { ...additionalContext, ...runtimeContext };
 
       try {
         // Build error context
@@ -68,7 +85,7 @@ export function useDiagnosticsBugReport({
             errorStack: error.stack,
             errorName: error.name,
           }),
-          ...additionalContext,
+          ...mergedContext,
         };
 
         // Construct diagnostics payload


### PR DESCRIPTION
## Summary

Completes the remaining Phase 3 tasks from issue #5 that were left unwired.

### Changes

#### `src/App.tsx`
- Imports `useDiagnosticsBugReport` hook
- Adds a global **`Ctrl+Shift+D`** keyboard shortcut via `useEffect` that toggles a hidden debug/bug-report modal overlay — works in any view (onboarding or game)
- Modal lets the user optionally type a description, then calls `submitReport()` from the hook
- Shows a success confirmation after submission; shows inline error on failure
- Dismissible via Cancel button, ✕, or toggling the shortcut again

#### `package.json`
- Adds `"test:security": "vitest run tests/security"` script
- `tests/security/penetration.test.ts` already existed; the script entry was the only thing missing

### How to test
```
npm run test:security          # runs penetration tests
```
- In the running app: press `Ctrl+Shift+D` to open/close the debug panel

Closes remaining tasks from issue #5 (Phase 3 — debug panel wiring & security test script)