### PR TITLE
fix(audio): audioSessionManager — sampleRate regression + init failure retry loop

### DIFF
--- a/src/lib/__tests__/audioSessionManager.test.ts
+++ b/src/lib/__tests__/audioSessionManager.test.ts
@@ -1,12 +1,37 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+// Override the global vi.mock set in src/test/setup.tsx so the real module
+// is loaded for behavioural tests in this file. vi.unmock() is hoisted by
+// Vitest's transform step and therefore runs before any import() calls.
+vi.unmock("@/lib/audioSessionManager");
+
 // ---------------------------------------------------------------------------
 // AudioContext stub factory — creates a fresh stub per test so state does not
 // leak between test cases.
 // ---------------------------------------------------------------------------
-function makeAudioContextStub(initialState: "running" | "suspended" = "running") {
-  return class {
-    state: string = initialState;
+type AudioContextState = "running" | "suspended" | "closed";
+
+interface AudioContextStub {
+  state: AudioContextState;
+  resume: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  createBuffer: ReturnType<typeof vi.fn>;
+  createOscillator: ReturnType<typeof vi.fn>;
+  createGain: ReturnType<typeof vi.fn>;
+  destination: Record<string, never>;
+  currentTime: number;
+  sampleRate: number;
+}
+
+type AudioContextStubConstructor = new (
+  options?: AudioContextOptions,
+) => AudioContextStub;
+
+function makeAudioContextStub(
+  initialState: AudioContextState = "running",
+): AudioContextStubConstructor {
+  return class implements AudioContextStub {
+    state: AudioContextState = initialState;
     resume = vi.fn(async () => {
       this.state = "running";
     });
@@ -16,7 +41,7 @@ function makeAudioContextStub(initialState: "running" | "suspended" = "running")
     createBuffer = vi.fn();
     createOscillator = vi.fn();
     createGain = vi.fn();
-    destination = {};
+    destination = {} as Record<string, never>;
     currentTime = 0;
     sampleRate = 48000; // browser default — NOT 44100
   };
@@ -29,15 +54,16 @@ describe("AudioSessionManager", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   // -------------------------------------------------------------------------
   // Interface contract
   // -------------------------------------------------------------------------
   it("exports audioSessionManager with the expected interface", async () => {
-    (window as any).AudioContext = makeAudioContextStub();
+    vi.stubGlobal("AudioContext", makeAudioContextStub());
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
-    const methods = [
+    const methods: Array<keyof typeof audioSessionManager> = [
       "initialize",
       "ensureActive",
       "cleanup",
@@ -46,7 +72,7 @@ describe("AudioSessionManager", () => {
       "getInitialized",
     ];
     for (const method of methods) {
-      expect(typeof (audioSessionManager as any)[method]).toBe("function");
+      expect(typeof audioSessionManager[method]).toBe("function");
     }
   });
 
@@ -55,17 +81,20 @@ describe("AudioSessionManager", () => {
   // -------------------------------------------------------------------------
   it("does not force sampleRate: 44100 when creating the AudioContext", async () => {
     let capturedOptions: AudioContextOptions | undefined;
-    (window as any).AudioContext = class {
-      state = "running";
-      resume = vi.fn();
-      close = vi.fn();
-      destination = {};
-      currentTime = 0;
-      sampleRate = 48000;
-      constructor(options?: AudioContextOptions) {
-        capturedOptions = options;
-      }
-    };
+    vi.stubGlobal(
+      "AudioContext",
+      class {
+        state = "running";
+        resume = vi.fn();
+        close = vi.fn();
+        destination = {};
+        currentTime = 0;
+        sampleRate = 48000;
+        constructor(options?: AudioContextOptions) {
+          capturedOptions = options;
+        }
+      },
+    );
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     await audioSessionManager.initialize();
     expect(capturedOptions).not.toHaveProperty("sampleRate");
@@ -75,14 +104,17 @@ describe("AudioSessionManager", () => {
   // Bug fix #2: context must be nulled on initialize() failure
   // -------------------------------------------------------------------------
   it("nulls audioContext when initialize() fails so ensureActive() retries cleanly", async () => {
-    (window as any).AudioContext = class {
-      state = "suspended";
-      resume = vi.fn().mockRejectedValue(new Error("resume rejected"));
-      close = vi.fn();
-      destination = {};
-      currentTime = 0;
-      sampleRate = 48000;
-    };
+    vi.stubGlobal(
+      "AudioContext",
+      class {
+        state = "suspended";
+        resume = vi.fn().mockRejectedValue(new Error("resume rejected"));
+        close = vi.fn();
+        destination = {};
+        currentTime = 0;
+        sampleRate = 48000;
+      },
+    );
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
 
     // First call — initialize fails due to resume rejection
@@ -91,9 +123,9 @@ describe("AudioSessionManager", () => {
     expect(audioSessionManager.getContext()).toBeNull();
     expect(audioSessionManager.getInitialized()).toBe(false);
 
-    // Second call — ensureActive() should re-enter initialize(), not hang
-    // Replace stub with a healthy one for the retry
-    (window as any).AudioContext = makeAudioContextStub("running");
+    // Second call — ensureActive() should re-enter initialize(), not hang.
+    // Replace stub with a healthy one for the retry.
+    vi.stubGlobal("AudioContext", makeAudioContextStub("running"));
     const second = await audioSessionManager.ensureActive();
     expect(second.success).toBe(true);
     expect(audioSessionManager.getInitialized()).toBe(true);
@@ -103,7 +135,7 @@ describe("AudioSessionManager", () => {
   // initialize() — happy path
   // -------------------------------------------------------------------------
   it("initialize() sets initialized=true and returns success", async () => {
-    (window as any).AudioContext = makeAudioContextStub("running");
+    vi.stubGlobal("AudioContext", makeAudioContextStub("running"));
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     const result = await audioSessionManager.initialize();
     expect(result.success).toBe(true);
@@ -113,15 +145,20 @@ describe("AudioSessionManager", () => {
 
   it("initialize() is idempotent — second call skips re-creation", async () => {
     let constructCount = 0;
-    (window as any).AudioContext = class {
-      state = "running";
-      resume = vi.fn();
-      close = vi.fn();
-      destination = {};
-      currentTime = 0;
-      sampleRate = 48000;
-      constructor() { constructCount++; }
-    };
+    vi.stubGlobal(
+      "AudioContext",
+      class {
+        state = "running";
+        resume = vi.fn();
+        close = vi.fn();
+        destination = {};
+        currentTime = 0;
+        sampleRate = 48000;
+        constructor() {
+          constructCount++;
+        }
+      },
+    );
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     await audioSessionManager.initialize();
     await audioSessionManager.initialize();
@@ -129,7 +166,7 @@ describe("AudioSessionManager", () => {
   });
 
   it("initialize() resumes a suspended context", async () => {
-    (window as any).AudioContext = makeAudioContextStub("suspended");
+    vi.stubGlobal("AudioContext", makeAudioContextStub("suspended"));
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     const result = await audioSessionManager.initialize();
     expect(result.success).toBe(true);
@@ -137,8 +174,8 @@ describe("AudioSessionManager", () => {
   });
 
   it("initialize() returns an error when AudioContext is not supported", async () => {
-    (window as any).AudioContext = undefined;
-    (window as any).webkitAudioContext = undefined;
+    vi.stubGlobal("AudioContext", undefined);
+    vi.stubGlobal("webkitAudioContext", undefined);
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     const result = await audioSessionManager.initialize();
     expect(result.success).toBe(false);
@@ -149,7 +186,7 @@ describe("AudioSessionManager", () => {
   // ensureActive()
   // -------------------------------------------------------------------------
   it("ensureActive() initializes when no context exists", async () => {
-    (window as any).AudioContext = makeAudioContextStub("running");
+    vi.stubGlobal("AudioContext", makeAudioContextStub("running"));
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     const result = await audioSessionManager.ensureActive();
     expect(result.success).toBe(true);
@@ -157,13 +194,15 @@ describe("AudioSessionManager", () => {
   });
 
   it("ensureActive() resumes a suspended context without re-initializing", async () => {
-    const Stub = makeAudioContextStub("running");
-    (window as any).AudioContext = Stub;
+    vi.stubGlobal("AudioContext", makeAudioContextStub("running"));
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     await audioSessionManager.initialize();
 
-    // Manually suspend the context after init
-    (audioSessionManager.getContext() as any).state = "suspended";
+    // Manually suspend the context after init.
+    // AudioContext.state is readonly in the TS DOM lib; cast to the minimal
+    // structural type needed rather than widening to any.
+    (audioSessionManager.getContext() as { state: string }).state =
+      "suspended";
     const result = await audioSessionManager.ensureActive();
     expect(result.success).toBe(true);
     expect(audioSessionManager.getContext()!.resume).toHaveBeenCalled();
@@ -173,7 +212,7 @@ describe("AudioSessionManager", () => {
   // cleanup()
   // -------------------------------------------------------------------------
   it("cleanup() closes the context and resets state", async () => {
-    (window as any).AudioContext = makeAudioContextStub("running");
+    vi.stubGlobal("AudioContext", makeAudioContextStub("running"));
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     await audioSessionManager.initialize();
     const ctx = audioSessionManager.getContext()!;
@@ -186,7 +225,7 @@ describe("AudioSessionManager", () => {
   });
 
   it("cleanup() is a no-op when never initialized", async () => {
-    (window as any).AudioContext = makeAudioContextStub();
+    vi.stubGlobal("AudioContext", makeAudioContextStub());
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     const result = await audioSessionManager.cleanup();
     expect(result.success).toBe(true);
@@ -196,7 +235,7 @@ describe("AudioSessionManager", () => {
   // audioManager delegation smoke test
   // -------------------------------------------------------------------------
   it("audioManager imports without errors and exposes expected API", async () => {
-    (window as any).AudioContext = makeAudioContextStub();
+    vi.stubGlobal("AudioContext", makeAudioContextStub());
     const mod = await import("@/lib/audioManager");
     expect(mod.audioManager).toBeDefined();
     expect(typeof mod.audioManager.speak).toBe("function");

--- a/src/lib/__tests__/audioSessionManager.test.ts
+++ b/src/lib/__tests__/audioSessionManager.test.ts
@@ -1,54 +1,206 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-describe("AudioSessionManager integration", () => {
-  beforeAll(() => {
-    // Provide minimal AudioContext stub for jsdom environment
-    if (typeof window !== "undefined" && !window.AudioContext) {
-      (window as any).AudioContext = class {
-        state = "running";
-        resume = vi.fn().mockResolvedValue(undefined);
-        close = vi.fn().mockResolvedValue(undefined);
-        createBuffer = vi.fn();
-        createOscillator = vi.fn();
-        createGain = vi.fn();
-        destination = {};
-        currentTime = 0;
-        sampleRate = 44100;
-      };
-    }
+// ---------------------------------------------------------------------------
+// AudioContext stub factory — creates a fresh stub per test so state does not
+// leak between test cases.
+// ---------------------------------------------------------------------------
+function makeAudioContextStub(initialState: "running" | "suspended" = "running") {
+  return class {
+    state: string = initialState;
+    resume = vi.fn(async () => {
+      this.state = "running";
+    });
+    close = vi.fn(async () => {
+      this.state = "closed";
+    });
+    createBuffer = vi.fn();
+    createOscillator = vi.fn();
+    createGain = vi.fn();
+    destination = {};
+    currentTime = 0;
+    sampleRate = 48000; // browser default — NOT 44100
+  };
+}
+
+describe("AudioSessionManager", () => {
+  beforeEach(() => {
+    vi.resetModules();
   });
 
-  afterAll(() => {
+  afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("audioManager imports audioSessionManager without errors", async () => {
-    const mod = await import("@/lib/audioManager");
-    expect(mod.audioManager).toBeDefined();
-    expect(typeof mod.audioManager.speak).toBe("function");
-    expect(typeof mod.audioManager.playEffect).toBe("function");
-    expect(typeof mod.audioManager.setMuted).toBe("function");
-  });
-
-  it("audioSessionManager has expected interface", async () => {
-    const asm = await import("@/lib/audioSessionManager");
-    expect(asm.audioSessionManager).toBeDefined();
+  // -------------------------------------------------------------------------
+  // Interface contract
+  // -------------------------------------------------------------------------
+  it("exports audioSessionManager with the expected interface", async () => {
+    (window as any).AudioContext = makeAudioContextStub();
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
     const methods = [
       "initialize",
       "ensureActive",
       "cleanup",
       "getRoutingState",
       "getContext",
+      "getInitialized",
     ];
     for (const method of methods) {
-      expect(typeof (asm.audioSessionManager as any)[method]).toBe("function");
+      expect(typeof (audioSessionManager as any)[method]).toBe("function");
     }
   });
 
-  it("cleanup returns success", async () => {
+  // -------------------------------------------------------------------------
+  // Bug fix #1: sampleRate must NOT be locked to 44100
+  // -------------------------------------------------------------------------
+  it("does not force sampleRate: 44100 when creating the AudioContext", async () => {
+    let capturedOptions: AudioContextOptions | undefined;
+    (window as any).AudioContext = class {
+      state = "running";
+      resume = vi.fn();
+      close = vi.fn();
+      destination = {};
+      currentTime = 0;
+      sampleRate = 48000;
+      constructor(options?: AudioContextOptions) {
+        capturedOptions = options;
+      }
+    };
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    await audioSessionManager.initialize();
+    expect(capturedOptions).not.toHaveProperty("sampleRate");
+  });
+
+  // -------------------------------------------------------------------------
+  // Bug fix #2: context must be nulled on initialize() failure
+  // -------------------------------------------------------------------------
+  it("nulls audioContext when initialize() fails so ensureActive() retries cleanly", async () => {
+    (window as any).AudioContext = class {
+      state = "suspended";
+      resume = vi.fn().mockRejectedValue(new Error("resume rejected"));
+      close = vi.fn();
+      destination = {};
+      currentTime = 0;
+      sampleRate = 48000;
+    };
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+
+    // First call — initialize fails due to resume rejection
+    const first = await audioSessionManager.initialize();
+    expect(first.success).toBe(false);
+    expect(audioSessionManager.getContext()).toBeNull();
+    expect(audioSessionManager.getInitialized()).toBe(false);
+
+    // Second call — ensureActive() should re-enter initialize(), not hang
+    // Replace stub with a healthy one for the retry
+    (window as any).AudioContext = makeAudioContextStub("running");
+    const second = await audioSessionManager.ensureActive();
+    expect(second.success).toBe(true);
+    expect(audioSessionManager.getInitialized()).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // initialize() — happy path
+  // -------------------------------------------------------------------------
+  it("initialize() sets initialized=true and returns success", async () => {
+    (window as any).AudioContext = makeAudioContextStub("running");
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    const result = await audioSessionManager.initialize();
+    expect(result.success).toBe(true);
+    expect(audioSessionManager.getInitialized()).toBe(true);
+    expect(audioSessionManager.getContext()).not.toBeNull();
+  });
+
+  it("initialize() is idempotent — second call skips re-creation", async () => {
+    let constructCount = 0;
+    (window as any).AudioContext = class {
+      state = "running";
+      resume = vi.fn();
+      close = vi.fn();
+      destination = {};
+      currentTime = 0;
+      sampleRate = 48000;
+      constructor() { constructCount++; }
+    };
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    await audioSessionManager.initialize();
+    await audioSessionManager.initialize();
+    expect(constructCount).toBe(1);
+  });
+
+  it("initialize() resumes a suspended context", async () => {
+    (window as any).AudioContext = makeAudioContextStub("suspended");
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    const result = await audioSessionManager.initialize();
+    expect(result.success).toBe(true);
+    expect(audioSessionManager.getContext()!.resume).toHaveBeenCalled();
+  });
+
+  it("initialize() returns an error when AudioContext is not supported", async () => {
+    (window as any).AudioContext = undefined;
+    (window as any).webkitAudioContext = undefined;
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    const result = await audioSessionManager.initialize();
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not supported/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // ensureActive()
+  // -------------------------------------------------------------------------
+  it("ensureActive() initializes when no context exists", async () => {
+    (window as any).AudioContext = makeAudioContextStub("running");
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    const result = await audioSessionManager.ensureActive();
+    expect(result.success).toBe(true);
+    expect(audioSessionManager.getInitialized()).toBe(true);
+  });
+
+  it("ensureActive() resumes a suspended context without re-initializing", async () => {
+    const Stub = makeAudioContextStub("running");
+    (window as any).AudioContext = Stub;
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    await audioSessionManager.initialize();
+
+    // Manually suspend the context after init
+    (audioSessionManager.getContext() as any).state = "suspended";
+    const result = await audioSessionManager.ensureActive();
+    expect(result.success).toBe(true);
+    expect(audioSessionManager.getContext()!.resume).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // cleanup()
+  // -------------------------------------------------------------------------
+  it("cleanup() closes the context and resets state", async () => {
+    (window as any).AudioContext = makeAudioContextStub("running");
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    await audioSessionManager.initialize();
+    const ctx = audioSessionManager.getContext()!;
+    const result = await audioSessionManager.cleanup();
+    expect(result.success).toBe(true);
+    expect(ctx.close).toHaveBeenCalled();
+    expect(audioSessionManager.getContext()).toBeNull();
+    expect(audioSessionManager.getInitialized()).toBe(false);
+    expect(audioSessionManager.getRoutingState()).toBe("unknown");
+  });
+
+  it("cleanup() is a no-op when never initialized", async () => {
+    (window as any).AudioContext = makeAudioContextStub();
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     const result = await audioSessionManager.cleanup();
-    expect(result).toBeDefined();
     expect(result.success).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // audioManager delegation smoke test
+  // -------------------------------------------------------------------------
+  it("audioManager imports without errors and exposes expected API", async () => {
+    (window as any).AudioContext = makeAudioContextStub();
+    const mod = await import("@/lib/audioManager");
+    expect(mod.audioManager).toBeDefined();
+    expect(typeof mod.audioManager.speak).toBe("function");
+    expect(typeof mod.audioManager.playEffect).toBe("function");
+    expect(typeof mod.audioManager.setMuted).toBe("function");
   });
 });

--- a/src/lib/audioSessionManager.ts
+++ b/src/lib/audioSessionManager.ts
@@ -1,4 +1,5 @@
 import { Sentry } from "./sentry";
+import { TTS_SAMPLE_RATE } from "../constants/audio";
 
 /**
  * Result of an audio session operation.
@@ -22,6 +23,12 @@ class AudioSessionManager {
   /**
    * Initialize the AudioContext with low-latency settings.
    * Idempotent — safe to call multiple times.
+   *
+   * NOTE: sampleRate is intentionally not set so the browser uses its
+   * hardware default. The Gemini TTS worker returns 24 kHz PCM
+   * (TTS_SAMPLE_RATE); the context resamples each AudioBuffer independently
+   * via AudioBuffer.sampleRate — locking the context to 44100 Hz caused
+   * TTS audio to play at the wrong speed.
    */
   async initialize(): Promise<AudioSessionResult> {
     if (this.initialized) return { success: true };
@@ -49,9 +56,10 @@ class AudioSessionManager {
         this.audioContext = null;
       }
 
+      // Do not set sampleRate — let the browser use its hardware default.
+      // Each AudioBuffer carries its own sampleRate for correct resampling.
       this.audioContext = new AudioContextClass({
         latencyHint: "interactive",
-        sampleRate: 44100,
       });
 
       if (this.audioContext.state === "suspended") {
@@ -68,6 +76,10 @@ class AudioSessionManager {
       this.routingState = "speaker";
       return { success: true };
     } catch (error) {
+      // Null out the context so ensureActive() re-enters initialize() rather
+      // than attempting to resume a broken/timed-out context indefinitely.
+      this.audioContext = null;
+      this.initialized = false;
       const message = error instanceof Error ? error.message : "Unknown error";
       console.error("[AudioSession] Init failed:", error);
       Sentry.captureException(error, {
@@ -124,6 +136,14 @@ class AudioSessionManager {
   }
 
   /**
+   * Whether the AudioContext has been successfully initialized.
+   * Exposed so test mocks can stay in sync with the real interface.
+   */
+  getInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
    * Close and clean up the AudioContext.
    * Safe to call even if never initialized.
    */
@@ -148,3 +168,7 @@ class AudioSessionManager {
 }
 
 export const audioSessionManager = new AudioSessionManager();
+
+// Re-export TTS_SAMPLE_RATE so callers don't need a separate constants import
+// when they need to create AudioBuffers at the correct rate.
+export { TTS_SAMPLE_RATE };


### PR DESCRIPTION
## Summary

Fixes two bugs introduced by commit `b216c4e` (issue #31 — `audioSessionManager`) that were committed directly to trunk without review.

---

## Bug 1 — Hardcoded `sampleRate: 44100` breaks Gemini TTS playback

**File:** `src/lib/audioSessionManager.ts`

The `AudioContextClass` constructor was called with `{ sampleRate: 44100 }`. The Gemini TTS worker returns PCM at **24,000 Hz** (`TTS_SAMPLE_RATE`). When the context is locked at 44,100 Hz, the 24 kHz buffer plays at the wrong speed and pitch (approximately 1.84× too fast).

**Fix:** Remove `sampleRate` from the constructor options. Each `AudioBuffer` carries its own `sampleRate`; the Web Audio API resamples independently and correctly without a locked context rate.

```diff
- this.audioContext = new AudioContextClass({
-   latencyHint: "interactive",
-   sampleRate: 44100,
- });
+ // Do not set sampleRate — let the browser use its hardware default.
+ // Each AudioBuffer carries its own sampleRate for correct resampling.
+ this.audioContext = new AudioContextClass({
+   latencyHint: "interactive",
+ });
```

---

## Bug 2 — Failed `initialize()` leaves stale context, causing infinite retry loop

**File:** `src/lib/audioSessionManager.ts`

If `initialize()` threw (e.g. the 5-second resume timeout fired), the `catch` block returned `{ success: false }` but left `this.audioContext` pointing at the broken/timed-out context with `this.initialized = false`. On the next call to `ensureActive()`:

1. `if (!this.audioContext)` → **false** (context still exists)
2. `if (state === 'suspended')` → **true** (still suspended)
3. Resume → timeout again → same catch → same state → repeat indefinitely

**Fix:** Null out `this.audioContext` inside the `catch` block so `ensureActive()` correctly re-enters `initialize()` on the next attempt.

```diff
  } catch (error) {
+   // Null the context so ensureActive() re-enters initialize() rather than
+   // attempting to resume a broken context indefinitely.
+   this.audioContext = null;
+   this.initialized = false;
    const message = error instanceof Error ? error.message : "Unknown error";
```

---

## Additional: `getInitialized()` accessor

`src/test/setup.tsx` mocked `getInitialized` on `audioSessionManager` but the method didn't exist on the class — a phantom mock that diverges from the real interface. Added the real method.

---

## Tests

Replaced the shallow duck-typing test suite with full behavioral coverage:

- ✅ `sampleRate` not passed to `AudioContext` constructor (regression guard for Bug 1)
- ✅ `getContext()` is `null` and `getInitialized()` is `false` after a failed init (Bug 2)
- ✅ `ensureActive()` successfully retries after a previous `initialize()` failure (Bug 2)
- ✅ `initialize()` happy path, idempotency, suspended-context resume
- ✅ `initialize()` returns error when `AudioContext` not supported
- ✅ `ensureActive()` initializes on first call; resumes suspended context
- ✅ `cleanup()` closes context and resets all state
- ✅ `cleanup()` is a no-op when never initialized
- ✅ `audioManager` delegation smoke test

---

## Related

- Trunk commit under review: `b216c4e`
- Issue: #31 (partial — `audioSessionManager` bugs only; `useSpeechSynthesis` port is a separate deliverable)
