### PR TITLE
fix(audio): restore sampleRate fix + null-on-failure + full test suite

### DIFF
--- a/src/lib/__tests__/audioSessionManager.test.ts
+++ b/src/lib/__tests__/audioSessionManager.test.ts
@@ -1,54 +1,206 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-describe("AudioSessionManager integration", () => {
-  beforeAll(() => {
-    // Provide minimal AudioContext stub for jsdom environment
-    if (typeof window !== "undefined" && !window.AudioContext) {
-      (window as any).AudioContext = class {
-        state = "running";
-        resume = vi.fn().mockResolvedValue(undefined);
-        close = vi.fn().mockResolvedValue(undefined);
-        createBuffer = vi.fn();
-        createOscillator = vi.fn();
-        createGain = vi.fn();
-        destination = {};
-        currentTime = 0;
-        sampleRate = 44100;
-      };
-    }
+// ---------------------------------------------------------------------------
+// AudioContext stub factory — creates a fresh stub per test so state does not
+// leak between test cases.
+// ---------------------------------------------------------------------------
+function makeAudioContextStub(initialState: "running" | "suspended" = "running") {
+  return class {
+    state: string = initialState;
+    resume = vi.fn(async () => {
+      this.state = "running";
+    });
+    close = vi.fn(async () => {
+      this.state = "closed";
+    });
+    createBuffer = vi.fn();
+    createOscillator = vi.fn();
+    createGain = vi.fn();
+    destination = {};
+    currentTime = 0;
+    sampleRate = 48000; // browser default — NOT 44100
+  };
+}
+
+describe("AudioSessionManager", () => {
+  beforeEach(() => {
+    vi.resetModules();
   });
 
-  afterAll(() => {
+  afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("audioManager imports audioSessionManager without errors", async () => {
-    const mod = await import("@/lib/audioManager");
-    expect(mod.audioManager).toBeDefined();
-    expect(typeof mod.audioManager.speak).toBe("function");
-    expect(typeof mod.audioManager.playEffect).toBe("function");
-    expect(typeof mod.audioManager.setMuted).toBe("function");
-  });
-
-  it("audioSessionManager has expected interface", async () => {
-    const asm = await import("@/lib/audioSessionManager");
-    expect(asm.audioSessionManager).toBeDefined();
+  // -------------------------------------------------------------------------
+  // Interface contract
+  // -------------------------------------------------------------------------
+  it("exports audioSessionManager with the expected interface", async () => {
+    (window as any).AudioContext = makeAudioContextStub();
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
     const methods = [
       "initialize",
       "ensureActive",
       "cleanup",
       "getRoutingState",
       "getContext",
+      "getInitialized",
     ];
     for (const method of methods) {
-      expect(typeof (asm.audioSessionManager as any)[method]).toBe("function");
+      expect(typeof (audioSessionManager as any)[method]).toBe("function");
     }
   });
 
-  it("cleanup returns success", async () => {
+  // -------------------------------------------------------------------------
+  // Bug fix #1: sampleRate must NOT be locked to 44100
+  // -------------------------------------------------------------------------
+  it("does not force sampleRate: 44100 when creating the AudioContext", async () => {
+    let capturedOptions: AudioContextOptions | undefined;
+    (window as any).AudioContext = class {
+      state = "running";
+      resume = vi.fn();
+      close = vi.fn();
+      destination = {};
+      currentTime = 0;
+      sampleRate = 48000;
+      constructor(options?: AudioContextOptions) {
+        capturedOptions = options;
+      }
+    };
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    await audioSessionManager.initialize();
+    expect(capturedOptions).not.toHaveProperty("sampleRate");
+  });
+
+  // -------------------------------------------------------------------------
+  // Bug fix #2: context must be nulled on initialize() failure
+  // -------------------------------------------------------------------------
+  it("nulls audioContext when initialize() fails so ensureActive() retries cleanly", async () => {
+    (window as any).AudioContext = class {
+      state = "suspended";
+      resume = vi.fn().mockRejectedValue(new Error("resume rejected"));
+      close = vi.fn();
+      destination = {};
+      currentTime = 0;
+      sampleRate = 48000;
+    };
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+
+    // First call — initialize fails due to resume rejection
+    const first = await audioSessionManager.initialize();
+    expect(first.success).toBe(false);
+    expect(audioSessionManager.getContext()).toBeNull();
+    expect(audioSessionManager.getInitialized()).toBe(false);
+
+    // Second call — ensureActive() should re-enter initialize(), not hang
+    // Replace stub with a healthy one for the retry
+    (window as any).AudioContext = makeAudioContextStub("running");
+    const second = await audioSessionManager.ensureActive();
+    expect(second.success).toBe(true);
+    expect(audioSessionManager.getInitialized()).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // initialize() — happy path
+  // -------------------------------------------------------------------------
+  it("initialize() sets initialized=true and returns success", async () => {
+    (window as any).AudioContext = makeAudioContextStub("running");
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    const result = await audioSessionManager.initialize();
+    expect(result.success).toBe(true);
+    expect(audioSessionManager.getInitialized()).toBe(true);
+    expect(audioSessionManager.getContext()).not.toBeNull();
+  });
+
+  it("initialize() is idempotent — second call skips re-creation", async () => {
+    let constructCount = 0;
+    (window as any).AudioContext = class {
+      state = "running";
+      resume = vi.fn();
+      close = vi.fn();
+      destination = {};
+      currentTime = 0;
+      sampleRate = 48000;
+      constructor() { constructCount++; }
+    };
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    await audioSessionManager.initialize();
+    await audioSessionManager.initialize();
+    expect(constructCount).toBe(1);
+  });
+
+  it("initialize() resumes a suspended context", async () => {
+    (window as any).AudioContext = makeAudioContextStub("suspended");
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    const result = await audioSessionManager.initialize();
+    expect(result.success).toBe(true);
+    expect(audioSessionManager.getContext()!.resume).toHaveBeenCalled();
+  });
+
+  it("initialize() returns an error when AudioContext is not supported", async () => {
+    (window as any).AudioContext = undefined;
+    (window as any).webkitAudioContext = undefined;
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    const result = await audioSessionManager.initialize();
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not supported/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // ensureActive()
+  // -------------------------------------------------------------------------
+  it("ensureActive() initializes when no context exists", async () => {
+    (window as any).AudioContext = makeAudioContextStub("running");
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    const result = await audioSessionManager.ensureActive();
+    expect(result.success).toBe(true);
+    expect(audioSessionManager.getInitialized()).toBe(true);
+  });
+
+  it("ensureActive() resumes a suspended context without re-initializing", async () => {
+    const Stub = makeAudioContextStub("running");
+    (window as any).AudioContext = Stub;
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    await audioSessionManager.initialize();
+
+    // Manually suspend the context after init
+    (audioSessionManager.getContext() as any).state = "suspended";
+    const result = await audioSessionManager.ensureActive();
+    expect(result.success).toBe(true);
+    expect(audioSessionManager.getContext()!.resume).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // cleanup()
+  // -------------------------------------------------------------------------
+  it("cleanup() closes the context and resets state", async () => {
+    (window as any).AudioContext = makeAudioContextStub("running");
+    const { audioSessionManager } = await import("@/lib/audioSessionManager");
+    await audioSessionManager.initialize();
+    const ctx = audioSessionManager.getContext()!;
+    const result = await audioSessionManager.cleanup();
+    expect(result.success).toBe(true);
+    expect(ctx.close).toHaveBeenCalled();
+    expect(audioSessionManager.getContext()).toBeNull();
+    expect(audioSessionManager.getInitialized()).toBe(false);
+    expect(audioSessionManager.getRoutingState()).toBe("unknown");
+  });
+
+  it("cleanup() is a no-op when never initialized", async () => {
+    (window as any).AudioContext = makeAudioContextStub();
     const { audioSessionManager } = await import("@/lib/audioSessionManager");
     const result = await audioSessionManager.cleanup();
-    expect(result).toBeDefined();
     expect(result.success).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // audioManager delegation smoke test
+  // -------------------------------------------------------------------------
+  it("audioManager imports without errors and exposes expected API", async () => {
+    (window as any).AudioContext = makeAudioContextStub();
+    const mod = await import("@/lib/audioManager");
+    expect(mod.audioManager).toBeDefined();
+    expect(typeof mod.audioManager.speak).toBe("function");
+    expect(typeof mod.audioManager.playEffect).toBe("function");
+    expect(typeof mod.audioManager.setMuted).toBe("function");
   });
 });

--- a/src/lib/audioSessionManager.ts
+++ b/src/lib/audioSessionManager.ts
@@ -1,4 +1,5 @@
 import { Sentry } from "./sentry";
+import { TTS_SAMPLE_RATE } from "../constants/audio";
 
 /**
  * Result of an audio session operation.
@@ -22,6 +23,12 @@ class AudioSessionManager {
   /**
    * Initialize the AudioContext with low-latency settings.
    * Idempotent — safe to call multiple times.
+   *
+   * NOTE: sampleRate is intentionally not set so the browser uses its
+   * hardware default. The Gemini TTS worker returns 24 kHz PCM
+   * (TTS_SAMPLE_RATE); the context resamples each AudioBuffer independently
+   * via AudioBuffer.sampleRate — locking the context to 44100 Hz caused
+   * TTS audio to play at the wrong speed.
    */
   async initialize(): Promise<AudioSessionResult> {
     if (this.initialized) return { success: true };
@@ -49,9 +56,10 @@ class AudioSessionManager {
         this.audioContext = null;
       }
 
+      // Do not set sampleRate — let the browser use its hardware default.
+      // Each AudioBuffer carries its own sampleRate for correct resampling.
       this.audioContext = new AudioContextClass({
         latencyHint: "interactive",
-        sampleRate: 44100,
       });
 
       if (this.audioContext.state === "suspended") {
@@ -68,6 +76,10 @@ class AudioSessionManager {
       this.routingState = "speaker";
       return { success: true };
     } catch (error) {
+      // Null out the context so ensureActive() re-enters initialize() rather
+      // than attempting to resume a broken/timed-out context indefinitely.
+      this.audioContext = null;
+      this.initialized = false;
       const message = error instanceof Error ? error.message : "Unknown error";
       console.error("[AudioSession] Init failed:", error);
       Sentry.captureException(error, {
@@ -124,6 +136,14 @@ class AudioSessionManager {
   }
 
   /**
+   * Whether the AudioContext has been successfully initialized.
+   * Exposed so test mocks can stay in sync with the real interface.
+   */
+  getInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
    * Close and clean up the AudioContext.
    * Safe to call even if never initialized.
    */
@@ -148,3 +168,7 @@ class AudioSessionManager {
 }
 
 export const audioSessionManager = new AudioSessionManager();
+
+// Re-export TTS_SAMPLE_RATE so callers don't need a separate constants import
+// when they need to create AudioBuffers at the correct rate.
+export { TTS_SAMPLE_RATE };


### PR DESCRIPTION
- Remove sampleRate: 44100 from AudioContextClass constructor; Gemini TTS returns 24 kHz PCM and the context was causing playback at wrong speed/pitch
- Null this.audioContext in initialize() catch block so ensureActive() can re-enter initialize() after a failure instead of looping on suspended ctx
- Add getInitialized() accessor (was mocked in setup.tsx but never existed)
- Re-export TTS_SAMPLE_RATE for callers that create AudioBuffers
- Replace 3-test stub suite with full 12-test behavioural coverage

Fixes regressions introduced by b216c4e (issue #31 audioSessionManager) that survived the PR #47 merge conflict resolution.