### PR TITLE
fix: address code review bugs in storage, sync, and progressSync

### DIFF
--- a/src/game-engine/storage.ts
+++ b/src/game-engine/storage.ts
@@ -1,0 +1,151 @@
+/**
+ * Storage module — clean API wrapping Dexie for all local persistence.
+ *
+ * Replaces inline `localDb` calls in useGameStore with a typed, testable interface.
+ *
+ * Object stores (Dexie v3):
+ *   - `preferences`: user settings (keyed by `uid`)
+ *   - `progress`: game progress (keyed by `uid`, single row per user)
+ *   - `sessions`: completed sessions (auto-increment id)
+ */
+
+import {
+  localDb,
+  type LocalUserProgress,
+  type LocalSession,
+  type LocalUserPreferences,
+} from "../lib/db";
+
+// ---------------------------------------------------------------------------
+// Progress
+// ---------------------------------------------------------------------------
+
+/**
+ * Save or update the user's game progress (upsert by uid).
+ */
+export async function saveGameProgress(
+  progress: LocalUserProgress,
+): Promise<void> {
+  await localDb.progress.put(progress);
+}
+
+/**
+ * Load game progress for a specific user ID.
+ * Returns `null` if no progress exists for the given uid.
+ */
+export async function loadGameProgress(
+  uid: string,
+): Promise<LocalUserProgress | null> {
+  const row = await localDb.progress.get(uid);
+  return row ?? null;
+}
+
+/**
+ * Clear game progress for a specific user.
+ */
+export async function clearGameProgress(uid: string): Promise<void> {
+  await localDb.progress.delete(uid);
+}
+
+/**
+ * Get all progress records that haven't been synced to the cloud yet.
+ */
+export async function getUnsyncedProgress(): Promise<LocalUserProgress[]> {
+  return localDb.progress.where({ synced: false }).toArray();
+}
+
+// ---------------------------------------------------------------------------
+// Sessions
+// ---------------------------------------------------------------------------
+
+/**
+ * Save a new game session. Returns the generated id.
+ */
+export async function saveSession(
+  session: Omit<LocalSession, "id">,
+): Promise<number> {
+  const id = await localDb.sessions.add(session as LocalSession);
+  return id as number;
+}
+
+/**
+ * Load all sessions for a specific user.
+ */
+export async function loadUserSessions(uid: string): Promise<LocalSession[]> {
+  return localDb.sessions.where("uid").equals(uid).toArray();
+}
+
+/**
+ * Get all sessions that haven't been synced to the cloud yet.
+ */
+export async function getUnsyncedSessions(): Promise<LocalSession[]> {
+  return localDb.sessions.where({ synced: false }).toArray();
+}
+
+/**
+ * Mark sessions as synced by their ids.
+ */
+export async function markSessionsSynced(ids: number[]): Promise<void> {
+  for (const id of ids) {
+    await localDb.sessions.update(id, { synced: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Preferences
+// ---------------------------------------------------------------------------
+
+/**
+ * Save or update user preferences (upsert by uid).
+ */
+export async function saveUserPreferences(
+  prefs: LocalUserPreferences,
+): Promise<void> {
+  const existing = await localDb.preferences
+    .where("uid")
+    .equals(prefs.uid)
+    .first();
+  if (existing && existing.id !== undefined) {
+    await localDb.preferences.update(existing.id, prefs);
+  } else {
+    await localDb.preferences.add(prefs);
+  }
+}
+
+/**
+ * Load user preferences by uid.
+ * Returns `null` if no preferences exist for the given uid.
+ */
+export async function loadUserPreferences(
+  uid: string,
+): Promise<LocalUserPreferences | null> {
+  const row = await localDb.preferences.where("uid").equals(uid).first();
+  return row ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Bulk operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Mark progress records as synced by their uids.
+ */
+export async function markProgressSynced(uids: string[]): Promise<void> {
+  for (const uid of uids) {
+    const existing = await localDb.progress.get(uid);
+    if (existing) {
+      await localDb.progress.update(uid, { synced: true });
+    }
+  }
+}
+
+/**
+ * Clear all local data for a specific user.
+ */
+export async function clearUserData(uid: string): Promise<void> {
+  await Promise.all([
+    localDb.progress.delete(uid),
+    localDb.sessions.where("uid").equals(uid).delete(),
+    localDb.preferences.where("uid").equals(uid).delete(),
+  ]);
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,0 +1,261 @@
+/**
+ * Sync queue — manages offline-first sync of local data to the cloud.
+ *
+ * Uses Dexie's `synced` flag on progress and session records to track
+ * which items need to be uploaded. When the user signs in (or comes
+ * back online), `syncPending()` uploads all unsynced records that
+ * belong to the currently authenticated user.
+ *
+ * Retry logic: exponential backoff with jitter, max 5 attempts per item.
+ */
+
+import { supabase } from "./supabase";
+import {
+  saveGameProgress,
+  loadGameProgress,
+  getUnsyncedProgress,
+  markProgressSynced,
+  getUnsyncedSessions,
+  saveSession,
+  markSessionsSynced,
+} from "../game-engine/storage";
+import type { LocalUserProgress, LocalSession } from "./db";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_SYNC_RETRIES = 5;
+const BASE_RETRY_DELAY_MS = 1000;
+const JITTER_RANGE_MS = 500;
+
+// ---------------------------------------------------------------------------
+// Retry queue (in-memory, survives page navigations via localStorage)
+// ---------------------------------------------------------------------------
+
+interface RetryEntry {
+  uid: string;
+  retryCount: number;
+  lastAttempt: number;
+}
+
+const RETRY_STORAGE_KEY = "real-bee-sync-retries";
+
+function loadRetryQueue(): Map<string, RetryEntry> {
+  try {
+    const raw = localStorage.getItem(RETRY_STORAGE_KEY);
+    if (!raw) return new Map();
+    const entries: RetryEntry[] = JSON.parse(raw);
+    return new Map(entries.map((e) => [e.uid, e]));
+  } catch {
+    return new Map();
+  }
+}
+
+function saveRetryQueue(queue: Map<string, RetryEntry>): void {
+  try {
+    localStorage.setItem(
+      RETRY_STORAGE_KEY,
+      JSON.stringify([...queue.values()]),
+    );
+  } catch {
+    // localStorage full — silently ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sync logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Upload a single progress record to Supabase.
+ *
+ * Uses an upsert pattern: if a row exists for this user_id, it is replaced.
+ */
+async function uploadProgressToSupabase(
+  progress: LocalUserProgress,
+): Promise<boolean> {
+  if (!supabase) return false;
+
+  const { error } = await supabase.from("user_progress").upsert(
+    {
+      id: progress.uid,
+      user_id: progress.uid,
+      type: "progress",
+      data: JSON.stringify({
+        score: progress.score,
+        streak: progress.streak,
+        bestStreak: progress.bestStreak,
+        masteredCount: progress.masteredCount,
+        gradeLevel: progress.gradeLevel,
+        difficulty: progress.difficulty,
+      }),
+      timestamp: progress.lastPlayed,
+    },
+    { onConflict: "id" },
+  );
+
+  if (error) {
+    console.warn(
+      "[sync] Failed to upload progress for",
+      progress.uid,
+      error.message,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Calculate delay with exponential backoff and jitter.
+ */
+function getRetryDelay(retryCount: number): number {
+  const base = BASE_RETRY_DELAY_MS * 2 ** retryCount;
+  const jitter = Math.random() * JITTER_RANGE_MS;
+  return Math.min(base + jitter, 30000); // Cap at 30s
+}
+
+/**
+ * Sync all pending progress records to Supabase.
+ *
+ * Only records whose uid matches the authenticated user are uploaded;
+ * offline-UID rows are skipped to prevent failed upserts.
+ *
+ * @returns Number of successfully synced records.
+ */
+export async function syncPending(): Promise<number> {
+  if (!supabase) return 0;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return 0;
+
+  const authedUid = user.id;
+
+  const allUnsynced = await getUnsyncedProgress();
+  // Only attempt to upload records that belong to the authenticated user.
+  // Rows written under an offline-* UID are intentionally excluded here;
+  // they can be migrated separately if needed.
+  const unsynced = allUnsynced.filter((record) => record.uid === authedUid);
+  if (unsynced.length === 0) return 0;
+
+  const retryQueue = loadRetryQueue();
+  let syncedCount = 0;
+
+  for (const record of unsynced) {
+    const retry = retryQueue.get(record.uid);
+
+    // Skip if max retries exceeded
+    if (retry && retry.retryCount >= MAX_SYNC_RETRIES) {
+      console.warn("[sync] Max retries exceeded for", record.uid, "— skipping");
+      continue;
+    }
+
+    // Skip if still in backoff window
+    if (
+      retry &&
+      Date.now() - retry.lastAttempt < getRetryDelay(retry.retryCount)
+    ) {
+      continue;
+    }
+
+    const success = await uploadProgressToSupabase(record);
+
+    if (success) {
+      await markProgressSynced([record.uid]);
+      retryQueue.delete(record.uid);
+      syncedCount++;
+    } else {
+      // Increment retry count
+      retryQueue.set(record.uid, {
+        uid: record.uid,
+        retryCount: (retry?.retryCount ?? 0) + 1,
+        lastAttempt: Date.now(),
+      });
+    }
+  }
+
+  saveRetryQueue(retryQueue);
+  return syncedCount;
+}
+
+/**
+ * Save progress locally and queue for cloud sync.
+ *
+ * This is the primary write path — always succeeds locally, queues sync
+ * for later when online + authenticated.
+ */
+export async function saveProgressAndQueue(
+  progress: LocalUserProgress,
+): Promise<void> {
+  await saveGameProgress(progress);
+  // Sync will be triggered by the next `syncPending()` call (e.g. on sign-in)
+}
+
+/**
+ * Save a session locally and queue for cloud sync.
+ */
+export async function saveSessionAndQueue(
+  session: Omit<LocalSession, "id" | "synced">,
+): Promise<number> {
+  const id = await saveSession({
+    uid: session.uid,
+    startTime: session.startTime,
+    endTime: session.endTime,
+    wordsSpelled: session.wordsSpelled,
+    correctCount: session.correctCount,
+    difficultyEvolution: session.difficultyEvolution,
+    synced: false,
+  });
+  return id;
+}
+
+/**
+ * Load the latest progress for a user, falling back to local if
+ * Supabase fetch fails.
+ */
+export async function loadProgressWithFallback(uid: string) {
+  // Try local first (fast, always available)
+  const local = await loadGameProgress(uid);
+
+  // Try cloud in background
+  if (supabase) {
+    const { data, error } = await supabase
+      .from("user_progress")
+      .select("*")
+      .eq("user_id", uid)
+      .eq("type", "progress")
+      .order("timestamp", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (!error && data) {
+      try {
+        const parsed = JSON.parse(data.data as string) as Record<
+          string,
+          unknown
+        >;
+        const cloudProgress: LocalUserProgress = {
+          uid,
+          score: (parsed.score as number) ?? 0,
+          streak: (parsed.streak as number) ?? 0,
+          bestStreak: (parsed.bestStreak as number) ?? 0,
+          masteredCount: (parsed.masteredCount as number) ?? 0,
+          gradeLevel: (parsed.gradeLevel as string) ?? "all",
+          difficulty: (parsed.difficulty as string) ?? "all",
+          lastPlayed: data.timestamp,
+          synced: true,
+        };
+        // Merge cloud data into local DB
+        await saveGameProgress(cloudProgress);
+        return cloudProgress;
+      } catch {
+        // Parse error — fall back to local
+      }
+    }
+  }
+
+  return local;
+}

--- a/src/services/progressSync.ts
+++ b/src/services/progressSync.ts
@@ -1,0 +1,67 @@
+/**
+ * Progress sync service — coordinates sync of local Dexie data to Supabase.
+ *
+ * Exposes:
+ *   - `syncUserProgress()` — one-time sync of all pending records for the
+ *     currently authenticated user (identity resolved inside syncPending())
+ *   - `getPendingCount()` — number of unsynced records
+ *   - `autoSyncOnSignIn(userId)` — triggers sync when user signs in
+ *
+ * Designed to be called from the AuthContext or App component on auth state changes.
+ */
+
+import { syncPending } from '../lib/sync';
+import { getUnsyncedProgress, getUnsyncedSessions } from '../game-engine/storage';
+
+export interface SyncResult {
+  progressSynced: number;
+  sessionsSynced: number;
+  totalPending: number;
+}
+
+/**
+ * Sync all pending user progress and sessions to the cloud.
+ *
+ * The authenticated user identity is derived from the active Supabase
+ * session inside `syncPending()` — no userId parameter is needed here.
+ *
+ * @returns Sync summary
+ */
+export async function syncUserProgress(): Promise<SyncResult> {
+  const progressSynced = await syncPending();
+
+  // Sessions sync is a no-op for now — sessions are stored locally
+  // and will be synced when a dedicated endpoint is added.
+  const sessionsSynced = 0;
+
+  const [progressAfter, sessionsAfter] = await Promise.all([
+    getUnsyncedProgress(),
+    getUnsyncedSessions(),
+  ]);
+
+  return {
+    progressSynced,
+    sessionsSynced,
+    totalPending: progressAfter.length + sessionsAfter.length,
+  };
+}
+
+/**
+ * Get the total number of unsynced records (progress + sessions).
+ */
+export async function getPendingCount(): Promise<number> {
+  const [progress, sessions] = await Promise.all([
+    getUnsyncedProgress(),
+    getUnsyncedSessions(),
+  ]);
+  return progress.length + sessions.length;
+}
+
+/**
+ * Trigger sync when the user signs in.
+ * Returns null if no user is authenticated.
+ */
+export async function autoSyncOnSignIn(userId: string | null): Promise<SyncResult | null> {
+  if (!userId) return null;
+  return syncUserProgress();
+}


### PR DESCRIPTION
1. Null fallback never applied (storage.ts)
   - loadGameProgress: await the Dexie promise before applying ?? null so callers receive null (not undefined) when no record exists.
   - loadUserPreferences: same fix — await .first() then coalesce to null.

2. Sync not scoped to user (sync.ts)
   - syncPending: after resolving the authenticated user.id, filter the unsynced records array to only entries whose uid matches the authed user's id. Offline-UID rows are no longer uploaded, preventing repeated failed upserts and ensuring real user progress is synced.

3. Wrong session parameter type (sync.ts)
   - saveSessionAndQueue: replace the incorrect Omit<LocalUserProgress,...> & {...} intersection type with Omit<LocalSession, 'id' | 'synced'> which is the canonical session shape. The implementation body is unchanged.

4. Unused userId parameter (progressSync.ts)
   - syncUserProgress: remove the unused userId parameter; identity is already derived from Supabase auth state inside syncPending().
   - Remove the dead progressBefore/sessionsBefore pre-queries that were computed but never used in the returned SyncResult.
   - autoSyncOnSignIn: update call-site to match new signature.