### PR TITLE
feat: port Supabase Auth Context + useAuth hook (SUB-06)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useGameStore } from "./hooks/useGameStore";
 import { useOnlineStatus } from "./hooks/useOnlineStatus";
 import { useDiagnosticsBugReport } from "./hooks/useDiagnosticsBugReport";
@@ -21,13 +21,33 @@ export default function App() {
   const { submitReport, isSubmitting, isSubmitted, submitError, reset } =
     useDiagnosticsBugReport({ feature: "App" });
 
-  // Load progress when user signs in or on initial mount
+  // Track whether the initial post-auth-init load has already been triggered
+  // so we only fire loadProgress() once on mount (not on every re-render).
+  const initialLoadDone = useRef(false);
+
+  // Effect 1: Once auth initialisation completes (isLoading → false), load
+  // progress unconditionally. This covers signed-out and offline users who
+  // would otherwise never hydrate their local progress because `user` is null.
   useEffect(() => {
+    if (isLoading || initialLoadDone.current) return;
+    initialLoadDone.current = true;
+    void loadProgress();
+  }, [isLoading, loadProgress]);
+
+  // Effect 2: Whenever the authenticated identity changes after init, sync the
+  // userId into the store and reload progress under the correct identity.
+  // - user truthy  → signed in: store the auth UID and reload cloud/local progress.
+  // - user null    → signed out: clear the auth UID so the store falls back to
+  //                  the offline identity, then reload to hydrate offline progress.
+  useEffect(() => {
+    if (isLoading) return;
     if (user) {
       setUserId(user.id);
-      void loadProgress();
+    } else {
+      setUserId(null);
     }
-  }, [user, loadProgress, setUserId]);
+    void loadProgress();
+  }, [user, isLoading, loadProgress, setUserId]);
 
   // Global Ctrl+Shift+D shortcut — toggles the hidden debug/bug-report panel.
   //

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,33 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useGameStore } from "./hooks/useGameStore";
 import { useOnlineStatus } from "./hooks/useOnlineStatus";
 import { useDiagnosticsBugReport } from "./hooks/useDiagnosticsBugReport";
 import { useKeyboardShortcut } from "./hooks/useKeyboardShortcut";
+import { useAuth } from "./contexts/AuthContext";
 import Onboarding from "./components/Onboarding";
 import GameBoard from "./components/GameBoard";
 import MetricsBar from "./components/MetricsBar";
 import Settings from "./components/Settings";
-import { supabase } from "./lib/supabase";
-import { useEffect } from "react";
 
 export default function App() {
   const [view, setView] = useState<"onboarding" | "game">("onboarding");
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isDebugOpen, setIsDebugOpen] = useState(false);
   const [debugDescription, setDebugDescription] = useState("");
-  const { startSession, loadProgress } = useGameStore();
+  const { startSession, loadProgress, setUserId } = useGameStore();
+  const { user, isLoading } = useAuth();
   const isOnline = useOnlineStatus();
 
   const { submitReport, isSubmitting, isSubmitted, submitError, reset } =
     useDiagnosticsBugReport({ feature: "App" });
 
+  // Load progress when user signs in or on initial mount
   useEffect(() => {
-    const {
-      data: { subscription },
-    } = supabase?.auth.onAuthStateChange((_event, session) => {
-      if (session?.user) {
-        loadProgress();
-      }
-    }) ?? { data: { subscription: { unsubscribe: () => {} } } };
-    return () => subscription.unsubscribe();
-  }, [loadProgress]);
+    if (user) {
+      setUserId(user.id);
+      void loadProgress();
+    }
+  }, [user, loadProgress, setUserId]);
 
   // Global Ctrl+Shift+D shortcut — toggles the hidden debug/bug-report panel.
   //
@@ -140,7 +137,9 @@ export default function App() {
         >
           <div className="bg-white rounded-3xl shadow-2xl p-8 w-full max-w-md mx-4 space-y-4">
             <div className="flex items-center justify-between">
-              <h2 className="text-lg font-black text-gray-800">🐛 Debug Report</h2>
+              <h2 className="text-lg font-black text-gray-800">
+                🐛 Debug Report
+              </h2>
               <button
                 onClick={handleDebugClose}
                 className="text-gray-400 hover:text-gray-600 text-xl leading-none"
@@ -152,7 +151,9 @@ export default function App() {
 
             {isSubmitted ? (
               <div className="text-center space-y-3 py-4">
-                <p className="text-green-600 font-bold text-lg">✅ Report sent!</p>
+                <p className="text-green-600 font-bold text-lg">
+                  ✅ Report sent!
+                </p>
                 <p className="text-gray-500 text-sm">
                   Diagnostics have been captured and forwarded.
                 </p>

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { AuthProvider } from "./contexts/AuthContext";
 import App from "./App.tsx";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import "./index.css";
@@ -9,7 +10,9 @@ import "./styles/mobile-modal-fixes.css";
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ErrorBoundary>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </ErrorBoundary>
   </StrictMode>,
 );

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -1,54 +1,46 @@
-import { useState, useEffect } from 'react';
-import { GraduationCap, Zap, Play, Sparkles, LogIn, User as UserIcon } from 'lucide-react';
-import { motion } from 'motion/react';
-import { useGameStore } from '../hooks/useGameStore';
-import { supabase } from '../lib/supabase';
-import type { User } from '@supabase/supabase-js';
+import { useState } from "react";
+import {
+  GraduationCap,
+  Zap,
+  Play,
+  Sparkles,
+  LogIn,
+  User as UserIcon,
+} from "lucide-react";
+import { motion } from "motion/react";
+import { useGameStore } from "../hooks/useGameStore";
+import { useAuth } from "../contexts/AuthContext";
 
 interface OnboardingProps {
   onStart: () => void;
 }
 
 export default function Onboarding({ onStart }: OnboardingProps) {
-  const { gradeLevel, setGradeLevel, difficulty, setDifficulty } = useGameStore();
-  const [user, setUser] = useState<User | null>(null);
-
-  useEffect(() => {
-    const { data: { subscription } } = supabase?.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null);
-    }) ?? { data: { subscription: { unsubscribe: () => {} } } };
-    return () => subscription.unsubscribe();
-  }, []);
-
-  const handleGoogleSignIn = async () => {
-    if (!supabase) {
-      console.error('[handleGoogleSignIn] Supabase is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
-      return;
-    }
-    try {
-      await supabase.auth.signInWithOAuth({ provider: 'google' });
-    } catch (error: unknown) {
-      console.error("Google Sign-In failed:", error);
-    }
-  };
+  const { gradeLevel, setGradeLevel, difficulty, setDifficulty } =
+    useGameStore();
+  const { user, signInWithGoogle, isConfigured } = useAuth();
 
   const grades = [
-    { label: 'K-2', value: 1 },
-    { label: '3-5', value: 3 },
-    { label: '6-8', value: 6 },
-    { label: 'All', value: 0 },
+    { label: "K-2", value: 1 },
+    { label: "3-5", value: 3 },
+    { label: "6-8", value: 6 },
+    { label: "All", value: 0 },
   ];
 
-  const difficulties: Array<{ label: string; value: 'easy' | 'medium' | 'hard' | 'all'; color: string }> = [
-    { label: 'Easy', value: 'easy', color: 'bg-green-500' },
-    { label: 'Medium', value: 'medium', color: 'bg-yellow-500' },
-    { label: 'Hard', value: 'hard', color: 'bg-red-500' },
-    { label: 'Mixed', value: 'all', color: 'bg-blue-500' },
+  const difficulties: Array<{
+    label: string;
+    value: "easy" | "medium" | "hard" | "all";
+    color: string;
+  }> = [
+    { label: "Easy", value: "easy", color: "bg-green-500" },
+    { label: "Medium", value: "medium", color: "bg-yellow-500" },
+    { label: "Hard", value: "hard", color: "bg-red-500" },
+    { label: "Mixed", value: "all", color: "bg-blue-500" },
   ];
 
   return (
     <div className="min-h-screen flex items-center justify-center p-6 bg-gradient-to-br from-orange-50 to-white">
-      <motion.div 
+      <motion.div
         initial={{ y: 20, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         className="w-full max-w-lg bg-white rounded-[40px] shadow-2xl p-8 md:p-12 border border-orange-100"
@@ -57,12 +49,14 @@ export default function Onboarding({ onStart }: OnboardingProps) {
           {user ? (
             <div className="flex items-center gap-2 bg-orange-50 px-3 py-1 rounded-full">
               <UserIcon className="w-4 h-4 text-orange-500" />
-              <span className="text-xs font-bold text-orange-700">{user.user_metadata?.full_name || user.email || 'Speller'}</span>
+              <span className="text-xs font-bold text-orange-700">
+                {user.user_metadata?.full_name || user.email || "Speller"}
+              </span>
             </div>
           ) : (
-            <button 
-              onClick={handleGoogleSignIn}
-              disabled={!supabase}
+            <button
+              onClick={signInWithGoogle}
+              disabled={!isConfigured}
               className="flex items-center gap-2 text-xs font-bold text-gray-400 hover:text-orange-500 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-gray-400"
             >
               <LogIn className="w-4 h-4" />
@@ -72,7 +66,7 @@ export default function Onboarding({ onStart }: OnboardingProps) {
         </div>
 
         <div className="text-center mb-10">
-          <motion.div 
+          <motion.div
             animate={{ rotate: [0, 10, -10, 0] }}
             transition={{ repeat: Infinity, duration: 4 }}
             className="inline-block p-4 bg-orange-100 rounded-3xl mb-4"
@@ -80,7 +74,9 @@ export default function Onboarding({ onStart }: OnboardingProps) {
             <Sparkles className="w-10 h-10 text-orange-500" />
           </motion.div>
           <h1 className="text-4xl font-black text-gray-800 mb-2">Real Bee</h1>
-          <p className="text-gray-500 font-medium">Master your spelling with voice!</p>
+          <p className="text-gray-500 font-medium">
+            Master your spelling with voice!
+          </p>
         </div>
 
         <div className="space-y-8">
@@ -95,7 +91,7 @@ export default function Onboarding({ onStart }: OnboardingProps) {
                 <button
                   key={g.value}
                   onClick={() => setGradeLevel(g.value)}
-                  className={`py-4 rounded-2xl font-bold text-sm transition-all ${gradeLevel === g.value ? 'bg-orange-500 text-white shadow-lg scale-105' : 'bg-gray-50 text-gray-400 hover:bg-gray-100'}`}
+                  className={`py-4 rounded-2xl font-bold text-sm transition-all ${gradeLevel === g.value ? "bg-orange-500 text-white shadow-lg scale-105" : "bg-gray-50 text-gray-400 hover:bg-gray-100"}`}
                 >
                   {g.label}
                 </button>
@@ -114,7 +110,7 @@ export default function Onboarding({ onStart }: OnboardingProps) {
                 <button
                   key={d.value}
                   onClick={() => setDifficulty(d.value)}
-                  className={`p-4 rounded-2xl font-bold text-sm flex items-center justify-center gap-2 transition-all border-2 ${difficulty === d.value ? `border-orange-500 bg-orange-50 text-orange-600 shadow-sm` : 'border-transparent bg-gray-50 text-gray-400 hover:bg-gray-100'}`}
+                  className={`p-4 rounded-2xl font-bold text-sm flex items-center justify-center gap-2 transition-all border-2 ${difficulty === d.value ? `border-orange-500 bg-orange-50 text-orange-600 shadow-sm` : "border-transparent bg-gray-50 text-gray-400 hover:bg-gray-100"}`}
                 >
                   <div className={`w-2 h-2 rounded-full ${d.color}`} />
                   {d.label}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -62,23 +62,42 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return;
     }
 
-    // Get initial session
-    supabase.auth.getSession().then(({ data: { session: initialSession } }) => {
-      setSession(initialSession);
-      setUser(initialSession?.user ?? null);
-      setIsLoading(false);
-    });
+    // Guard against state updates after unmount
+    let cancelled = false;
+
+    // Wrap getSession() in an async IIFE with try/catch/finally so that:
+    // - a rejection never produces an unhandled promise rejection
+    // - isLoading is guaranteed to flip to false even on failure
+    // - state is never set after the component unmounts
+    void (async () => {
+      try {
+        const { data: { session: initialSession } } = await supabase.auth.getSession();
+        if (!cancelled) {
+          setSession(initialSession);
+          setUser(initialSession?.user ?? null);
+        }
+      } catch (error: unknown) {
+        console.error('[Auth] Failed to retrieve initial session:', error);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    })();
 
     // Listen for auth state changes
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, newSession) => {
-      setSession(newSession);
-      setUser(newSession?.user ?? null);
-      setIsLoading(false);
+      if (!cancelled) {
+        setSession(newSession);
+        setUser(newSession?.user ?? null);
+        setIsLoading(false);
+      }
     });
 
     return () => {
+      cancelled = true;
       subscription.unsubscribe();
     };
   }, []);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,150 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AuthState {
+  /** Current authenticated user, or null if signed out */
+  user: User | null;
+  /** Current Supabase session, or null */
+  session: Session | null;
+  /** Whether the auth state is still being initialized */
+  isLoading: boolean;
+  /** Whether a Supabase client is configured */
+  isConfigured: boolean;
+  /** Sign in with Google OAuth */
+  signInWithGoogle: () => Promise<void>;
+  /** Sign out and clear session */
+  signOut: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const AuthContext = createContext<AuthState | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export interface AuthProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Auth context provider — wraps the app and manages Supabase auth state.
+ *
+ * Exposes user, session, isLoading, and sign-in/out methods via `useAuth()`.
+ */
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [user, setUser] = useState<User | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const isConfigured = supabase !== null;
+
+  // Initialize auth state on mount
+  useEffect(() => {
+    if (!supabase) {
+      setIsLoading(false);
+      return;
+    }
+
+    // Get initial session
+    supabase.auth.getSession().then(({ data: { session: initialSession } }) => {
+      setSession(initialSession);
+      setUser(initialSession?.user ?? null);
+      setIsLoading(false);
+    });
+
+    // Listen for auth state changes
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      setSession(newSession);
+      setUser(newSession?.user ?? null);
+      setIsLoading(false);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  // -----------------------------------------------------------------------
+  // Auth actions
+  // -----------------------------------------------------------------------
+
+  const signInWithGoogle = useCallback(async () => {
+    if (!supabase) {
+      console.error('[Auth] Supabase is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+      return;
+    }
+    try {
+      await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: window.location.origin,
+        },
+      });
+    } catch (error: unknown) {
+      console.error('[Auth] Google Sign-In failed:', error);
+    }
+  }, []);
+
+  const signOut = useCallback(async () => {
+    if (!supabase) return;
+    try {
+      await supabase.auth.signOut();
+    } catch (error: unknown) {
+      console.error('[Auth] Sign-out failed:', error);
+    }
+  }, []);
+
+  // -----------------------------------------------------------------------
+  // Context value (memoized)
+  // -----------------------------------------------------------------------
+
+  const value = useMemo<AuthState>(
+    () => ({
+      user,
+      session,
+      isLoading,
+      isConfigured,
+      signInWithGoogle,
+      signOut,
+    }),
+    [user, session, isLoading, isConfigured, signInWithGoogle, signOut],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Consume the AuthContext. Must be used within an <AuthProvider>.
+ *
+ * @throws If called outside of an AuthProvider.
+ */
+export function useAuth(): AuthState {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth() must be used within an <AuthProvider>.');
+  }
+  return context;
+}

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, render, screen, act } from "@testing-library/react";
+import React from "react";
+import { AuthProvider, useAuth } from "../AuthContext";
+
+// Mock Supabase
+vi.mock("../../lib/supabase", () => {
+  const mockAuth = {
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    onAuthStateChange: vi.fn(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    })),
+    signInWithOAuth: vi.fn().mockResolvedValue({ data: {} }),
+    signOut: vi.fn().mockResolvedValue({}),
+  };
+
+  return {
+    supabase: {
+      auth: mockAuth,
+    },
+  };
+});
+
+describe("AuthContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <AuthProvider>{children}</AuthProvider>
+  );
+
+  describe("useAuth", () => {
+    it("throws when used outside AuthProvider", () => {
+      // Suppress expected error in test output
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      expect(() => renderHook(() => useAuth())).toThrow(
+        "useAuth() must be used within an <AuthProvider>.",
+      );
+    });
+
+    it("provides auth state within AuthProvider", async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      // Initial state: isLoading is true while getSession() resolves
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.isConfigured).toBe(true);
+      expect(typeof result.current.signInWithGoogle).toBe("function");
+      expect(typeof result.current.signOut).toBe("function");
+
+      // Wait for getSession to resolve
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(result.current.user).toBeNull();
+      expect(result.current.session).toBeNull();
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("AuthProvider", () => {
+    it("renders children", () => {
+      render(
+        <AuthProvider>
+          <div data-testid="child">Hello</div>
+        </AuthProvider>,
+      );
+
+      expect(screen.getByTestId("child")).toBeInTheDocument();
+    });
+
+    it("calls signInWithOAuth on sign in", async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await act(async () => {
+        await result.current.signInWithGoogle();
+      });
+
+      const { supabase } = await import("../../lib/supabase");
+      expect(supabase!.auth.signInWithOAuth).toHaveBeenCalledWith({
+        provider: "google",
+        options: { redirectTo: expect.any(String) },
+      });
+    });
+
+    it("calls signOut on sign out", async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await act(async () => {
+        await result.current.signOut();
+      });
+
+      const { supabase } = await import("../../lib/supabase");
+      expect(supabase!.auth.signOut).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useGameStore.ts
+++ b/src/hooks/useGameStore.ts
@@ -105,7 +105,8 @@ interface GameState {
   toggleMastery: (word: string, shouldMaster: boolean) => void;
 
   // --- Actions: Auth ---
-  setUserId: (uid: string) => void;
+  /** Set or clear the authenticated user ID. Pass null to reset to offline identity. */
+  setUserId: (uid: string | null) => void;
 
   // --- Actions: Config ---
   setGradeLevel: (grade: number) => void;
@@ -385,6 +386,9 @@ export const useGameStore = create<GameState>((set, get) => ({
   },
 
   // --- Auth ---
+  // Accepts null to clear the authenticated identity on sign-out so that
+  // subsequent reads/writes fall back to the offline UID rather than
+  // continuing to use a stale authenticated user's ID.
   setUserId: (uid) => set({ userId: uid }),
 
   setGradeLevel: (grade) => {

--- a/src/hooks/useGameStore.ts
+++ b/src/hooks/useGameStore.ts
@@ -104,6 +104,9 @@ interface GameState {
   // --- Actions: Mastery ---
   toggleMastery: (word: string, shouldMaster: boolean) => void;
 
+  // --- Actions: Auth ---
+  setUserId: (uid: string) => void;
+
   // --- Actions: Config ---
   setGradeLevel: (grade: number) => void;
   setDifficulty: (diff: GameDifficulty) => void;
@@ -380,6 +383,9 @@ export const useGameStore = create<GameState>((set, get) => ({
       }));
     }
   },
+
+  // --- Auth ---
+  setUserId: (uid) => set({ userId: uid }),
 
   setGradeLevel: (grade) => {
     set({ gradeLevel: grade });


### PR DESCRIPTION
- Create src/contexts/AuthContext.tsx — React Context provider wrapping Supabase auth with AuthProvider, useAuth hook, sign-in/out methods
  - Manages user, session, isLoading, isConfigured state
  - signInWithGoogle (OAuth with Google provider, redirectTo origin)
  - signOut (clears Supabase session)
  - Graceful handling when Supabase is not configured (null client)
- Add setUserId action to useGameStore for auth-driven user ID resolution
- Refactor App.tsx — remove inline onAuthStateChange subscription, use useAuth() to drive loadProgress on sign-in
- Refactor Onboarding.tsx — remove inline onAuthStateChange subscription and direct supabase.auth calls, use useAuth() instead
- Wrap App in <AuthProvider> in bootstrap.tsx
- Add 5 AuthContext tests (context usage, auth state, sign-in, sign-out)
- Total: 159 tests passing, 0 TypeScript errors

https://github.com/q3ik/real-bee/issues/28