### PR TITLE
Make tests deterministic and tidy formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 firebase-applet-config.json
 .qwen/
 /test-results
+/logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -516,7 +517,8 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
       "integrity": "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==",
       "dev": true,
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -630,6 +632,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -653,6 +656,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2620,6 +2624,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2869,6 +2874,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2948,6 +2954,7 @@
       "integrity": "sha512-/MBdrkA8t6hbdCWFKs09dPik774xvs4Z6L4bycdCxYNLHM8oZuRyosumQMG19LUlBsB6GeVpL1q4kFFazvyKGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.3",
@@ -3471,6 +3478,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3881,8 +3889,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -4889,6 +4896,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -5794,6 +5802,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5987,6 +5996,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5996,6 +6006,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6848,6 +6859,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6897,6 +6909,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6927,6 +6940,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -7014,6 +7028,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7546,6 +7561,7 @@
       "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -7814,6 +7830,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/src/game-engine/__tests__/index.test.ts
+++ b/src/game-engine/__tests__/index.test.ts
@@ -244,9 +244,27 @@ describe("difficulty", () => {
 
   describe("getAvailableWords", () => {
     const words: Word[] = [
-      { word: "cat", definition: "A pet.", sentence: "The cat sat.", difficulty: "easy" as const, grade: 1 },
-      { word: "dog", definition: "A pet.", sentence: "The dog barked.", difficulty: "easy" as const, grade: 1 },
-      { word: "apple", definition: "A fruit.", sentence: "I ate an apple.", difficulty: "medium" as const, grade: 1 },
+      {
+        word: "cat",
+        definition: "A pet.",
+        sentence: "The cat sat.",
+        difficulty: "easy" as const,
+        grade: 1,
+      },
+      {
+        word: "dog",
+        definition: "A pet.",
+        sentence: "The dog barked.",
+        difficulty: "easy" as const,
+        grade: 1,
+      },
+      {
+        word: "apple",
+        definition: "A fruit.",
+        sentence: "I ate an apple.",
+        difficulty: "medium" as const,
+        grade: 1,
+      },
     ];
 
     it("returns available words filtered by difficulty", () => {
@@ -270,6 +288,10 @@ describe("difficulty", () => {
     });
 
     it("excludes mastered words (mostly)", () => {
+      // Mock Math.random() to ensure deterministic behavior
+      // We want allowMastered to be false (Math.random() >= 0.1)
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
       const mastered = new Set(["cat", "dog"]);
       const result = getAvailableWords(
         words,
@@ -279,6 +301,8 @@ describe("difficulty", () => {
         "all",
       );
       expect(result.availableWords).toHaveLength(0);
+
+      randomSpy.mockRestore();
     });
 
     it("shouldResetUsed is true when no words available", () => {
@@ -300,7 +324,13 @@ describe("difficulty", () => {
 
     it("returns a word from the array", () => {
       const words: Word[] = [
-        { word: "cat", definition: "A pet.", sentence: "The cat sat.", difficulty: "easy" as const, grade: 1 },
+        {
+          word: "cat",
+          definition: "A pet.",
+          sentence: "The cat sat.",
+          difficulty: "easy" as const,
+          grade: 1,
+        },
       ];
       expect(selectRandomWord(words)).toEqual(words[0]);
     });

--- a/src/hooks/__tests__/useGameState.test.ts
+++ b/src/hooks/__tests__/useGameState.test.ts
@@ -13,25 +13,25 @@
  *  - session completion (word pool exhausted → idle)
  *  - streak-5: store streak reaches 5, triggerMessage yields celebratory tone
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
 
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
 
-vi.mock('../../lib/supabase', () => ({
+vi.mock("../../lib/supabase", () => ({
   supabase: {
     auth: {
       getUser: vi.fn().mockResolvedValue({
-        data: { user: { id: 'test-user-123' } },
+        data: { user: { id: "test-user-123" } },
         error: null,
       }),
     },
   },
 }));
 
-vi.mock('../../lib/db', () => ({
+vi.mock("../../lib/db", () => ({
   localDb: {
     progress: {
       put: vi.fn().mockResolvedValue(1),
@@ -58,15 +58,51 @@ vi.mock('../../lib/db', () => ({
  * pool) while keeping the set small and deterministic.
  */
 const MOCK_WORDS = [
-  { word: 'cat', definition: 'A small furry animal.', sentence: 'The cat sat.', grade: 1, difficulty: 'easy' },
-  { word: 'dog', definition: 'A friendly pet.', sentence: 'The dog barked.', grade: 1, difficulty: 'easy' },
-  { word: 'bee', definition: 'A flying insect.', sentence: 'The bee buzzed.', grade: 1, difficulty: 'easy' },
-  { word: 'ant', definition: 'A small insect.', sentence: 'The ant worked.', grade: 1, difficulty: 'easy' },
-  { word: 'hen', definition: 'A female chicken.', sentence: 'The hen clucked.', grade: 1, difficulty: 'easy' },
-  { word: 'fox', definition: 'A clever animal.', sentence: 'The fox ran.', grade: 1, difficulty: 'easy' },
+  {
+    word: "cat",
+    definition: "A small furry animal.",
+    sentence: "The cat sat.",
+    grade: 1,
+    difficulty: "easy",
+  },
+  {
+    word: "dog",
+    definition: "A friendly pet.",
+    sentence: "The dog barked.",
+    grade: 1,
+    difficulty: "easy",
+  },
+  {
+    word: "run",
+    definition: "To move quickly on foot.",
+    sentence: "The child ran fast.",
+    grade: 1,
+    difficulty: "easy",
+  },
+  {
+    word: "ant",
+    definition: "A small insect.",
+    sentence: "The ant worked.",
+    grade: 1,
+    difficulty: "easy",
+  },
+  {
+    word: "hen",
+    definition: "A female chicken.",
+    sentence: "The hen clucked.",
+    grade: 1,
+    difficulty: "easy",
+  },
+  {
+    word: "fox",
+    definition: "A clever animal.",
+    sentence: "The fox ran.",
+    grade: 1,
+    difficulty: "easy",
+  },
 ];
 
-vi.mock('../../lib/wordList', () => ({
+vi.mock("../../lib/wordList", () => ({
   getWordsForConfig: vi.fn().mockReturnValue(MOCK_WORDS),
   WORD_LIST: MOCK_WORDS,
 }));
@@ -85,7 +121,7 @@ vi.mock('../../lib/wordList', () => ({
  * call restartGame() which also sets lastSubmitAt = 0 in startSession.
  */
 async function getStore() {
-  const { useGameStore } = await import('../useGameStore');
+  const { useGameStore } = await import("../useGameStore");
   return useGameStore;
 }
 
@@ -93,7 +129,7 @@ async function getStore() {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('useGameState', () => {
+describe("useGameState", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -104,135 +140,178 @@ describe('useGameState', () => {
 
   // ── Basic state ────────────────────────────────────────────────────────────
 
-  it('starts in idle phase', async () => {
-    const { useGameState } = await import('../useGameState');
+  it("starts in idle phase", async () => {
+    const { useGameState } = await import("../useGameState");
     const { result } = renderHook(() => useGameState());
-    expect(result.current.phase).toBe('idle');
+    expect(result.current.phase).toBe("idle");
     expect(result.current.result).toBeNull();
   });
 
   // ── Phase transitions ──────────────────────────────────────────────────────
 
-  it('startSession transitions phase to playing and sets a currentWord', async () => {
+  it("startSession transitions phase to playing and sets a currentWord", async () => {
     const store = await getStore();
-    act(() => { store.getState().restartGame(); });
+    act(() => {
+      store.getState().restartGame();
+    });
 
-    const { useGameState } = await import('../useGameState');
+    const { useGameState } = await import("../useGameState");
     const { result } = renderHook(() => useGameState());
 
-    act(() => { result.current.startSession(); });
+    act(() => {
+      result.current.startSession();
+    });
 
-    expect(result.current.phase).toBe('playing');
+    expect(result.current.phase).toBe("playing");
     expect(store.getState().currentWord).not.toBeNull();
   });
 
-  it('submitAnswer returns true and advances to round_end on correct answer', async () => {
+  it("submitAnswer returns true and advances to round_end on correct answer", async () => {
     const store = await getStore();
-    act(() => { store.getState().restartGame(); });
+    act(() => {
+      store.getState().restartGame();
+    });
 
-    const { useGameState } = await import('../useGameState');
+    const { useGameState } = await import("../useGameState");
     const { result } = renderHook(() => useGameState());
 
-    act(() => { result.current.startSession(); });
+    act(() => {
+      result.current.startSession();
+    });
     const word = store.getState().currentWord!.word;
 
     let returnValue: boolean | null = null;
-    act(() => { returnValue = result.current.submitAnswer(word); });
+    act(() => {
+      returnValue = result.current.submitAnswer(word);
+    });
 
     expect(returnValue).toBe(true);
-    expect(result.current.phase).toBe('round_end');
+    expect(result.current.phase).toBe("round_end");
     expect(result.current.result?.isCorrect).toBe(true);
   });
 
-  it('submitAnswer returns false and advances to round_end on wrong answer', async () => {
+  it("submitAnswer returns false and advances to round_end on wrong answer", async () => {
     const store = await getStore();
-    act(() => { store.getState().restartGame(); });
+    act(() => {
+      store.getState().restartGame();
+    });
 
-    const { useGameState } = await import('../useGameState');
+    const { useGameState } = await import("../useGameState");
     const { result } = renderHook(() => useGameState());
 
-    act(() => { result.current.startSession(); });
+    act(() => {
+      result.current.startSession();
+    });
 
     let returnValue: boolean | null = null;
-    act(() => { returnValue = result.current.submitAnswer('zzzzzzwrongzzzzz'); });
+    act(() => {
+      returnValue = result.current.submitAnswer("zzzzzzwrongzzzzz");
+    });
 
     expect(returnValue).toBe(false);
-    expect(result.current.phase).toBe('round_end');
+    expect(result.current.phase).toBe("round_end");
     expect(result.current.result?.isCorrect).toBe(false);
   });
 
-  it('submitAnswer returns null for empty input and does NOT advance to round_end', async () => {
+  it("submitAnswer returns null for empty input and does NOT advance to round_end", async () => {
     const store = await getStore();
-    act(() => { store.getState().restartGame(); });
+    act(() => {
+      store.getState().restartGame();
+    });
 
-    const { useGameState } = await import('../useGameState');
+    const { useGameState } = await import("../useGameState");
     const { result } = renderHook(() => useGameState());
 
-    act(() => { result.current.startSession(); });
+    act(() => {
+      result.current.startSession();
+    });
 
     let returnValue: boolean | null = false;
-    act(() => { returnValue = result.current.submitAnswer(''); });
+    act(() => {
+      returnValue = result.current.submitAnswer("");
+    });
 
     expect(returnValue).toBeNull();
-    expect(result.current.phase).toBe('playing');
+    expect(result.current.phase).toBe("playing");
   });
 
-  it('timeoutRound transitions to round_end with isCorrect:false and resets streak', async () => {
+  it("timeoutRound transitions to round_end with isCorrect:false and resets streak", async () => {
     const store = await getStore();
-    act(() => { store.getState().restartGame(); });
+    act(() => {
+      store.getState().restartGame();
+    });
 
-    const { useGameState } = await import('../useGameState');
+    const { useGameState } = await import("../useGameState");
     const { result } = renderHook(() => useGameState());
 
-    act(() => { result.current.startSession(); });
-    act(() => { result.current.timeoutRound(); });
+    act(() => {
+      result.current.startSession();
+    });
+    act(() => {
+      result.current.timeoutRound();
+    });
 
-    expect(result.current.phase).toBe('round_end');
+    expect(result.current.phase).toBe("round_end");
     expect(result.current.result?.isCorrect).toBe(false);
     // timeoutRound must reset the streak
     expect(store.getState().streak).toBe(0);
   });
 
-  it('restartGame resets phase to idle and clears result', async () => {
+  it("restartGame resets phase to idle and clears result", async () => {
     const store = await getStore();
-    act(() => { store.getState().restartGame(); });
+    act(() => {
+      store.getState().restartGame();
+    });
 
-    const { useGameState } = await import('../useGameState');
+    const { useGameState } = await import("../useGameState");
     const { result } = renderHook(() => useGameState());
 
-    act(() => { result.current.startSession(); result.current.timeoutRound(); });
-    expect(result.current.phase).toBe('round_end');
+    act(() => {
+      result.current.startSession();
+      result.current.timeoutRound();
+    });
+    expect(result.current.phase).toBe("round_end");
 
-    act(() => { result.current.restartGame(); });
+    act(() => {
+      result.current.restartGame();
+    });
 
-    expect(result.current.phase).toBe('idle');
+    expect(result.current.phase).toBe("idle");
     expect(result.current.result).toBeNull();
   });
 
   // ── Full 3-round session flow ───────────────────────────────────────────────
 
-  it('full 3-round session: correct answers advance through rounds and accumulate score', async () => {
+  it("full 3-round session: correct answers advance through rounds and accumulate score", async () => {
     const store = await getStore();
-    act(() => { store.getState().restartGame(); });
+    act(() => {
+      store.getState().restartGame();
+    });
 
-    const { useGameState } = await import('../useGameState');
+    const { useGameState } = await import("../useGameState");
     const { result } = renderHook(() => useGameState());
 
-    act(() => { result.current.startSession(); });
+    act(() => {
+      result.current.startSession();
+    });
 
     for (let round = 0; round < 3; round++) {
-      expect(result.current.phase).toBe('playing');
+      expect(result.current.phase).toBe("playing");
       const word = store.getState().currentWord!.word;
 
       let returned: boolean | null = null;
-      act(() => { returned = result.current.submitAnswer(word); });
+      act(() => {
+        returned = result.current.submitAnswer(word);
+      });
 
       expect(returned).toBe(true);
-      expect(result.current.phase).toBe('round_end');
+      expect(result.current.phase).toBe("round_end");
       expect(result.current.result?.isCorrect).toBe(true);
 
       if (round < 2) {
-        act(() => { result.current.nextWord(); });
+        act(() => {
+          result.current.nextWord();
+        });
       }
     }
 
@@ -249,36 +328,48 @@ describe('useGameState', () => {
    * which is the message GameBoard should display when the player requests
    * a hint. The integration point is the trigger key — not store state.
    */
-  it('triggerMessage(hint-used) produces a neutral-tone host message', async () => {
-    const { useHostMessages } = await import('../useHostMessages');
+  it("triggerMessage(hint-used) produces a neutral-tone host message", async () => {
+    const { useHostMessages } = await import("../useHostMessages");
     const { result } = renderHook(() => useHostMessages());
 
-    act(() => { result.current.triggerMessage('hint-used'); });
+    act(() => {
+      result.current.triggerMessage("hint-used");
+    });
 
     expect(result.current.currentMessage).not.toBeNull();
-    expect(result.current.currentMessage!.tone).toBe('neutral');
+    expect(result.current.currentMessage!.tone).toBe("neutral");
   });
 
   // ── Streak reset on incorrect ──────────────────────────────────────────────
 
-  it('streak resets to 0 after an incorrect answer following a correct one', async () => {
+  it("streak resets to 0 after an incorrect answer following a correct one", async () => {
     const store = await getStore();
-    act(() => { store.getState().restartGame(); });
+    act(() => {
+      store.getState().restartGame();
+    });
 
-    const { useGameState } = await import('../useGameState');
+    const { useGameState } = await import("../useGameState");
     const { result } = renderHook(() => useGameState());
 
-    act(() => { result.current.startSession(); });
+    act(() => {
+      result.current.startSession();
+    });
 
     // Round 1: correct — builds streak to 1
     const word = store.getState().currentWord!.word;
-    act(() => { result.current.submitAnswer(word); });
+    act(() => {
+      result.current.submitAnswer(word);
+    });
     expect(store.getState().streak).toBe(1);
 
-    act(() => { result.current.nextWord(); });
+    act(() => {
+      result.current.nextWord();
+    });
 
     // Round 2: incorrect — streak must drop to 0
-    act(() => { result.current.submitAnswer('zzzzzzwrongzzzzz'); });
+    act(() => {
+      result.current.submitAnswer("zzzzzzwrongzzzzz");
+    });
     expect(store.getState().streak).toBe(0);
   });
 
@@ -293,29 +384,37 @@ describe('useGameState', () => {
    * completing all MOCK_WORDS words and confirming the session is still
    * playable (pool resets) — i.e., phase is not "crashed".
    */
-  it('session completion: playing all words exhausts pool and store resets used-words for continued play', async () => {
+  it("session completion: playing all words exhausts pool and store resets used-words for continued play", async () => {
     const store = await getStore();
-    act(() => { store.getState().restartGame(); });
+    act(() => {
+      store.getState().restartGame();
+    });
 
-    const { useGameState } = await import('../useGameState');
+    const { useGameState } = await import("../useGameState");
     const { result } = renderHook(() => useGameState());
 
-    act(() => { result.current.startSession(); });
+    act(() => {
+      result.current.startSession();
+    });
 
     // Play through all MOCK_WORDS (6 words)
     for (let i = 0; i < MOCK_WORDS.length; i++) {
-      if (result.current.phase !== 'playing') break;
+      if (result.current.phase !== "playing") break;
       const word = store.getState().currentWord!.word;
-      act(() => { result.current.submitAnswer(word); });
+      act(() => {
+        result.current.submitAnswer(word);
+      });
       // After the last word, don't call nextWord — let it lapse
       if (i < MOCK_WORDS.length - 1) {
-        act(() => { result.current.nextWord(); });
+        act(() => {
+          result.current.nextWord();
+        });
       }
     }
 
     // Phase is either round_end (last word played) or idle (pool empty fallback)
     // In both cases the store must not be in an error state
-    expect(['round_end', 'playing', 'idle']).toContain(result.current.phase);
+    expect(["round_end", "playing", "idle"]).toContain(result.current.phase);
     // usedWords reflects words seen — should be >= 1
     expect(store.getState().usedWords.length).toBeGreaterThanOrEqual(1);
   });
@@ -335,29 +434,37 @@ describe('useGameState', () => {
    *   - store side: streak reaches 5 after 5 correct answers
    *   - host side: 'streak-5' trigger produces celebratory tone with "5" in text
    */
-  it('streak reaches 5 after 5 correct answers and streak-5 trigger produces celebratory message', async () => {
+  it("streak reaches 5 after 5 correct answers and streak-5 trigger produces celebratory message", async () => {
     const store = await getStore();
     // Full reset: clears lastSubmitAt (happens inside startSession)
-    act(() => { store.getState().restartGame(); });
+    act(() => {
+      store.getState().restartGame();
+    });
 
-    const { useGameState } = await import('../useGameState');
-    const { useHostMessages } = await import('../useHostMessages');
+    const { useGameState } = await import("../useGameState");
+    const { useHostMessages } = await import("../useHostMessages");
     const { result: gameResult } = renderHook(() => useGameState());
     const { result: hostResult } = renderHook(() => useHostMessages());
 
-    act(() => { gameResult.current.startSession(); });
+    act(() => {
+      gameResult.current.startSession();
+    });
 
     // Submit 5 correct answers, advancing through rounds
     let correctCount = 0;
     for (let i = 0; i < 5; i++) {
-      if (gameResult.current.phase !== 'playing') break;
+      if (gameResult.current.phase !== "playing") break;
       const word = store.getState().currentWord!.word;
       let returned: boolean | null = null;
-      act(() => { returned = gameResult.current.submitAnswer(word); });
+      act(() => {
+        returned = gameResult.current.submitAnswer(word);
+      });
       if (returned === true) {
         correctCount++;
         if (correctCount < 5) {
-          act(() => { gameResult.current.nextWord(); });
+          act(() => {
+            gameResult.current.nextWord();
+          });
         }
       } else {
         // Word pool may have repeated — break to avoid infinite loop
@@ -372,11 +479,13 @@ describe('useGameState', () => {
     if (correctCount >= 5) {
       expect(store.getState().streak).toBe(5);
 
-      act(() => { hostResult.current.triggerMessage('streak-5'); });
+      act(() => {
+        hostResult.current.triggerMessage("streak-5");
+      });
 
       expect(hostResult.current.currentMessage).not.toBeNull();
-      expect(hostResult.current.currentMessage!.tone).toBe('celebratory');
-      expect(hostResult.current.currentMessage!.text).toContain('5');
+      expect(hostResult.current.currentMessage!.tone).toBe("celebratory");
+      expect(hostResult.current.currentMessage!.text).toContain("5");
     } else {
       // Word pool too small to reach 5 without repetition in this env —
       // assert streak matches correctCount (pool-size constraint acknowledged)


### PR DESCRIPTION
Add /logs to .gitignore and refactor tests for readability and determinism. Tests were reformatted (multiline objects, consistent quoting) and module mocks normalized; MOCK_WORDS adjusted for clarity. A deterministic Math.random() mock was added to the getAvailableWords test (and restored afterwards), and act() calls were expanded for clearer behavior. (Note: package-lock.json updated separately.)