### PR TITLE
fix(types,wordLoader): close remaining SUB-01 and SUB-03 acceptance c…

### DIFF
--- a/public/data/words/grade-1.json
+++ b/public/data/words/grade-1.json
@@ -2,26 +2,980 @@
   "grade": 1,
   "language": "en-US",
   "version": "1.0.0",
-  "lastUpdated": "2026-03-23T17:03:57.090Z",
-  "wordCount": 15,
+  "lastUpdated": "2026-03-03T22:00:53.309Z",
+  "wordCount": 108,
   "words": [
     {
       "word": "apple",
-      "definition": "A round fruit with red, green, or yellow skin and crisp flesh.",
-      "example": "I ate a juicy apple for lunch.",
+      "definition": "A round fruit with red or green skin",
+      "example": "She picked a fresh apple from the tree.",
       "phonetic": "AP-ple",
       "syllables": "ap-ple",
       "difficulty": "easy",
       "gradeLevel": "K-2"
     },
     {
-      "word": "banana",
-      "definition": "A long curved fruit with yellow skin and soft flesh.",
-      "example": "The monkey peeled the banana.",
-      "phonetic": "BA-na-na",
-      "syllables": "ba-na-na",
+      "word": "book",
+      "definition": "A written work bound together",
+      "example": "I read a great book last week.",
+      "phonetic": "BOOK",
+      "syllables": "book",
       "difficulty": "easy",
       "gradeLevel": "K-2"
     },
     {
+      "word": "cat",
+      "definition": "A small domesticated feline",
+      "example": "The cat slept on the warm windowsill.",
+      "phonetic": "CAT",
+      "syllables": "cat",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "door",
+      "definition": "A hinged barrier at an entrance",
+      "example": "Please close the door behind you.",
+      "phonetic": "DOOR",
+      "syllables": "door",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "friend",
+      "definition": "A person you know and like",
+      "example": "My best friend lives next door.",
+      "phonetic": "FRIEND",
+      "syllables": "friend",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "garden",
+      "definition": "A piece of ground for growing plants",
+      "example": "We planted tomatoes in the garden.",
+      "phonetic": "GAR-den",
+      "syllables": "gar-den",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
       "word": "happy",
+      "definition": "Feeling pleasure or contentment",
+      "example": "The children were happy to see snow.",
+      "phonetic": "HAP-py",
+      "syllables": "hap-py",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "kite",
+      "definition": "A toy flown in the wind",
+      "example": "The kite soared high above the park.",
+      "phonetic": "KITE",
+      "syllables": "kite",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "lemon",
+      "definition": "A yellow citrus fruit",
+      "example": "She squeezed lemon into her tea.",
+      "phonetic": "LEM-on",
+      "syllables": "lem-on",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "monkey",
+      "definition": "A primate with a long tail",
+      "example": "The monkey swung from branch to branch.",
+      "phonetic": "MON-key",
+      "syllables": "mon-key",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "pencil",
+      "definition": "A writing instrument",
+      "example": "Write your name with a pencil.",
+      "phonetic": "PEN-cil",
+      "syllables": "pen-cil",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "queen",
+      "definition": "A female monarch",
+      "example": "The queen wore a golden crown.",
+      "phonetic": "QUEEN",
+      "syllables": "queen",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "ant",
+      "definition": "A small insect that lives in colonies",
+      "example": "The ant carried a crumb to its hill.",
+      "phonetic": "ANT",
+      "syllables": "ant",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "baby",
+      "definition": "A very young child",
+      "example": "The baby is sleeping in the crib.",
+      "phonetic": "BA-by",
+      "syllables": "ba-by",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "bear",
+      "definition": "A large mammal with fur",
+      "example": "The bear loves to eat honey.",
+      "phonetic": "BEAR",
+      "syllables": "bear",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "bird",
+      "definition": "An animal with feathers and wings",
+      "example": "A blue bird sang in the tree.",
+      "phonetic": "BIRD",
+      "syllables": "bird",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "boat",
+      "definition": "A vehicle for traveling on water",
+      "example": "We rowed the boat across the lake.",
+      "phonetic": "BOAT",
+      "syllables": "boat",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "bread",
+      "definition": "Food made from flour and baked",
+      "example": "I like bread with butter.",
+      "phonetic": "BREAD",
+      "syllables": "bread",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "bus",
+      "definition": "A large vehicle for carrying passengers",
+      "example": "The school bus arrives at 8 AM.",
+      "phonetic": "BUS",
+      "syllables": "bus",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "cake",
+      "definition": "A sweet baked dessert",
+      "example": "We ate chocolate cake for his birthday.",
+      "phonetic": "CAKE",
+      "syllables": "cake",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "car",
+      "definition": "A vehicle with four wheels",
+      "example": "My dad drives a red car.",
+      "phonetic": "CAR",
+      "syllables": "car",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "chair",
+      "definition": "A seat with a back",
+      "example": "Please sit on the chair.",
+      "phonetic": "CHAIR",
+      "syllables": "chair",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "chicken",
+      "definition": "A bird raised for food",
+      "example": "The chicken laid an egg.",
+      "phonetic": "CHICK-en",
+      "syllables": "chick-en",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "clock",
+      "definition": "A device that tells time",
+      "example": "The clock struck twelve.",
+      "phonetic": "CLOCK",
+      "syllables": "clock",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "coat",
+      "definition": "Outer clothing worn for warmth",
+      "example": "Wear your coat, it's cold outside.",
+      "phonetic": "COAT",
+      "syllables": "coat",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "cow",
+      "definition": "A large farm animal that gives milk",
+      "example": "The cow is eating grass.",
+      "phonetic": "COW",
+      "syllables": "cow",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "cup",
+      "definition": "A small bowl for drinking",
+      "example": "I would like a cup of water.",
+      "phonetic": "CUP",
+      "syllables": "cup",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "desk",
+      "definition": "A table for writing or working",
+      "example": "She sat at her desk to study.",
+      "phonetic": "DESK",
+      "syllables": "desk",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "dog",
+      "definition": "A common pet animal",
+      "example": "The dog wagged its tail.",
+      "phonetic": "DOG",
+      "syllables": "dog",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "doll",
+      "definition": "A toy that looks like a person",
+      "example": "She played with her favorite doll.",
+      "phonetic": "DOLL",
+      "syllables": "doll",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "duck",
+      "definition": "A water bird with webbed feet",
+      "example": "The duck swam in the pond.",
+      "phonetic": "DUCK",
+      "syllables": "duck",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "egg",
+      "definition": "An oval object laid by birds",
+      "example": "He ate a boiled egg for breakfast.",
+      "phonetic": "EGG",
+      "syllables": "egg",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "eye",
+      "definition": "The organ of sight",
+      "example": "She closed one eye to aim.",
+      "phonetic": "EYE",
+      "syllables": "eye",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "farm",
+      "definition": "Land used for growing crops",
+      "example": "Animals live on the farm.",
+      "phonetic": "FARM",
+      "syllables": "farm",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "fish",
+      "definition": "An animal that lives in water",
+      "example": "The fish swam in the bowl.",
+      "phonetic": "FISH",
+      "syllables": "fish",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "flower",
+      "definition": "The colorful part of a plant",
+      "example": "He picked a yellow flower.",
+      "phonetic": "FLOW-er",
+      "syllables": "flow-er",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "food",
+      "definition": "What people and animals eat",
+      "example": "We need food to live.",
+      "phonetic": "FOOD",
+      "syllables": "food",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "frog",
+      "definition": "A small green animal that hops",
+      "example": "The frog jumped into the water.",
+      "phonetic": "FROG",
+      "syllables": "frog",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "game",
+      "definition": "An activity played for fun",
+      "example": "Let's play a board game.",
+      "phonetic": "GAME",
+      "syllables": "game",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "girl",
+      "definition": "A female child",
+      "example": "The girl skipped down the street.",
+      "phonetic": "GIRL",
+      "syllables": "girl",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "goat",
+      "definition": "A farm animal with horns",
+      "example": "The goat climbed the rock.",
+      "phonetic": "GOAT",
+      "syllables": "goat",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "grass",
+      "definition": "Green plants covering the ground",
+      "example": "The grass is wet with dew.",
+      "phonetic": "GRASS",
+      "syllables": "grass",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "hand",
+      "definition": "Body part at the end of the arm",
+      "example": "Raise your hand if you know the answer.",
+      "phonetic": "HAND",
+      "syllables": "hand",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "hat",
+      "definition": "A covering for the head",
+      "example": "He wore a hat to block the sun.",
+      "phonetic": "HAT",
+      "syllables": "hat",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "hill",
+      "definition": "A raised area of land",
+      "example": "We rolled down the grassy hill.",
+      "phonetic": "HILL",
+      "syllables": "hill",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "horse",
+      "definition": "A large animal used for riding",
+      "example": "She loves to ride her horse.",
+      "phonetic": "HORSE",
+      "syllables": "horse",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "house",
+      "definition": "A building where people live",
+      "example": "Our house has a red door.",
+      "phonetic": "HOUSE",
+      "syllables": "house",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "ice",
+      "definition": "Frozen water",
+      "example": "Put some ice in my drink.",
+      "phonetic": "ICE",
+      "syllables": "ice",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "juice",
+      "definition": "Liquid from fruit or vegetables",
+      "example": "I drank orange juice with toast.",
+      "phonetic": "JUICE",
+      "syllables": "juice",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "lamp",
+      "definition": "A device that gives light",
+      "example": "Turn on the lamp so we can see.",
+      "phonetic": "LAMP",
+      "syllables": "lamp",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "leaf",
+      "definition": "The green part of a plant",
+      "example": "A brown leaf fell from the tree.",
+      "phonetic": "LEAF",
+      "syllables": "leaf",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "lion",
+      "definition": "A large wild cat",
+      "example": "The lion roared loudly.",
+      "phonetic": "LI-on",
+      "syllables": "li-on",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "milk",
+      "definition": "White liquid from cows",
+      "example": "Milk is good for your bones.",
+      "phonetic": "MILK",
+      "syllables": "milk",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "moon",
+      "definition": "Object that orbits the Earth",
+      "example": "The full moon shines at night.",
+      "phonetic": "MOON",
+      "syllables": "moon",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "mouse",
+      "definition": "A small rodent",
+      "example": "The mouse ran into a hole.",
+      "phonetic": "MOUSE",
+      "syllables": "mouse",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "nest",
+      "definition": "A home built by a bird",
+      "example": "There are three eggs in the nest.",
+      "phonetic": "NEST",
+      "syllables": "nest",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "nose",
+      "definition": "Body part used for smelling",
+      "example": "My nose is cold.",
+      "phonetic": "NOSE",
+      "syllables": "nose",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "park",
+      "definition": "Public land for recreation",
+      "example": "We played soccer at the park.",
+      "phonetic": "PARK",
+      "syllables": "park",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "pig",
+      "definition": "A farm animal with a pink snout",
+      "example": "The pig played in the mud.",
+      "phonetic": "PIG",
+      "syllables": "pig",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "rain",
+      "definition": "Water falling from clouds",
+      "example": "Take an umbrella in the rain.",
+      "phonetic": "RAIN",
+      "syllables": "rain",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "ring",
+      "definition": "A circular band worn on a finger",
+      "example": "She lost her gold ring.",
+      "phonetic": "RING",
+      "syllables": "ring",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "road",
+      "definition": "A hard surface for vehicles",
+      "example": "Look both ways before crossing the road.",
+      "phonetic": "ROAD",
+      "syllables": "road",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "room",
+      "definition": "A space inside a building",
+      "example": "My room is very messy.",
+      "phonetic": "ROOM",
+      "syllables": "room",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "shoe",
+      "definition": "Footwear",
+      "example": "Tie your shoe lace.",
+      "phonetic": "SHOE",
+      "syllables": "shoe",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "snow",
+      "definition": "Frozen white rain",
+      "example": "The snow covered the ground.",
+      "phonetic": "SNOW",
+      "syllables": "snow",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "star",
+      "definition": "A bright point in the night sky",
+      "example": "Make a wish on a falling star.",
+      "phonetic": "STAR",
+      "syllables": "star",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "sun",
+      "definition": "The star that warms the Earth",
+      "example": "The sun rises in the east.",
+      "phonetic": "SUN",
+      "syllables": "sun",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "acorn",
+      "definition": "The nut of an oak tree",
+      "example": "A squirrel carried the acorn up the tree.",
+      "phonetic": "A-corn",
+      "syllables": "a-corn",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "bubble",
+      "definition": "A thin sphere of liquid filled with air",
+      "example": "The bubble floated and popped.",
+      "phonetic": "BUB-ble",
+      "syllables": "bub-ble",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "cabin",
+      "definition": "A small simple house, often in the woods",
+      "example": "They stayed in a cozy cabin by the lake.",
+      "phonetic": "CAB-in",
+      "syllables": "cab-in",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "lantern",
+      "definition": "A portable light with a protective cover",
+      "example": "We carried a lantern on the evening walk.",
+      "phonetic": "LAN-tern",
+      "syllables": "lan-tern",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "igloo",
+      "definition": "A dome-shaped shelter made of snow blocks",
+      "example": "The picture book showed an igloo in winter.",
+      "phonetic": "IG-loo",
+      "syllables": "ig-loo",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "glove",
+      "definition": "A hand covering with finger sections",
+      "example": "She wore one warm glove on each hand.",
+      "phonetic": "GLOVE",
+      "syllables": "glove",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "meadow",
+      "definition": "A grassy field",
+      "example": "Wildflowers bloomed in the meadow.",
+      "phonetic": "MEAD-ow",
+      "syllables": "mead-ow",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "pebble",
+      "definition": "A small smooth stone",
+      "example": "He skipped a pebble across the pond.",
+      "phonetic": "PEB-ble",
+      "syllables": "peb-ble",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "thunder",
+      "definition": "The loud sound during a storm",
+      "example": "Thunder rumbled in the distance.",
+      "phonetic": "THUN-der",
+      "syllables": "thun-der",
+      "difficulty": "easy",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "basket",
+      "definition": "A container woven from strips",
+      "example": "She carried apples in a basket.",
+      "phonetic": "BAS-ket",
+      "syllables": "bas-ket",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "blanket",
+      "definition": "A warm cover for a bed",
+      "example": "I pulled the blanket up to my chin.",
+      "phonetic": "BLAN-ket",
+      "syllables": "blan-ket",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "branch",
+      "definition": "A part of a tree that grows from the trunk",
+      "example": "A bird landed on the branch.",
+      "phonetic": "BRANCH",
+      "syllables": "branch",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "cactus",
+      "definition": "A desert plant with spines",
+      "example": "The cactus needs very little water.",
+      "phonetic": "CAC-tus",
+      "syllables": "cac-tus",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "dragon",
+      "definition": "A large mythical creature",
+      "example": "The storybook dragon guarded a cave.",
+      "phonetic": "DRAG-on",
+      "syllables": "drag-on",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "frozen",
+      "definition": "Turned into ice by cold",
+      "example": "The pond was frozen this morning.",
+      "phonetic": "FRO-zen",
+      "syllables": "fro-zen",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "gardenia",
+      "definition": "A fragrant white flower",
+      "example": "A gardenia bloomed near the porch.",
+      "phonetic": "GAR-de-ni-a",
+      "syllables": "gar-de-ni-a",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "helmet",
+      "definition": "A hard hat for protection",
+      "example": "Wear your helmet when riding a bike.",
+      "phonetic": "HEL-met",
+      "syllables": "hel-met",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "kittenish",
+      "definition": "Playful like a kitten",
+      "example": "The puppy made kittenish jumps around us.",
+      "phonetic": "KIT-ten-ish",
+      "syllables": "kit-ten-ish",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "lantern",
+      "definition": "A lamp with a protective case",
+      "example": "We carried a lantern on the trail.",
+      "phonetic": "LAN-tern",
+      "syllables": "lan-tern",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "magnet",
+      "definition": "An object that attracts iron",
+      "example": "The magnet pulled the paper clips close.",
+      "phonetic": "MAG-net",
+      "syllables": "mag-net",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "napkin",
+      "definition": "A cloth or paper used at meals",
+      "example": "Put the napkin on your lap.",
+      "phonetic": "NAP-kin",
+      "syllables": "nap-kin",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "planet",
+      "definition": "A large body orbiting a star",
+      "example": "Earth is the planet we live on.",
+      "phonetic": "PLAN-et",
+      "syllables": "plan-et",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "rocket",
+      "definition": "A vehicle that can travel into space",
+      "example": "The toy rocket zoomed across the room.",
+      "phonetic": "ROCK-et",
+      "syllables": "rock-et",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "splash",
+      "definition": "The sound or act of water striking",
+      "example": "The duck made a big splash.",
+      "phonetic": "SPLASH",
+      "syllables": "splash",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "thunder",
+      "definition": "The loud sound after lightning",
+      "example": "Thunder shook the windows last night.",
+      "phonetic": "THUN-der",
+      "syllables": "thun-der",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "trumpet",
+      "definition": "A brass musical instrument",
+      "example": "He practiced trumpet in band class.",
+      "phonetic": "TRUM-pet",
+      "syllables": "trum-pet",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "window",
+      "definition": "An opening in a wall with glass",
+      "example": "Rain tapped on the window.",
+      "phonetic": "WIN-dow",
+      "syllables": "win-dow",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "yellowish",
+      "definition": "Slightly yellow in color",
+      "example": "The old paper looked yellowish.",
+      "phonetic": "YEL-low-ish",
+      "syllables": "yel-low-ish",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "zigzag",
+      "definition": "A pattern with sharp turns",
+      "example": "The path made a zigzag up the hill.",
+      "phonetic": "ZIG-zag",
+      "syllables": "zig-zag",
+      "difficulty": "medium",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "adventure",
+      "definition": "An exciting experience",
+      "example": "Our camping trip was a big adventure.",
+      "phonetic": "AD-ven-ture",
+      "syllables": "ad-ven-ture",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "butterfly",
+      "definition": "An insect with colorful wings",
+      "example": "A butterfly landed on the flower.",
+      "phonetic": "BUT-ter-fly",
+      "syllables": "but-ter-fly",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "chocolate",
+      "definition": "A sweet food made from cocoa",
+      "example": "She shared a piece of chocolate.",
+      "phonetic": "CHOC-o-late",
+      "syllables": "choc-o-late",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "dinosaur",
+      "definition": "A prehistoric reptile",
+      "example": "The dinosaur exhibit was my favorite.",
+      "phonetic": "DI-no-saur",
+      "syllables": "di-no-saur",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "elephant",
+      "definition": "A very large animal with a trunk",
+      "example": "The elephant sprayed water on itself.",
+      "phonetic": "EL-e-phant",
+      "syllables": "el-e-phant",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "fireworks",
+      "definition": "Exploding lights in the sky",
+      "example": "We watched fireworks on the holiday.",
+      "phonetic": "FIRE-works",
+      "syllables": "fire-works",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "giraffe",
+      "definition": "A tall animal with a long neck",
+      "example": "The giraffe reached the highest leaves.",
+      "phonetic": "GI-raffe",
+      "syllables": "gi-raffe",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "hamburger",
+      "definition": "A sandwich with a cooked patty",
+      "example": "He ordered a hamburger for lunch.",
+      "phonetic": "HAM-bur-ger",
+      "syllables": "ham-bur-ger",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "important",
+      "definition": "Having great value or meaning",
+      "example": "It is important to be kind to others.",
+      "phonetic": "IM-por-tant",
+      "syllables": "im-por-tant",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "jellyfish",
+      "definition": "A sea animal with soft body",
+      "example": "A jellyfish drifted near the shore.",
+      "phonetic": "JEL-ly-fish",
+      "syllables": "jel-ly-fish",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "kangaroo",
+      "definition": "A hopping animal from Australia",
+      "example": "The kangaroo carried a joey in its pouch.",
+      "phonetic": "KAN-ga-roo",
+      "syllables": "kan-ga-roo",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    },
+    {
+      "word": "lighthouse",
+      "definition": "A tower with a bright warning light",
+      "example": "The lighthouse guided ships at night.",
+      "phonetic": "LIGHT-house",
+      "syllables": "light-house",
+      "difficulty": "hard",
+      "gradeLevel": "K-2"
+    }
+  ]
+}

--- a/public/data/words/grade-1.json
+++ b/public/data/words/grade-1.json
@@ -1,981 +1,956 @@
-{
-  "grade": 1,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 108,
-  "words": [
-    {
-      "word": "apple",
-      "definition": "A round fruit with red or green skin",
-      "example": "She picked a fresh apple from the tree.",
-      "phonetic": "AP-ple",
-      "syllables": "ap-ple",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "book",
-      "definition": "A written work bound together",
-      "example": "I read a great book last week.",
-      "phonetic": "BOOK",
-      "syllables": "book",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cat",
-      "definition": "A small domesticated feline",
-      "example": "The cat slept on the warm windowsill.",
-      "phonetic": "CAT",
-      "syllables": "cat",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "door",
-      "definition": "A hinged barrier at an entrance",
-      "example": "Please close the door behind you.",
-      "phonetic": "DOOR",
-      "syllables": "door",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "friend",
-      "definition": "A person you know and like",
-      "example": "My best friend lives next door.",
-      "phonetic": "FRIEND",
-      "syllables": "friend",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "garden",
-      "definition": "A piece of ground for growing plants",
-      "example": "We planted tomatoes in the garden.",
-      "phonetic": "GAR-den",
-      "syllables": "gar-den",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "happy",
-      "definition": "Feeling pleasure or contentment",
-      "example": "The children were happy to see snow.",
-      "phonetic": "HAP-py",
-      "syllables": "hap-py",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "kite",
-      "definition": "A toy flown in the wind",
-      "example": "The kite soared high above the park.",
-      "phonetic": "KITE",
-      "syllables": "kite",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lemon",
-      "definition": "A yellow citrus fruit",
-      "example": "She squeezed lemon into her tea.",
-      "phonetic": "LEM-on",
-      "syllables": "lem-on",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "monkey",
-      "definition": "A primate with a long tail",
-      "example": "The monkey swung from branch to branch.",
-      "phonetic": "MON-key",
-      "syllables": "mon-key",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "pencil",
-      "definition": "A writing instrument",
-      "example": "Write your name with a pencil.",
-      "phonetic": "PEN-cil",
-      "syllables": "pen-cil",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "queen",
-      "definition": "A female monarch",
-      "example": "The queen wore a golden crown.",
-      "phonetic": "QUEEN",
-      "syllables": "queen",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "ant",
-      "definition": "A small insect that lives in colonies",
-      "example": "The ant carried a crumb to its hill.",
-      "phonetic": "ANT",
-      "syllables": "ant",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "baby",
-      "definition": "A very young child",
-      "example": "The baby is sleeping in the crib.",
-      "phonetic": "BA-by",
-      "syllables": "ba-by",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "bear",
-      "definition": "A large mammal with fur",
-      "example": "The bear loves to eat honey.",
-      "phonetic": "BEAR",
-      "syllables": "bear",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "bird",
-      "definition": "An animal with feathers and wings",
-      "example": "A blue bird sang in the tree.",
-      "phonetic": "BIRD",
-      "syllables": "bird",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "boat",
-      "definition": "A vehicle for traveling on water",
-      "example": "We rowed the boat across the lake.",
-      "phonetic": "BOAT",
-      "syllables": "boat",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "bread",
-      "definition": "Food made from flour and baked",
-      "example": "I like bread with butter.",
-      "phonetic": "BREAD",
-      "syllables": "bread",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "bus",
-      "definition": "A large vehicle for carrying passengers",
-      "example": "The school bus arrives at 8 AM.",
-      "phonetic": "BUS",
-      "syllables": "bus",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cake",
-      "definition": "A sweet baked dessert",
-      "example": "We ate chocolate cake for his birthday.",
-      "phonetic": "CAKE",
-      "syllables": "cake",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "car",
-      "definition": "A vehicle with four wheels",
-      "example": "My dad drives a red car.",
-      "phonetic": "CAR",
-      "syllables": "car",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "chair",
-      "definition": "A seat with a back",
-      "example": "Please sit on the chair.",
-      "phonetic": "CHAIR",
-      "syllables": "chair",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "chicken",
-      "definition": "A bird raised for food",
-      "example": "The chicken laid an egg.",
-      "phonetic": "CHICK-en",
-      "syllables": "chick-en",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "clock",
-      "definition": "A device that tells time",
-      "example": "The clock struck twelve.",
-      "phonetic": "CLOCK",
-      "syllables": "clock",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "coat",
-      "definition": "Outer clothing worn for warmth",
-      "example": "Wear your coat, it's cold outside.",
-      "phonetic": "COAT",
-      "syllables": "coat",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cow",
-      "definition": "A large farm animal that gives milk",
-      "example": "The cow is eating grass.",
-      "phonetic": "COW",
-      "syllables": "cow",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cup",
-      "definition": "A small bowl for drinking",
-      "example": "I would like a cup of water.",
-      "phonetic": "CUP",
-      "syllables": "cup",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "desk",
-      "definition": "A table for writing or working",
-      "example": "She sat at her desk to study.",
-      "phonetic": "DESK",
-      "syllables": "desk",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "dog",
-      "definition": "A common pet animal",
-      "example": "The dog wagged its tail.",
-      "phonetic": "DOG",
-      "syllables": "dog",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "doll",
-      "definition": "A toy that looks like a person",
-      "example": "She played with her favorite doll.",
-      "phonetic": "DOLL",
-      "syllables": "doll",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "duck",
-      "definition": "A water bird with webbed feet",
-      "example": "The duck swam in the pond.",
-      "phonetic": "DUCK",
-      "syllables": "duck",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "egg",
-      "definition": "An oval object laid by birds",
-      "example": "He ate a boiled egg for breakfast.",
-      "phonetic": "EGG",
-      "syllables": "egg",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "eye",
-      "definition": "The organ of sight",
-      "example": "She closed one eye to aim.",
-      "phonetic": "EYE",
-      "syllables": "eye",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "farm",
-      "definition": "Land used for growing crops",
-      "example": "Animals live on the farm.",
-      "phonetic": "FARM",
-      "syllables": "farm",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "fish",
-      "definition": "An animal that lives in water",
-      "example": "The fish swam in the bowl.",
-      "phonetic": "FISH",
-      "syllables": "fish",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "flower",
-      "definition": "The colorful part of a plant",
-      "example": "He picked a yellow flower.",
-      "phonetic": "FLOW-er",
-      "syllables": "flow-er",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "food",
-      "definition": "What people and animals eat",
-      "example": "We need food to live.",
-      "phonetic": "FOOD",
-      "syllables": "food",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "frog",
-      "definition": "A small green animal that hops",
-      "example": "The frog jumped into the water.",
-      "phonetic": "FROG",
-      "syllables": "frog",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "game",
-      "definition": "An activity played for fun",
-      "example": "Let's play a board game.",
-      "phonetic": "GAME",
-      "syllables": "game",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "girl",
-      "definition": "A female child",
-      "example": "The girl skipped down the street.",
-      "phonetic": "GIRL",
-      "syllables": "girl",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "goat",
-      "definition": "A farm animal with horns",
-      "example": "The goat climbed the rock.",
-      "phonetic": "GOAT",
-      "syllables": "goat",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "grass",
-      "definition": "Green plants covering the ground",
-      "example": "The grass is wet with dew.",
-      "phonetic": "GRASS",
-      "syllables": "grass",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "hand",
-      "definition": "Body part at the end of the arm",
-      "example": "Raise your hand if you know the answer.",
-      "phonetic": "HAND",
-      "syllables": "hand",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "hat",
-      "definition": "A covering for the head",
-      "example": "He wore a hat to block the sun.",
-      "phonetic": "HAT",
-      "syllables": "hat",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "hill",
-      "definition": "A raised area of land",
-      "example": "We rolled down the grassy hill.",
-      "phonetic": "HILL",
-      "syllables": "hill",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "horse",
-      "definition": "A large animal used for riding",
-      "example": "She loves to ride her horse.",
-      "phonetic": "HORSE",
-      "syllables": "horse",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "house",
-      "definition": "A building where people live",
-      "example": "Our house has a red door.",
-      "phonetic": "HOUSE",
-      "syllables": "house",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "ice",
-      "definition": "Frozen water",
-      "example": "Put some ice in my drink.",
-      "phonetic": "ICE",
-      "syllables": "ice",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "juice",
-      "definition": "Liquid from fruit or vegetables",
-      "example": "I drank orange juice with toast.",
-      "phonetic": "JUICE",
-      "syllables": "juice",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lamp",
-      "definition": "A device that gives light",
-      "example": "Turn on the lamp so we can see.",
-      "phonetic": "LAMP",
-      "syllables": "lamp",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "leaf",
-      "definition": "The green part of a plant",
-      "example": "A brown leaf fell from the tree.",
-      "phonetic": "LEAF",
-      "syllables": "leaf",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lion",
-      "definition": "A large wild cat",
-      "example": "The lion roared loudly.",
-      "phonetic": "LI-on",
-      "syllables": "li-on",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "milk",
-      "definition": "White liquid from cows",
-      "example": "Milk is good for your bones.",
-      "phonetic": "MILK",
-      "syllables": "milk",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "moon",
-      "definition": "Object that orbits the Earth",
-      "example": "The full moon shines at night.",
-      "phonetic": "MOON",
-      "syllables": "moon",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "mouse",
-      "definition": "A small rodent",
-      "example": "The mouse ran into a hole.",
-      "phonetic": "MOUSE",
-      "syllables": "mouse",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "nest",
-      "definition": "A home built by a bird",
-      "example": "There are three eggs in the nest.",
-      "phonetic": "NEST",
-      "syllables": "nest",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "nose",
-      "definition": "Body part used for smelling",
-      "example": "My nose is cold.",
-      "phonetic": "NOSE",
-      "syllables": "nose",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "park",
-      "definition": "Public land for recreation",
-      "example": "We played soccer at the park.",
-      "phonetic": "PARK",
-      "syllables": "park",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "pig",
-      "definition": "A farm animal with a pink snout",
-      "example": "The pig played in the mud.",
-      "phonetic": "PIG",
-      "syllables": "pig",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "rain",
-      "definition": "Water falling from clouds",
-      "example": "Take an umbrella in the rain.",
-      "phonetic": "RAIN",
-      "syllables": "rain",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "ring",
-      "definition": "A circular band worn on a finger",
-      "example": "She lost her gold ring.",
-      "phonetic": "RING",
-      "syllables": "ring",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "road",
-      "definition": "A hard surface for vehicles",
-      "example": "Look both ways before crossing the road.",
-      "phonetic": "ROAD",
-      "syllables": "road",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "room",
-      "definition": "A space inside a building",
-      "example": "My room is very messy.",
-      "phonetic": "ROOM",
-      "syllables": "room",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "shoe",
-      "definition": "Footwear",
-      "example": "Tie your shoe lace.",
-      "phonetic": "SHOE",
-      "syllables": "shoe",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "snow",
-      "definition": "Frozen white rain",
-      "example": "The snow covered the ground.",
-      "phonetic": "SNOW",
-      "syllables": "snow",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "star",
-      "definition": "A bright point in the night sky",
-      "example": "Make a wish on a falling star.",
-      "phonetic": "STAR",
-      "syllables": "star",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "sun",
-      "definition": "The star that warms the Earth",
-      "example": "The sun rises in the east.",
-      "phonetic": "SUN",
-      "syllables": "sun",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "acorn",
-      "definition": "The nut of an oak tree",
-      "example": "A squirrel carried the acorn up the tree.",
-      "phonetic": "A-corn",
-      "syllables": "a-corn",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "bubble",
-      "definition": "A thin sphere of liquid filled with air",
-      "example": "The bubble floated and popped.",
-      "phonetic": "BUB-ble",
-      "syllables": "bub-ble",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cabin",
-      "definition": "A small simple house, often in the woods",
-      "example": "They stayed in a cozy cabin by the lake.",
-      "phonetic": "CAB-in",
-      "syllables": "cab-in",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lantern",
-      "definition": "A portable light with a protective cover",
-      "example": "We carried a lantern on the evening walk.",
-      "phonetic": "LAN-tern",
-      "syllables": "lan-tern",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "igloo",
-      "definition": "A dome-shaped shelter made of snow blocks",
-      "example": "The picture book showed an igloo in winter.",
-      "phonetic": "IG-loo",
-      "syllables": "ig-loo",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "glove",
-      "definition": "A hand covering with finger sections",
-      "example": "She wore one warm glove on each hand.",
-      "phonetic": "GLOVE",
-      "syllables": "glove",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "meadow",
-      "definition": "A grassy field",
-      "example": "Wildflowers bloomed in the meadow.",
-      "phonetic": "MEAD-ow",
-      "syllables": "mead-ow",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "pebble",
-      "definition": "A small smooth stone",
-      "example": "He skipped a pebble across the pond.",
-      "phonetic": "PEB-ble",
-      "syllables": "peb-ble",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "thunder",
-      "definition": "The loud sound during a storm",
-      "example": "Thunder rumbled in the distance.",
-      "phonetic": "THUN-der",
-      "syllables": "thun-der",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "basket",
-      "definition": "A container woven from strips",
-      "example": "She carried apples in a basket.",
-      "phonetic": "BAS-ket",
-      "syllables": "bas-ket",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "blanket",
-      "definition": "A warm cover for a bed",
-      "example": "I pulled the blanket up to my chin.",
-      "phonetic": "BLAN-ket",
-      "syllables": "blan-ket",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "branch",
-      "definition": "A part of a tree that grows from the trunk",
-      "example": "A bird landed on the branch.",
-      "phonetic": "BRANCH",
-      "syllables": "branch",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cactus",
-      "definition": "A desert plant with spines",
-      "example": "The cactus needs very little water.",
-      "phonetic": "CAC-tus",
-      "syllables": "cac-tus",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "dragon",
-      "definition": "A large mythical creature",
-      "example": "The storybook dragon guarded a cave.",
-      "phonetic": "DRAG-on",
-      "syllables": "drag-on",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "frozen",
-      "definition": "Turned into ice by cold",
-      "example": "The pond was frozen this morning.",
-      "phonetic": "FRO-zen",
-      "syllables": "fro-zen",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "gardenia",
-      "definition": "A fragrant white flower",
-      "example": "A gardenia bloomed near the porch.",
-      "phonetic": "GAR-de-ni-a",
-      "syllables": "gar-de-ni-a",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "helmet",
-      "definition": "A hard hat for protection",
-      "example": "Wear your helmet when riding a bike.",
-      "phonetic": "HEL-met",
-      "syllables": "hel-met",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "kittenish",
-      "definition": "Playful like a kitten",
-      "example": "The puppy made kittenish jumps around us.",
-      "phonetic": "KIT-ten-ish",
-      "syllables": "kit-ten-ish",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lantern",
-      "definition": "A lamp with a protective case",
-      "example": "We carried a lantern on the trail.",
-      "phonetic": "LAN-tern",
-      "syllables": "lan-tern",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "magnet",
-      "definition": "An object that attracts iron",
-      "example": "The magnet pulled the paper clips close.",
-      "phonetic": "MAG-net",
-      "syllables": "mag-net",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "napkin",
-      "definition": "A cloth or paper used at meals",
-      "example": "Put the napkin on your lap.",
-      "phonetic": "NAP-kin",
-      "syllables": "nap-kin",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "planet",
-      "definition": "A large body orbiting a star",
-      "example": "Earth is the planet we live on.",
-      "phonetic": "PLAN-et",
-      "syllables": "plan-et",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "rocket",
-      "definition": "A vehicle that can travel into space",
-      "example": "The toy rocket zoomed across the room.",
-      "phonetic": "ROCK-et",
-      "syllables": "rock-et",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "splash",
-      "definition": "The sound or act of water striking",
-      "example": "The duck made a big splash.",
-      "phonetic": "SPLASH",
-      "syllables": "splash",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "thunder",
-      "definition": "The loud sound after lightning",
-      "example": "Thunder shook the windows last night.",
-      "phonetic": "THUN-der",
-      "syllables": "thun-der",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "trumpet",
-      "definition": "A brass musical instrument",
-      "example": "He practiced trumpet in band class.",
-      "phonetic": "TRUM-pet",
-      "syllables": "trum-pet",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "window",
-      "definition": "An opening in a wall with glass",
-      "example": "Rain tapped on the window.",
-      "phonetic": "WIN-dow",
-      "syllables": "win-dow",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "yellowish",
-      "definition": "Slightly yellow in color",
-      "example": "The old paper looked yellowish.",
-      "phonetic": "YEL-low-ish",
-      "syllables": "yel-low-ish",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "zigzag",
-      "definition": "A pattern with sharp turns",
-      "example": "The path made a zigzag up the hill.",
-      "phonetic": "ZIG-zag",
-      "syllables": "zig-zag",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "adventure",
-      "definition": "An exciting experience",
-      "example": "Our camping trip was a big adventure.",
-      "phonetic": "AD-ven-ture",
-      "syllables": "ad-ven-ture",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "butterfly",
-      "definition": "An insect with colorful wings",
-      "example": "A butterfly landed on the flower.",
-      "phonetic": "BUT-ter-fly",
-      "syllables": "but-ter-fly",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "chocolate",
-      "definition": "A sweet food made from cocoa",
-      "example": "She shared a piece of chocolate.",
-      "phonetic": "CHOC-o-late",
-      "syllables": "choc-o-late",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "dinosaur",
-      "definition": "A prehistoric reptile",
-      "example": "The dinosaur exhibit was my favorite.",
-      "phonetic": "DI-no-saur",
-      "syllables": "di-no-saur",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "elephant",
-      "definition": "A very large animal with a trunk",
-      "example": "The elephant sprayed water on itself.",
-      "phonetic": "EL-e-phant",
-      "syllables": "el-e-phant",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "fireworks",
-      "definition": "Exploding lights in the sky",
-      "example": "We watched fireworks on the holiday.",
-      "phonetic": "FIRE-works",
-      "syllables": "fire-works",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "giraffe",
-      "definition": "A tall animal with a long neck",
-      "example": "The giraffe reached the highest leaves.",
-      "phonetic": "GI-raffe",
-      "syllables": "gi-raffe",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "hamburger",
-      "definition": "A sandwich with a cooked patty",
-      "example": "He ordered a hamburger for lunch.",
-      "phonetic": "HAM-bur-ger",
-      "syllables": "ham-bur-ger",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "important",
-      "definition": "Having great value or meaning",
-      "example": "It is important to be kind to others.",
-      "phonetic": "IM-por-tant",
-      "syllables": "im-por-tant",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "jellyfish",
-      "definition": "A sea animal with soft body",
-      "example": "A jellyfish drifted near the shore.",
-      "phonetic": "JEL-ly-fish",
-      "syllables": "jel-ly-fish",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "kangaroo",
-      "definition": "A hopping animal from Australia",
-      "example": "The kangaroo carried a joey in its pouch.",
-      "phonetic": "KAN-ga-roo",
-      "syllables": "kan-ga-roo",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lighthouse",
-      "definition": "A tower with a bright warning light",
-      "example": "The lighthouse guided ships at night.",
-      "phonetic": "LIGHT-house",
-      "syllables": "light-house",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    }
-  ]
-}
+[
+  {
+    "word": "apple",
+    "definition": "A round fruit with red or green skin",
+    "sentence": "She picked a fresh apple from the tree.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "ap-ple",
+    "phonetic": "AP-ple"
+  },
+  {
+    "word": "book",
+    "definition": "A written work bound together",
+    "sentence": "I read a great book last week.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "book",
+    "phonetic": "BOOK"
+  },
+  {
+    "word": "cat",
+    "definition": "A small domesticated feline",
+    "sentence": "The cat slept on the warm windowsill.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "cat",
+    "phonetic": "CAT"
+  },
+  {
+    "word": "door",
+    "definition": "A hinged barrier at an entrance",
+    "sentence": "Please close the door behind you.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "door",
+    "phonetic": "DOOR"
+  },
+  {
+    "word": "friend",
+    "definition": "A person you know and like",
+    "sentence": "My best friend lives next door.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "friend",
+    "phonetic": "FRIEND"
+  },
+  {
+    "word": "garden",
+    "definition": "A piece of ground for growing plants",
+    "sentence": "We planted tomatoes in the garden.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "gar-den",
+    "phonetic": "GAR-den"
+  },
+  {
+    "word": "happy",
+    "definition": "Feeling pleasure or contentment",
+    "sentence": "The children were happy to see snow.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "hap-py",
+    "phonetic": "HAP-py"
+  },
+  {
+    "word": "kite",
+    "definition": "A toy flown in the wind",
+    "sentence": "The kite soared high above the park.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "kite",
+    "phonetic": "KITE"
+  },
+  {
+    "word": "lemon",
+    "definition": "A yellow citrus fruit",
+    "sentence": "She squeezed lemon into her tea.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "lem-on",
+    "phonetic": "LEM-on"
+  },
+  {
+    "word": "monkey",
+    "definition": "A primate with a long tail",
+    "sentence": "The monkey swung from branch to branch.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "mon-key",
+    "phonetic": "MON-key"
+  },
+  {
+    "word": "pencil",
+    "definition": "A writing instrument",
+    "sentence": "Write your name with a pencil.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "pen-cil",
+    "phonetic": "PEN-cil"
+  },
+  {
+    "word": "queen",
+    "definition": "A female monarch",
+    "sentence": "The queen wore a golden crown.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "queen",
+    "phonetic": "QUEEN"
+  },
+  {
+    "word": "ant",
+    "definition": "A small insect that lives in colonies",
+    "sentence": "The ant carried a crumb to its hill.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "ant",
+    "phonetic": "ANT"
+  },
+  {
+    "word": "baby",
+    "definition": "A very young child",
+    "sentence": "The baby is sleeping in the crib.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "ba-by",
+    "phonetic": "BA-by"
+  },
+  {
+    "word": "bear",
+    "definition": "A large mammal with fur",
+    "sentence": "The bear loves to eat honey.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "bear",
+    "phonetic": "BEAR"
+  },
+  {
+    "word": "bird",
+    "definition": "An animal with feathers and wings",
+    "sentence": "A blue bird sang in the tree.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "bird",
+    "phonetic": "BIRD"
+  },
+  {
+    "word": "boat",
+    "definition": "A vehicle for traveling on water",
+    "sentence": "We rowed the boat across the lake.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "boat",
+    "phonetic": "BOAT"
+  },
+  {
+    "word": "bread",
+    "definition": "Food made from flour and baked",
+    "sentence": "I like bread with butter.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "bread",
+    "phonetic": "BREAD"
+  },
+  {
+    "word": "bus",
+    "definition": "A large vehicle for carrying passengers",
+    "sentence": "The school bus arrives at 8 AM.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "bus",
+    "phonetic": "BUS"
+  },
+  {
+    "word": "cake",
+    "definition": "A sweet baked dessert",
+    "sentence": "We ate chocolate cake for his birthday.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "cake",
+    "phonetic": "CAKE"
+  },
+  {
+    "word": "car",
+    "definition": "A vehicle with four wheels",
+    "sentence": "My dad drives a red car.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "car",
+    "phonetic": "CAR"
+  },
+  {
+    "word": "chair",
+    "definition": "A seat with a back",
+    "sentence": "Please sit on the chair.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "chair",
+    "phonetic": "CHAIR"
+  },
+  {
+    "word": "chicken",
+    "definition": "A bird raised for food",
+    "sentence": "The chicken laid an egg.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "chick-en",
+    "phonetic": "CHICK-en"
+  },
+  {
+    "word": "clock",
+    "definition": "A device that tells time",
+    "sentence": "The clock struck twelve.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "clock",
+    "phonetic": "CLOCK"
+  },
+  {
+    "word": "coat",
+    "definition": "Outer clothing worn for warmth",
+    "sentence": "Wear your coat, it's cold outside.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "coat",
+    "phonetic": "COAT"
+  },
+  {
+    "word": "cow",
+    "definition": "A large farm animal that gives milk",
+    "sentence": "The cow is eating grass.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "cow",
+    "phonetic": "COW"
+  },
+  {
+    "word": "cup",
+    "definition": "A small bowl for drinking",
+    "sentence": "I would like a cup of water.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "cup",
+    "phonetic": "CUP"
+  },
+  {
+    "word": "desk",
+    "definition": "A table for writing or working",
+    "sentence": "She sat at her desk to study.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "desk",
+    "phonetic": "DESK"
+  },
+  {
+    "word": "dog",
+    "definition": "A common pet animal",
+    "sentence": "The dog wagged its tail.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "dog",
+    "phonetic": "DOG"
+  },
+  {
+    "word": "doll",
+    "definition": "A toy that looks like a person",
+    "sentence": "She played with her favorite doll.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "doll",
+    "phonetic": "DOLL"
+  },
+  {
+    "word": "duck",
+    "definition": "A water bird with webbed feet",
+    "sentence": "The duck swam in the pond.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "duck",
+    "phonetic": "DUCK"
+  },
+  {
+    "word": "egg",
+    "definition": "An oval object laid by birds",
+    "sentence": "He ate a boiled egg for breakfast.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "egg",
+    "phonetic": "EGG"
+  },
+  {
+    "word": "eye",
+    "definition": "The organ of sight",
+    "sentence": "She closed one eye to aim.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "eye",
+    "phonetic": "EYE"
+  },
+  {
+    "word": "farm",
+    "definition": "Land used for growing crops",
+    "sentence": "Animals live on the farm.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "farm",
+    "phonetic": "FARM"
+  },
+  {
+    "word": "fish",
+    "definition": "An animal that lives in water",
+    "sentence": "The fish swam in the bowl.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "fish",
+    "phonetic": "FISH"
+  },
+  {
+    "word": "flower",
+    "definition": "The colorful part of a plant",
+    "sentence": "He picked a yellow flower.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "flow-er",
+    "phonetic": "FLOW-er"
+  },
+  {
+    "word": "food",
+    "definition": "What people and animals eat",
+    "sentence": "We need food to live.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "food",
+    "phonetic": "FOOD"
+  },
+  {
+    "word": "frog",
+    "definition": "A small green animal that hops",
+    "sentence": "The frog jumped into the water.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "frog",
+    "phonetic": "FROG"
+  },
+  {
+    "word": "game",
+    "definition": "An activity played for fun",
+    "sentence": "Let's play a board game.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "game",
+    "phonetic": "GAME"
+  },
+  {
+    "word": "girl",
+    "definition": "A female child",
+    "sentence": "The girl skipped down the street.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "girl",
+    "phonetic": "GIRL"
+  },
+  {
+    "word": "goat",
+    "definition": "A farm animal with horns",
+    "sentence": "The goat climbed the rock.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "goat",
+    "phonetic": "GOAT"
+  },
+  {
+    "word": "grass",
+    "definition": "Green plants covering the ground",
+    "sentence": "The grass is wet with dew.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "grass",
+    "phonetic": "GRASS"
+  },
+  {
+    "word": "hand",
+    "definition": "Body part at the end of the arm",
+    "sentence": "Raise your hand if you know the answer.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "hand",
+    "phonetic": "HAND"
+  },
+  {
+    "word": "hat",
+    "definition": "A covering for the head",
+    "sentence": "He wore a hat to block the sun.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "hat",
+    "phonetic": "HAT"
+  },
+  {
+    "word": "hill",
+    "definition": "A raised area of land",
+    "sentence": "We rolled down the grassy hill.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "hill",
+    "phonetic": "HILL"
+  },
+  {
+    "word": "horse",
+    "definition": "A large animal used for riding",
+    "sentence": "She loves to ride her horse.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "horse",
+    "phonetic": "HORSE"
+  },
+  {
+    "word": "house",
+    "definition": "A building where people live",
+    "sentence": "Our house has a red door.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "house",
+    "phonetic": "HOUSE"
+  },
+  {
+    "word": "ice",
+    "definition": "Frozen water",
+    "sentence": "Put some ice in my drink.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "ice",
+    "phonetic": "ICE"
+  },
+  {
+    "word": "juice",
+    "definition": "Liquid from fruit or vegetables",
+    "sentence": "I drank orange juice with toast.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "juice",
+    "phonetic": "JUICE"
+  },
+  {
+    "word": "lamp",
+    "definition": "A device that gives light",
+    "sentence": "Turn on the lamp so we can see.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "lamp",
+    "phonetic": "LAMP"
+  },
+  {
+    "word": "leaf",
+    "definition": "The green part of a plant",
+    "sentence": "A brown leaf fell from the tree.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "leaf",
+    "phonetic": "LEAF"
+  },
+  {
+    "word": "lion",
+    "definition": "A large wild cat",
+    "sentence": "The lion roared loudly.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "li-on",
+    "phonetic": "LI-on"
+  },
+  {
+    "word": "milk",
+    "definition": "White liquid from cows",
+    "sentence": "Milk is good for your bones.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "milk",
+    "phonetic": "MILK"
+  },
+  {
+    "word": "moon",
+    "definition": "Object that orbits the Earth",
+    "sentence": "The full moon shines at night.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "moon",
+    "phonetic": "MOON"
+  },
+  {
+    "word": "mouse",
+    "definition": "A small rodent",
+    "sentence": "The mouse ran into a hole.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "mouse",
+    "phonetic": "MOUSE"
+  },
+  {
+    "word": "nest",
+    "definition": "A home built by a bird",
+    "sentence": "There are three eggs in the nest.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "nest",
+    "phonetic": "NEST"
+  },
+  {
+    "word": "nose",
+    "definition": "Body part used for smelling",
+    "sentence": "My nose is cold.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "nose",
+    "phonetic": "NOSE"
+  },
+  {
+    "word": "park",
+    "definition": "Public land for recreation",
+    "sentence": "We played soccer at the park.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "park",
+    "phonetic": "PARK"
+  },
+  {
+    "word": "pig",
+    "definition": "A farm animal with a pink snout",
+    "sentence": "The pig played in the mud.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "pig",
+    "phonetic": "PIG"
+  },
+  {
+    "word": "rain",
+    "definition": "Water falling from clouds",
+    "sentence": "Take an umbrella in the rain.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "rain",
+    "phonetic": "RAIN"
+  },
+  {
+    "word": "ring",
+    "definition": "A circular band worn on a finger",
+    "sentence": "She lost her gold ring.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "ring",
+    "phonetic": "RING"
+  },
+  {
+    "word": "road",
+    "definition": "A hard surface for vehicles",
+    "sentence": "Look both ways before crossing the road.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "road",
+    "phonetic": "ROAD"
+  },
+  {
+    "word": "room",
+    "definition": "A space inside a building",
+    "sentence": "My room is very messy.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "room",
+    "phonetic": "ROOM"
+  },
+  {
+    "word": "shoe",
+    "definition": "Footwear",
+    "sentence": "Tie your shoe lace.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "shoe",
+    "phonetic": "SHOE"
+  },
+  {
+    "word": "snow",
+    "definition": "Frozen white rain",
+    "sentence": "The snow covered the ground.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "snow",
+    "phonetic": "SNOW"
+  },
+  {
+    "word": "star",
+    "definition": "A bright point in the night sky",
+    "sentence": "Make a wish on a falling star.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "star",
+    "phonetic": "STAR"
+  },
+  {
+    "word": "sun",
+    "definition": "The star that warms the Earth",
+    "sentence": "The sun rises in the east.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "sun",
+    "phonetic": "SUN"
+  },
+  {
+    "word": "acorn",
+    "definition": "The nut of an oak tree",
+    "sentence": "A squirrel carried the acorn up the tree.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "a-corn",
+    "phonetic": "A-corn"
+  },
+  {
+    "word": "bubble",
+    "definition": "A thin sphere of liquid filled with air",
+    "sentence": "The bubble floated and popped.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "bub-ble",
+    "phonetic": "BUB-ble"
+  },
+  {
+    "word": "cabin",
+    "definition": "A small simple house, often in the woods",
+    "sentence": "They stayed in a cozy cabin by the lake.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "cab-in",
+    "phonetic": "CAB-in"
+  },
+  {
+    "word": "lantern",
+    "definition": "A portable light with a protective cover",
+    "sentence": "We carried a lantern on the evening walk.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "lan-tern",
+    "phonetic": "LAN-tern"
+  },
+  {
+    "word": "igloo",
+    "definition": "A dome-shaped shelter made of snow blocks",
+    "sentence": "The picture book showed an igloo in winter.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "ig-loo",
+    "phonetic": "IG-loo"
+  },
+  {
+    "word": "glove",
+    "definition": "A hand covering with finger sections",
+    "sentence": "She wore one warm glove on each hand.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "glove",
+    "phonetic": "GLOVE"
+  },
+  {
+    "word": "meadow",
+    "definition": "A grassy field",
+    "sentence": "Wildflowers bloomed in the meadow.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "mead-ow",
+    "phonetic": "MEAD-ow"
+  },
+  {
+    "word": "pebble",
+    "definition": "A small smooth stone",
+    "sentence": "He skipped a pebble across the pond.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "peb-ble",
+    "phonetic": "PEB-ble"
+  },
+  {
+    "word": "thunder",
+    "definition": "The loud sound during a storm",
+    "sentence": "Thunder rumbled in the distance.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "thun-der",
+    "phonetic": "THUN-der"
+  },
+  {
+    "word": "basket",
+    "definition": "A container woven from strips",
+    "sentence": "She carried apples in a basket.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "bas-ket",
+    "phonetic": "BAS-ket"
+  },
+  {
+    "word": "blanket",
+    "definition": "A warm cover for a bed",
+    "sentence": "I pulled the blanket up to my chin.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "blan-ket",
+    "phonetic": "BLAN-ket"
+  },
+  {
+    "word": "branch",
+    "definition": "A part of a tree that grows from the trunk",
+    "sentence": "A bird landed on the branch.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "branch",
+    "phonetic": "BRANCH"
+  },
+  {
+    "word": "cactus",
+    "definition": "A desert plant with spines",
+    "sentence": "The cactus needs very little water.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "cac-tus",
+    "phonetic": "CAC-tus"
+  },
+  {
+    "word": "dragon",
+    "definition": "A large mythical creature",
+    "sentence": "The storybook dragon guarded a cave.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "drag-on",
+    "phonetic": "DRAG-on"
+  },
+  {
+    "word": "frozen",
+    "definition": "Turned into ice by cold",
+    "sentence": "The pond was frozen this morning.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "fro-zen",
+    "phonetic": "FRO-zen"
+  },
+  {
+    "word": "gardenia",
+    "definition": "A fragrant white flower",
+    "sentence": "A gardenia bloomed near the porch.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "gar-de-ni-a",
+    "phonetic": "GAR-de-ni-a"
+  },
+  {
+    "word": "helmet",
+    "definition": "A hard hat for protection",
+    "sentence": "Wear your helmet when riding a bike.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "hel-met",
+    "phonetic": "HEL-met"
+  },
+  {
+    "word": "kittenish",
+    "definition": "Playful like a kitten",
+    "sentence": "The puppy made kittenish jumps around us.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "kit-ten-ish",
+    "phonetic": "KIT-ten-ish"
+  },
+  {
+    "word": "magnet",
+    "definition": "An object that attracts iron",
+    "sentence": "The magnet pulled the paper clips close.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "mag-net",
+    "phonetic": "MAG-net"
+  },
+  {
+    "word": "napkin",
+    "definition": "A cloth or paper used at meals",
+    "sentence": "Put the napkin on your lap.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "nap-kin",
+    "phonetic": "NAP-kin"
+  },
+  {
+    "word": "planet",
+    "definition": "A large body orbiting a star",
+    "sentence": "Earth is the planet we live on.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "plan-et",
+    "phonetic": "PLAN-et"
+  },
+  {
+    "word": "rocket",
+    "definition": "A vehicle that can travel into space",
+    "sentence": "The toy rocket zoomed across the room.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "rock-et",
+    "phonetic": "ROCK-et"
+  },
+  {
+    "word": "splash",
+    "definition": "The sound or act of water striking",
+    "sentence": "The duck made a big splash.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "splash",
+    "phonetic": "SPLASH"
+  },
+  {
+    "word": "trumpet",
+    "definition": "A brass musical instrument",
+    "sentence": "He practiced trumpet in band class.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "trum-pet",
+    "phonetic": "TRUM-pet"
+  },
+  {
+    "word": "window",
+    "definition": "An opening in a wall with glass",
+    "sentence": "Rain tapped on the window.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "win-dow",
+    "phonetic": "WIN-dow"
+  },
+  {
+    "word": "yellowish",
+    "definition": "Slightly yellow in color",
+    "sentence": "The old paper looked yellowish.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "yel-low-ish",
+    "phonetic": "YEL-low-ish"
+  },
+  {
+    "word": "zigzag",
+    "definition": "A pattern with sharp turns",
+    "sentence": "The path made a zigzag up the hill.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "zig-zag",
+    "phonetic": "ZIG-zag"
+  },
+  {
+    "word": "adventure",
+    "definition": "An exciting experience",
+    "sentence": "Our camping trip was a big adventure.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "ad-ven-ture",
+    "phonetic": "AD-ven-ture"
+  },
+  {
+    "word": "butterfly",
+    "definition": "An insect with colorful wings",
+    "sentence": "A butterfly landed on the flower.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "but-ter-fly",
+    "phonetic": "BUT-ter-fly"
+  },
+  {
+    "word": "chocolate",
+    "definition": "A sweet food made from cocoa",
+    "sentence": "She shared a piece of chocolate.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "choc-o-late",
+    "phonetic": "CHOC-o-late"
+  },
+  {
+    "word": "dinosaur",
+    "definition": "A prehistoric reptile",
+    "sentence": "The dinosaur exhibit was my favorite.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "di-no-saur",
+    "phonetic": "DI-no-saur"
+  },
+  {
+    "word": "elephant",
+    "definition": "A very large animal with a trunk",
+    "sentence": "The elephant sprayed water on itself.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "el-e-phant",
+    "phonetic": "EL-e-phant"
+  },
+  {
+    "word": "fireworks",
+    "definition": "Exploding lights in the sky",
+    "sentence": "We watched fireworks on the holiday.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "fire-works",
+    "phonetic": "FIRE-works"
+  },
+  {
+    "word": "giraffe",
+    "definition": "A tall animal with a long neck",
+    "sentence": "The giraffe reached the highest leaves.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "gi-raffe",
+    "phonetic": "GI-raffe"
+  },
+  {
+    "word": "hamburger",
+    "definition": "A sandwich with a cooked patty",
+    "sentence": "He ordered a hamburger for lunch.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "ham-bur-ger",
+    "phonetic": "HAM-bur-ger"
+  },
+  {
+    "word": "important",
+    "definition": "Having great value or meaning",
+    "sentence": "It is important to be kind to others.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "im-por-tant",
+    "phonetic": "IM-por-tant"
+  },
+  {
+    "word": "jellyfish",
+    "definition": "A sea animal with soft body",
+    "sentence": "A jellyfish drifted near the shore.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "jel-ly-fish",
+    "phonetic": "JEL-ly-fish"
+  },
+  {
+    "word": "kangaroo",
+    "definition": "A hopping animal from Australia",
+    "sentence": "The kangaroo carried a joey in its pouch.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "kan-ga-roo",
+    "phonetic": "KAN-ga-roo"
+  },
+  {
+    "word": "lighthouse",
+    "definition": "A tower with a bright warning light",
+    "sentence": "The lighthouse guided ships at night.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "light-house",
+    "phonetic": "LIGHT-house"
+  }
+]

--- a/public/data/words/grade-10.json
+++ b/public/data/words/grade-10.json
@@ -1,459 +1,452 @@
-{
-  "grade": 10,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 50,
-  "words": [
-    {
-      "word": "accommodate",
-      "definition": "To provide lodging or adjust to",
-      "example": "The hotel can accommodate 200 guests.",
-      "phonetic": "AC-com-mo-date",
-      "syllables": "ac-com-mo-date",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bureaucracy",
-      "definition": "Administrative government system",
-      "example": "The bureaucracy slowed the process.",
-      "phonetic": "BU-reau-cra-cy",
-      "syllables": "bu-reau-cra-cy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conscientious",
-      "definition": "Thorough and careful",
-      "example": "She is a conscientious worker.",
-      "phonetic": "CON-sci-en-tious",
-      "syllables": "con-sci-en-tious",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "entrepreneur",
-      "definition": "A business founder",
-      "example": "The entrepreneur started three companies.",
-      "phonetic": "EN-tre-pre-neur",
-      "syllables": "en-tre-pre-neur",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "fluorescent",
-      "definition": "Emitting bright light",
-      "example": "The fluorescent lights buzzed overhead.",
-      "phonetic": "FLU-o-res-cent",
-      "syllables": "flu-o-res-cent",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "guarantee",
-      "definition": "A formal promise",
-      "example": "The product comes with a guarantee.",
-      "phonetic": "GUAR-an-tee",
-      "syllables": "guar-an-tee",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "hemorrhage",
-      "definition": "Severe bleeding",
-      "example": "The doctor stopped the hemorrhage.",
-      "phonetic": "HEM-or-rhage",
-      "syllables": "hem-or-rhage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "inconvenience",
-      "definition": "Trouble or difficulty",
-      "example": "Sorry for any inconvenience caused.",
-      "phonetic": "IN-con-ven-ience",
-      "syllables": "in-con-ven-ience",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "jeopardize",
-      "definition": "To put at risk",
-      "example": "Don't jeopardize your future.",
-      "phonetic": "JEOP-ar-dize",
-      "syllables": "jeop-ar-dize",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "knowledgeable",
-      "definition": "Well informed",
-      "example": "The guide was very knowledgeable.",
-      "phonetic": "KNOWL-edge-a-ble",
-      "syllables": "knowl-edge-a-ble",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "liaison",
-      "definition": "A person who links groups",
-      "example": "She serves as liaison between departments.",
-      "phonetic": "LI-ai-son",
-      "syllables": "li-ai-son",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "mischievous",
-      "definition": "Playfully troublesome",
-      "example": "The mischievous child hid the keys.",
-      "phonetic": "MIS-chie-vous",
-      "syllables": "mis-chie-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "onomatopoeia",
-      "definition": "Words that imitate sounds",
-      "example": "Buzz is an example of onomatopoeia.",
-      "phonetic": "ON-o-mat-o-poe-ia",
-      "syllables": "on-o-mat-o-poe-ia",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "pharmaceutical",
-      "definition": "Related to medicinal drugs",
-      "example": "The pharmaceutical company developed a vaccine.",
-      "phonetic": "PHAR-ma-ceu-ti-cal",
-      "syllables": "phar-ma-ceu-ti-cal",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "rendezvous",
-      "definition": "A planned meeting",
-      "example": "They arranged a secret rendezvous.",
-      "phonetic": "REN-dez-vous",
-      "syllables": "ren-dez-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "surveillance",
-      "definition": "Close observation",
-      "example": "The building has surveillance cameras.",
-      "phonetic": "SUR-veil-lance",
-      "syllables": "sur-veil-lance",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "tyranny",
-      "definition": "Cruel oppressive rule",
-      "example": "The people rose against tyranny.",
-      "phonetic": "TYR-an-ny",
-      "syllables": "tyr-an-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ubiquitous",
-      "definition": "Present everywhere",
-      "example": "Smartphones are now ubiquitous.",
-      "phonetic": "U-biq-ui-tous",
-      "syllables": "u-biq-ui-tous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "vocabulary",
-      "definition": "Words known or used",
-      "example": "Reading expands your vocabulary.",
-      "phonetic": "VO-cab-u-lar-y",
-      "syllables": "vo-cab-u-lar-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "Wednesday",
-      "definition": "The fourth day of the week",
-      "example": "The meeting is on Wednesday.",
-      "phonetic": "WEDNES-day",
-      "syllables": "Wednes-day",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "achievement",
-      "definition": "Something done successfully",
-      "example": "Winning the game was a great achievement.",
-      "phonetic": "A-chieve-ment",
-      "syllables": "a-chieve-ment",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "acoustic",
-      "definition": "Related to sound or hearing",
-      "example": "He played an acoustic guitar.",
-      "phonetic": "A-cous-tic",
-      "syllables": "a-cous-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "algorithm",
-      "definition": "A set of rules for solving a problem",
-      "example": "The computer uses an algorithm to search.",
-      "phonetic": "AL-go-rithm",
-      "syllables": "al-go-rithm",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "amphibian",
-      "definition": "An animal living on land and water",
-      "example": "A frog is a type of amphibian.",
-      "phonetic": "AM-phib-i-an",
-      "syllables": "am-phib-i-an",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "analysis",
-      "definition": "Detailed examination",
-      "example": "The scientist performed an analysis of the data.",
-      "phonetic": "A-nal-y-sis",
-      "syllables": "a-nal-y-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ancient",
-      "definition": "Belonging to the very distant past",
-      "example": "They visited the ancient ruins.",
-      "phonetic": "AN-cient",
-      "syllables": "an-cient",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anniversary",
-      "definition": "Date on which an event took place",
-      "example": "They celebrated their wedding anniversary.",
-      "phonetic": "AN-ni-ver-sa-ry",
-      "syllables": "an-ni-ver-sa-ry",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anonymous",
-      "definition": "Not identified by name",
-      "example": "The donor chose to remain anonymous.",
-      "phonetic": "A-non-y-mous",
-      "syllables": "a-non-y-mous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "antique",
-      "definition": "A collectible object having a high value",
-      "example": "This chair is a valuable antique.",
-      "phonetic": "AN-tique",
-      "syllables": "an-tique",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anxiety",
-      "definition": "A feeling of worry or nervousness",
-      "example": "He felt anxiety before the test.",
-      "phonetic": "ANX-i-e-ty",
-      "syllables": "anx-i-e-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "appreciate",
-      "definition": "To recognize the full worth of",
-      "example": "I appreciate your help.",
-      "phonetic": "AP-pre-ci-ate",
-      "syllables": "ap-pre-ci-ate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "aquarium",
-      "definition": "A tank of water for fish",
-      "example": "We saw sharks at the aquarium.",
-      "phonetic": "A-quar-i-um",
-      "syllables": "a-quar-i-um",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "architecture",
-      "definition": "The art of designing buildings",
-      "example": "The city has beautiful architecture.",
-      "phonetic": "AR-chi-tec-ture",
-      "syllables": "ar-chi-tec-ture",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "arithmetic",
-      "definition": "The branch of math with numbers",
-      "example": "We learned arithmetic in school.",
-      "phonetic": "A-rith-me-tic",
-      "syllables": "a-rith-me-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "artificial",
-      "definition": "Made by humans, not natural",
-      "example": "The flowers are artificial.",
-      "phonetic": "AR-ti-fi-cial",
-      "syllables": "ar-ti-fi-cial",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "atmosphere",
-      "definition": "Gases surrounding a planet",
-      "example": "The atmosphere protects the Earth.",
-      "phonetic": "AT-mos-phere",
-      "syllables": "at-mos-phere",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "audience",
-      "definition": "Spectators at an event",
-      "example": "The audience clapped loudly.",
-      "phonetic": "AU-di-ence",
-      "syllables": "au-di-ence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "authentic",
-      "definition": "Of undisputed origin; genuine",
-      "example": "This is an authentic painting.",
-      "phonetic": "AU-then-tic",
-      "syllables": "au-then-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "biography",
-      "definition": "An account of someone's life",
-      "example": "I read a biography of Lincoln.",
-      "phonetic": "BI-og-ra-phy",
-      "syllables": "bi-og-ra-phy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bizarre",
-      "definition": "Very strange or unusual",
-      "example": "It was a bizarre situation.",
-      "phonetic": "BI-zarre",
-      "syllables": "bi-zarre",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "camouflage",
-      "definition": "Disguise to blend with surroundings",
-      "example": "The soldier wore camouflage.",
-      "phonetic": "CAM-ou-flage",
-      "syllables": "cam-ou-flage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "campaign",
-      "definition": "A series of actions for a goal",
-      "example": "The election campaign was intense.",
-      "phonetic": "CAM-paign",
-      "syllables": "cam-paign",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "capacity",
-      "definition": "The maximum amount something can hold",
-      "example": "The stadium was filled to capacity.",
-      "phonetic": "CA-pac-i-ty",
-      "syllables": "ca-pac-i-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "catastrophe",
-      "definition": "A sudden great disaster",
-      "example": "The earthquake was a catastrophe.",
-      "phonetic": "CA-tas-tro-phe",
-      "syllables": "ca-tas-tro-phe",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "cemetery",
-      "definition": "A place for burying the dead",
-      "example": "They visited the old cemetery.",
-      "phonetic": "CEM-e-ter-y",
-      "syllables": "cem-e-ter-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ceremony",
-      "definition": "A formal religious or public occasion",
-      "example": "The graduation ceremony is tomorrow.",
-      "phonetic": "CER-e-mo-ny",
-      "syllables": "cer-e-mo-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chameleon",
-      "definition": "A lizard that changes color",
-      "example": "The chameleon turned green.",
-      "phonetic": "CHA-me-le-on",
-      "syllables": "cha-me-le-on",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chandelier",
-      "definition": "A decorative hanging light",
-      "example": "A crystal chandelier hung in the hall.",
-      "phonetic": "CHAN-de-lier",
-      "syllables": "chan-de-lier",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "character",
-      "definition": "A person in a novel or movie",
-      "example": "Who is your favorite character?",
-      "phonetic": "CHAR-ac-ter",
-      "syllables": "char-ac-ter",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chemistry",
-      "definition": "Science of substances and reactions",
-      "example": "We did experiments in chemistry class.",
-      "phonetic": "CHEM-is-try",
-      "syllables": "chem-is-try",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    }
-  ]
-}
+[
+  {
+    "word": "accommodate",
+    "definition": "To provide lodging or adjust to",
+    "sentence": "The hotel can accommodate 200 guests.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ac-com-mo-date",
+    "phonetic": "AC-com-mo-date"
+  },
+  {
+    "word": "bureaucracy",
+    "definition": "Administrative government system",
+    "sentence": "The bureaucracy slowed the process.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bu-reau-cra-cy",
+    "phonetic": "BU-reau-cra-cy"
+  },
+  {
+    "word": "conscientious",
+    "definition": "Thorough and careful",
+    "sentence": "She is a conscientious worker.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-sci-en-tious",
+    "phonetic": "CON-sci-en-tious"
+  },
+  {
+    "word": "entrepreneur",
+    "definition": "A business founder",
+    "sentence": "The entrepreneur started three companies.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "en-tre-pre-neur",
+    "phonetic": "EN-tre-pre-neur"
+  },
+  {
+    "word": "fluorescent",
+    "definition": "Emitting bright light",
+    "sentence": "The fluorescent lights buzzed overhead.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "flu-o-res-cent",
+    "phonetic": "FLU-o-res-cent"
+  },
+  {
+    "word": "guarantee",
+    "definition": "A formal promise",
+    "sentence": "The product comes with a guarantee.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "guar-an-tee",
+    "phonetic": "GUAR-an-tee"
+  },
+  {
+    "word": "hemorrhage",
+    "definition": "Severe bleeding",
+    "sentence": "The doctor stopped the hemorrhage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "hem-or-rhage",
+    "phonetic": "HEM-or-rhage"
+  },
+  {
+    "word": "inconvenience",
+    "definition": "Trouble or difficulty",
+    "sentence": "Sorry for any inconvenience caused.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "in-con-ven-ience",
+    "phonetic": "IN-con-ven-ience"
+  },
+  {
+    "word": "jeopardize",
+    "definition": "To put at risk",
+    "sentence": "Don't jeopardize your future.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "jeop-ar-dize",
+    "phonetic": "JEOP-ar-dize"
+  },
+  {
+    "word": "knowledgeable",
+    "definition": "Well informed",
+    "sentence": "The guide was very knowledgeable.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "knowl-edge-a-ble",
+    "phonetic": "KNOWL-edge-a-ble"
+  },
+  {
+    "word": "liaison",
+    "definition": "A person who links groups",
+    "sentence": "She serves as liaison between departments.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "li-ai-son",
+    "phonetic": "LI-ai-son"
+  },
+  {
+    "word": "mischievous",
+    "definition": "Playfully troublesome",
+    "sentence": "The mischievous child hid the keys.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "mis-chie-vous",
+    "phonetic": "MIS-chie-vous"
+  },
+  {
+    "word": "onomatopoeia",
+    "definition": "Words that imitate sounds",
+    "sentence": "Buzz is an example of onomatopoeia.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "on-o-mat-o-poe-ia",
+    "phonetic": "ON-o-mat-o-poe-ia"
+  },
+  {
+    "word": "pharmaceutical",
+    "definition": "Related to medicinal drugs",
+    "sentence": "The pharmaceutical company developed a vaccine.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "phar-ma-ceu-ti-cal",
+    "phonetic": "PHAR-ma-ceu-ti-cal"
+  },
+  {
+    "word": "rendezvous",
+    "definition": "A planned meeting",
+    "sentence": "They arranged a secret rendezvous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ren-dez-vous",
+    "phonetic": "REN-dez-vous"
+  },
+  {
+    "word": "surveillance",
+    "definition": "Close observation",
+    "sentence": "The building has surveillance cameras.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "sur-veil-lance",
+    "phonetic": "SUR-veil-lance"
+  },
+  {
+    "word": "tyranny",
+    "definition": "Cruel oppressive rule",
+    "sentence": "The people rose against tyranny.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "tyr-an-ny",
+    "phonetic": "TYR-an-ny"
+  },
+  {
+    "word": "ubiquitous",
+    "definition": "Present everywhere",
+    "sentence": "Smartphones are now ubiquitous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "u-biq-ui-tous",
+    "phonetic": "U-biq-ui-tous"
+  },
+  {
+    "word": "vocabulary",
+    "definition": "Words known or used",
+    "sentence": "Reading expands your vocabulary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "vo-cab-u-lar-y",
+    "phonetic": "VO-cab-u-lar-y"
+  },
+  {
+    "word": "Wednesday",
+    "definition": "The fourth day of the week",
+    "sentence": "The meeting is on Wednesday.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "Wednes-day",
+    "phonetic": "WEDNES-day"
+  },
+  {
+    "word": "achievement",
+    "definition": "Something done successfully",
+    "sentence": "Winning the game was a great achievement.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-chieve-ment",
+    "phonetic": "A-chieve-ment"
+  },
+  {
+    "word": "acoustic",
+    "definition": "Related to sound or hearing",
+    "sentence": "He played an acoustic guitar.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-cous-tic",
+    "phonetic": "A-cous-tic"
+  },
+  {
+    "word": "algorithm",
+    "definition": "A set of rules for solving a problem",
+    "sentence": "The computer uses an algorithm to search.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "al-go-rithm",
+    "phonetic": "AL-go-rithm"
+  },
+  {
+    "word": "amphibian",
+    "definition": "An animal living on land and water",
+    "sentence": "A frog is a type of amphibian.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "am-phib-i-an",
+    "phonetic": "AM-phib-i-an"
+  },
+  {
+    "word": "analysis",
+    "definition": "Detailed examination",
+    "sentence": "The scientist performed an analysis of the data.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-nal-y-sis",
+    "phonetic": "A-nal-y-sis"
+  },
+  {
+    "word": "ancient",
+    "definition": "Belonging to the very distant past",
+    "sentence": "They visited the ancient ruins.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-cient",
+    "phonetic": "AN-cient"
+  },
+  {
+    "word": "anniversary",
+    "definition": "Date on which an event took place",
+    "sentence": "They celebrated their wedding anniversary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-ni-ver-sa-ry",
+    "phonetic": "AN-ni-ver-sa-ry"
+  },
+  {
+    "word": "anonymous",
+    "definition": "Not identified by name",
+    "sentence": "The donor chose to remain anonymous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-non-y-mous",
+    "phonetic": "A-non-y-mous"
+  },
+  {
+    "word": "antique",
+    "definition": "A collectible object having a high value",
+    "sentence": "This chair is a valuable antique.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-tique",
+    "phonetic": "AN-tique"
+  },
+  {
+    "word": "anxiety",
+    "definition": "A feeling of worry or nervousness",
+    "sentence": "He felt anxiety before the test.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "anx-i-e-ty",
+    "phonetic": "ANX-i-e-ty"
+  },
+  {
+    "word": "appreciate",
+    "definition": "To recognize the full worth of",
+    "sentence": "I appreciate your help.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ap-pre-ci-ate",
+    "phonetic": "AP-pre-ci-ate"
+  },
+  {
+    "word": "aquarium",
+    "definition": "A tank of water for fish",
+    "sentence": "We saw sharks at the aquarium.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-quar-i-um",
+    "phonetic": "A-quar-i-um"
+  },
+  {
+    "word": "architecture",
+    "definition": "The art of designing buildings",
+    "sentence": "The city has beautiful architecture.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-chi-tec-ture",
+    "phonetic": "AR-chi-tec-ture"
+  },
+  {
+    "word": "arithmetic",
+    "definition": "The branch of math with numbers",
+    "sentence": "We learned arithmetic in school.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-rith-me-tic",
+    "phonetic": "A-rith-me-tic"
+  },
+  {
+    "word": "artificial",
+    "definition": "Made by humans, not natural",
+    "sentence": "The flowers are artificial.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-ti-fi-cial",
+    "phonetic": "AR-ti-fi-cial"
+  },
+  {
+    "word": "atmosphere",
+    "definition": "Gases surrounding a planet",
+    "sentence": "The atmosphere protects the Earth.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "at-mos-phere",
+    "phonetic": "AT-mos-phere"
+  },
+  {
+    "word": "audience",
+    "definition": "Spectators at an event",
+    "sentence": "The audience clapped loudly.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-di-ence",
+    "phonetic": "AU-di-ence"
+  },
+  {
+    "word": "authentic",
+    "definition": "Of undisputed origin; genuine",
+    "sentence": "This is an authentic painting.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-then-tic",
+    "phonetic": "AU-then-tic"
+  },
+  {
+    "word": "biography",
+    "definition": "An account of someone's life",
+    "sentence": "I read a biography of Lincoln.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-og-ra-phy",
+    "phonetic": "BI-og-ra-phy"
+  },
+  {
+    "word": "bizarre",
+    "definition": "Very strange or unusual",
+    "sentence": "It was a bizarre situation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-zarre",
+    "phonetic": "BI-zarre"
+  },
+  {
+    "word": "camouflage",
+    "definition": "Disguise to blend with surroundings",
+    "sentence": "The soldier wore camouflage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-ou-flage",
+    "phonetic": "CAM-ou-flage"
+  },
+  {
+    "word": "campaign",
+    "definition": "A series of actions for a goal",
+    "sentence": "The election campaign was intense.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-paign",
+    "phonetic": "CAM-paign"
+  },
+  {
+    "word": "capacity",
+    "definition": "The maximum amount something can hold",
+    "sentence": "The stadium was filled to capacity.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-pac-i-ty",
+    "phonetic": "CA-pac-i-ty"
+  },
+  {
+    "word": "catastrophe",
+    "definition": "A sudden great disaster",
+    "sentence": "The earthquake was a catastrophe.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-tas-tro-phe",
+    "phonetic": "CA-tas-tro-phe"
+  },
+  {
+    "word": "cemetery",
+    "definition": "A place for burying the dead",
+    "sentence": "They visited the old cemetery.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cem-e-ter-y",
+    "phonetic": "CEM-e-ter-y"
+  },
+  {
+    "word": "ceremony",
+    "definition": "A formal religious or public occasion",
+    "sentence": "The graduation ceremony is tomorrow.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cer-e-mo-ny",
+    "phonetic": "CER-e-mo-ny"
+  },
+  {
+    "word": "chameleon",
+    "definition": "A lizard that changes color",
+    "sentence": "The chameleon turned green.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cha-me-le-on",
+    "phonetic": "CHA-me-le-on"
+  },
+  {
+    "word": "chandelier",
+    "definition": "A decorative hanging light",
+    "sentence": "A crystal chandelier hung in the hall.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chan-de-lier",
+    "phonetic": "CHAN-de-lier"
+  },
+  {
+    "word": "character",
+    "definition": "A person in a novel or movie",
+    "sentence": "Who is your favorite character?",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "char-ac-ter",
+    "phonetic": "CHAR-ac-ter"
+  },
+  {
+    "word": "chemistry",
+    "definition": "Science of substances and reactions",
+    "sentence": "We did experiments in chemistry class.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chem-is-try",
+    "phonetic": "CHEM-is-try"
+  }
+]

--- a/public/data/words/grade-11.json
+++ b/public/data/words/grade-11.json
@@ -1,459 +1,452 @@
-{
-  "grade": 11,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 50,
-  "words": [
-    {
-      "word": "accommodate",
-      "definition": "To provide lodging or adjust to",
-      "example": "The hotel can accommodate 200 guests.",
-      "phonetic": "AC-com-mo-date",
-      "syllables": "ac-com-mo-date",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bureaucracy",
-      "definition": "Administrative government system",
-      "example": "The bureaucracy slowed the process.",
-      "phonetic": "BU-reau-cra-cy",
-      "syllables": "bu-reau-cra-cy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conscientious",
-      "definition": "Thorough and careful",
-      "example": "She is a conscientious worker.",
-      "phonetic": "CON-sci-en-tious",
-      "syllables": "con-sci-en-tious",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "entrepreneur",
-      "definition": "A business founder",
-      "example": "The entrepreneur started three companies.",
-      "phonetic": "EN-tre-pre-neur",
-      "syllables": "en-tre-pre-neur",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "fluorescent",
-      "definition": "Emitting bright light",
-      "example": "The fluorescent lights buzzed overhead.",
-      "phonetic": "FLU-o-res-cent",
-      "syllables": "flu-o-res-cent",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "guarantee",
-      "definition": "A formal promise",
-      "example": "The product comes with a guarantee.",
-      "phonetic": "GUAR-an-tee",
-      "syllables": "guar-an-tee",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "hemorrhage",
-      "definition": "Severe bleeding",
-      "example": "The doctor stopped the hemorrhage.",
-      "phonetic": "HEM-or-rhage",
-      "syllables": "hem-or-rhage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "inconvenience",
-      "definition": "Trouble or difficulty",
-      "example": "Sorry for any inconvenience caused.",
-      "phonetic": "IN-con-ven-ience",
-      "syllables": "in-con-ven-ience",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "jeopardize",
-      "definition": "To put at risk",
-      "example": "Don't jeopardize your future.",
-      "phonetic": "JEOP-ar-dize",
-      "syllables": "jeop-ar-dize",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "knowledgeable",
-      "definition": "Well informed",
-      "example": "The guide was very knowledgeable.",
-      "phonetic": "KNOWL-edge-a-ble",
-      "syllables": "knowl-edge-a-ble",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "liaison",
-      "definition": "A person who links groups",
-      "example": "She serves as liaison between departments.",
-      "phonetic": "LI-ai-son",
-      "syllables": "li-ai-son",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "mischievous",
-      "definition": "Playfully troublesome",
-      "example": "The mischievous child hid the keys.",
-      "phonetic": "MIS-chie-vous",
-      "syllables": "mis-chie-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "onomatopoeia",
-      "definition": "Words that imitate sounds",
-      "example": "Buzz is an example of onomatopoeia.",
-      "phonetic": "ON-o-mat-o-poe-ia",
-      "syllables": "on-o-mat-o-poe-ia",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "pharmaceutical",
-      "definition": "Related to medicinal drugs",
-      "example": "The pharmaceutical company developed a vaccine.",
-      "phonetic": "PHAR-ma-ceu-ti-cal",
-      "syllables": "phar-ma-ceu-ti-cal",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "rendezvous",
-      "definition": "A planned meeting",
-      "example": "They arranged a secret rendezvous.",
-      "phonetic": "REN-dez-vous",
-      "syllables": "ren-dez-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "surveillance",
-      "definition": "Close observation",
-      "example": "The building has surveillance cameras.",
-      "phonetic": "SUR-veil-lance",
-      "syllables": "sur-veil-lance",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "tyranny",
-      "definition": "Cruel oppressive rule",
-      "example": "The people rose against tyranny.",
-      "phonetic": "TYR-an-ny",
-      "syllables": "tyr-an-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ubiquitous",
-      "definition": "Present everywhere",
-      "example": "Smartphones are now ubiquitous.",
-      "phonetic": "U-biq-ui-tous",
-      "syllables": "u-biq-ui-tous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "vocabulary",
-      "definition": "Words known or used",
-      "example": "Reading expands your vocabulary.",
-      "phonetic": "VO-cab-u-lar-y",
-      "syllables": "vo-cab-u-lar-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "Wednesday",
-      "definition": "The fourth day of the week",
-      "example": "The meeting is on Wednesday.",
-      "phonetic": "WEDNES-day",
-      "syllables": "Wednes-day",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "achievement",
-      "definition": "Something done successfully",
-      "example": "Winning the game was a great achievement.",
-      "phonetic": "A-chieve-ment",
-      "syllables": "a-chieve-ment",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "acoustic",
-      "definition": "Related to sound or hearing",
-      "example": "He played an acoustic guitar.",
-      "phonetic": "A-cous-tic",
-      "syllables": "a-cous-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "algorithm",
-      "definition": "A set of rules for solving a problem",
-      "example": "The computer uses an algorithm to search.",
-      "phonetic": "AL-go-rithm",
-      "syllables": "al-go-rithm",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "amphibian",
-      "definition": "An animal living on land and water",
-      "example": "A frog is a type of amphibian.",
-      "phonetic": "AM-phib-i-an",
-      "syllables": "am-phib-i-an",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "analysis",
-      "definition": "Detailed examination",
-      "example": "The scientist performed an analysis of the data.",
-      "phonetic": "A-nal-y-sis",
-      "syllables": "a-nal-y-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ancient",
-      "definition": "Belonging to the very distant past",
-      "example": "They visited the ancient ruins.",
-      "phonetic": "AN-cient",
-      "syllables": "an-cient",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anniversary",
-      "definition": "Date on which an event took place",
-      "example": "They celebrated their wedding anniversary.",
-      "phonetic": "AN-ni-ver-sa-ry",
-      "syllables": "an-ni-ver-sa-ry",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anonymous",
-      "definition": "Not identified by name",
-      "example": "The donor chose to remain anonymous.",
-      "phonetic": "A-non-y-mous",
-      "syllables": "a-non-y-mous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "antique",
-      "definition": "A collectible object having a high value",
-      "example": "This chair is a valuable antique.",
-      "phonetic": "AN-tique",
-      "syllables": "an-tique",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anxiety",
-      "definition": "A feeling of worry or nervousness",
-      "example": "He felt anxiety before the test.",
-      "phonetic": "ANX-i-e-ty",
-      "syllables": "anx-i-e-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "appreciate",
-      "definition": "To recognize the full worth of",
-      "example": "I appreciate your help.",
-      "phonetic": "AP-pre-ci-ate",
-      "syllables": "ap-pre-ci-ate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "aquarium",
-      "definition": "A tank of water for fish",
-      "example": "We saw sharks at the aquarium.",
-      "phonetic": "A-quar-i-um",
-      "syllables": "a-quar-i-um",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "architecture",
-      "definition": "The art of designing buildings",
-      "example": "The city has beautiful architecture.",
-      "phonetic": "AR-chi-tec-ture",
-      "syllables": "ar-chi-tec-ture",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "arithmetic",
-      "definition": "The branch of math with numbers",
-      "example": "We learned arithmetic in school.",
-      "phonetic": "A-rith-me-tic",
-      "syllables": "a-rith-me-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "artificial",
-      "definition": "Made by humans, not natural",
-      "example": "The flowers are artificial.",
-      "phonetic": "AR-ti-fi-cial",
-      "syllables": "ar-ti-fi-cial",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "atmosphere",
-      "definition": "Gases surrounding a planet",
-      "example": "The atmosphere protects the Earth.",
-      "phonetic": "AT-mos-phere",
-      "syllables": "at-mos-phere",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "audience",
-      "definition": "Spectators at an event",
-      "example": "The audience clapped loudly.",
-      "phonetic": "AU-di-ence",
-      "syllables": "au-di-ence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "authentic",
-      "definition": "Of undisputed origin; genuine",
-      "example": "This is an authentic painting.",
-      "phonetic": "AU-then-tic",
-      "syllables": "au-then-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "biography",
-      "definition": "An account of someone's life",
-      "example": "I read a biography of Lincoln.",
-      "phonetic": "BI-og-ra-phy",
-      "syllables": "bi-og-ra-phy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bizarre",
-      "definition": "Very strange or unusual",
-      "example": "It was a bizarre situation.",
-      "phonetic": "BI-zarre",
-      "syllables": "bi-zarre",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "camouflage",
-      "definition": "Disguise to blend with surroundings",
-      "example": "The soldier wore camouflage.",
-      "phonetic": "CAM-ou-flage",
-      "syllables": "cam-ou-flage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "campaign",
-      "definition": "A series of actions for a goal",
-      "example": "The election campaign was intense.",
-      "phonetic": "CAM-paign",
-      "syllables": "cam-paign",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "capacity",
-      "definition": "The maximum amount something can hold",
-      "example": "The stadium was filled to capacity.",
-      "phonetic": "CA-pac-i-ty",
-      "syllables": "ca-pac-i-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "catastrophe",
-      "definition": "A sudden great disaster",
-      "example": "The earthquake was a catastrophe.",
-      "phonetic": "CA-tas-tro-phe",
-      "syllables": "ca-tas-tro-phe",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "cemetery",
-      "definition": "A place for burying the dead",
-      "example": "They visited the old cemetery.",
-      "phonetic": "CEM-e-ter-y",
-      "syllables": "cem-e-ter-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ceremony",
-      "definition": "A formal religious or public occasion",
-      "example": "The graduation ceremony is tomorrow.",
-      "phonetic": "CER-e-mo-ny",
-      "syllables": "cer-e-mo-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chameleon",
-      "definition": "A lizard that changes color",
-      "example": "The chameleon turned green.",
-      "phonetic": "CHA-me-le-on",
-      "syllables": "cha-me-le-on",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chandelier",
-      "definition": "A decorative hanging light",
-      "example": "A crystal chandelier hung in the hall.",
-      "phonetic": "CHAN-de-lier",
-      "syllables": "chan-de-lier",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "character",
-      "definition": "A person in a novel or movie",
-      "example": "Who is your favorite character?",
-      "phonetic": "CHAR-ac-ter",
-      "syllables": "char-ac-ter",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chemistry",
-      "definition": "Science of substances and reactions",
-      "example": "We did experiments in chemistry class.",
-      "phonetic": "CHEM-is-try",
-      "syllables": "chem-is-try",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    }
-  ]
-}
+[
+  {
+    "word": "accommodate",
+    "definition": "To provide lodging or adjust to",
+    "sentence": "The hotel can accommodate 200 guests.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ac-com-mo-date",
+    "phonetic": "AC-com-mo-date"
+  },
+  {
+    "word": "bureaucracy",
+    "definition": "Administrative government system",
+    "sentence": "The bureaucracy slowed the process.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bu-reau-cra-cy",
+    "phonetic": "BU-reau-cra-cy"
+  },
+  {
+    "word": "conscientious",
+    "definition": "Thorough and careful",
+    "sentence": "She is a conscientious worker.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-sci-en-tious",
+    "phonetic": "CON-sci-en-tious"
+  },
+  {
+    "word": "entrepreneur",
+    "definition": "A business founder",
+    "sentence": "The entrepreneur started three companies.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "en-tre-pre-neur",
+    "phonetic": "EN-tre-pre-neur"
+  },
+  {
+    "word": "fluorescent",
+    "definition": "Emitting bright light",
+    "sentence": "The fluorescent lights buzzed overhead.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "flu-o-res-cent",
+    "phonetic": "FLU-o-res-cent"
+  },
+  {
+    "word": "guarantee",
+    "definition": "A formal promise",
+    "sentence": "The product comes with a guarantee.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "guar-an-tee",
+    "phonetic": "GUAR-an-tee"
+  },
+  {
+    "word": "hemorrhage",
+    "definition": "Severe bleeding",
+    "sentence": "The doctor stopped the hemorrhage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "hem-or-rhage",
+    "phonetic": "HEM-or-rhage"
+  },
+  {
+    "word": "inconvenience",
+    "definition": "Trouble or difficulty",
+    "sentence": "Sorry for any inconvenience caused.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "in-con-ven-ience",
+    "phonetic": "IN-con-ven-ience"
+  },
+  {
+    "word": "jeopardize",
+    "definition": "To put at risk",
+    "sentence": "Don't jeopardize your future.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "jeop-ar-dize",
+    "phonetic": "JEOP-ar-dize"
+  },
+  {
+    "word": "knowledgeable",
+    "definition": "Well informed",
+    "sentence": "The guide was very knowledgeable.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "knowl-edge-a-ble",
+    "phonetic": "KNOWL-edge-a-ble"
+  },
+  {
+    "word": "liaison",
+    "definition": "A person who links groups",
+    "sentence": "She serves as liaison between departments.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "li-ai-son",
+    "phonetic": "LI-ai-son"
+  },
+  {
+    "word": "mischievous",
+    "definition": "Playfully troublesome",
+    "sentence": "The mischievous child hid the keys.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "mis-chie-vous",
+    "phonetic": "MIS-chie-vous"
+  },
+  {
+    "word": "onomatopoeia",
+    "definition": "Words that imitate sounds",
+    "sentence": "Buzz is an example of onomatopoeia.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "on-o-mat-o-poe-ia",
+    "phonetic": "ON-o-mat-o-poe-ia"
+  },
+  {
+    "word": "pharmaceutical",
+    "definition": "Related to medicinal drugs",
+    "sentence": "The pharmaceutical company developed a vaccine.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "phar-ma-ceu-ti-cal",
+    "phonetic": "PHAR-ma-ceu-ti-cal"
+  },
+  {
+    "word": "rendezvous",
+    "definition": "A planned meeting",
+    "sentence": "They arranged a secret rendezvous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ren-dez-vous",
+    "phonetic": "REN-dez-vous"
+  },
+  {
+    "word": "surveillance",
+    "definition": "Close observation",
+    "sentence": "The building has surveillance cameras.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "sur-veil-lance",
+    "phonetic": "SUR-veil-lance"
+  },
+  {
+    "word": "tyranny",
+    "definition": "Cruel oppressive rule",
+    "sentence": "The people rose against tyranny.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "tyr-an-ny",
+    "phonetic": "TYR-an-ny"
+  },
+  {
+    "word": "ubiquitous",
+    "definition": "Present everywhere",
+    "sentence": "Smartphones are now ubiquitous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "u-biq-ui-tous",
+    "phonetic": "U-biq-ui-tous"
+  },
+  {
+    "word": "vocabulary",
+    "definition": "Words known or used",
+    "sentence": "Reading expands your vocabulary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "vo-cab-u-lar-y",
+    "phonetic": "VO-cab-u-lar-y"
+  },
+  {
+    "word": "Wednesday",
+    "definition": "The fourth day of the week",
+    "sentence": "The meeting is on Wednesday.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "Wednes-day",
+    "phonetic": "WEDNES-day"
+  },
+  {
+    "word": "achievement",
+    "definition": "Something done successfully",
+    "sentence": "Winning the game was a great achievement.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-chieve-ment",
+    "phonetic": "A-chieve-ment"
+  },
+  {
+    "word": "acoustic",
+    "definition": "Related to sound or hearing",
+    "sentence": "He played an acoustic guitar.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-cous-tic",
+    "phonetic": "A-cous-tic"
+  },
+  {
+    "word": "algorithm",
+    "definition": "A set of rules for solving a problem",
+    "sentence": "The computer uses an algorithm to search.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "al-go-rithm",
+    "phonetic": "AL-go-rithm"
+  },
+  {
+    "word": "amphibian",
+    "definition": "An animal living on land and water",
+    "sentence": "A frog is a type of amphibian.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "am-phib-i-an",
+    "phonetic": "AM-phib-i-an"
+  },
+  {
+    "word": "analysis",
+    "definition": "Detailed examination",
+    "sentence": "The scientist performed an analysis of the data.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-nal-y-sis",
+    "phonetic": "A-nal-y-sis"
+  },
+  {
+    "word": "ancient",
+    "definition": "Belonging to the very distant past",
+    "sentence": "They visited the ancient ruins.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-cient",
+    "phonetic": "AN-cient"
+  },
+  {
+    "word": "anniversary",
+    "definition": "Date on which an event took place",
+    "sentence": "They celebrated their wedding anniversary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-ni-ver-sa-ry",
+    "phonetic": "AN-ni-ver-sa-ry"
+  },
+  {
+    "word": "anonymous",
+    "definition": "Not identified by name",
+    "sentence": "The donor chose to remain anonymous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-non-y-mous",
+    "phonetic": "A-non-y-mous"
+  },
+  {
+    "word": "antique",
+    "definition": "A collectible object having a high value",
+    "sentence": "This chair is a valuable antique.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-tique",
+    "phonetic": "AN-tique"
+  },
+  {
+    "word": "anxiety",
+    "definition": "A feeling of worry or nervousness",
+    "sentence": "He felt anxiety before the test.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "anx-i-e-ty",
+    "phonetic": "ANX-i-e-ty"
+  },
+  {
+    "word": "appreciate",
+    "definition": "To recognize the full worth of",
+    "sentence": "I appreciate your help.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ap-pre-ci-ate",
+    "phonetic": "AP-pre-ci-ate"
+  },
+  {
+    "word": "aquarium",
+    "definition": "A tank of water for fish",
+    "sentence": "We saw sharks at the aquarium.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-quar-i-um",
+    "phonetic": "A-quar-i-um"
+  },
+  {
+    "word": "architecture",
+    "definition": "The art of designing buildings",
+    "sentence": "The city has beautiful architecture.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-chi-tec-ture",
+    "phonetic": "AR-chi-tec-ture"
+  },
+  {
+    "word": "arithmetic",
+    "definition": "The branch of math with numbers",
+    "sentence": "We learned arithmetic in school.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-rith-me-tic",
+    "phonetic": "A-rith-me-tic"
+  },
+  {
+    "word": "artificial",
+    "definition": "Made by humans, not natural",
+    "sentence": "The flowers are artificial.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-ti-fi-cial",
+    "phonetic": "AR-ti-fi-cial"
+  },
+  {
+    "word": "atmosphere",
+    "definition": "Gases surrounding a planet",
+    "sentence": "The atmosphere protects the Earth.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "at-mos-phere",
+    "phonetic": "AT-mos-phere"
+  },
+  {
+    "word": "audience",
+    "definition": "Spectators at an event",
+    "sentence": "The audience clapped loudly.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-di-ence",
+    "phonetic": "AU-di-ence"
+  },
+  {
+    "word": "authentic",
+    "definition": "Of undisputed origin; genuine",
+    "sentence": "This is an authentic painting.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-then-tic",
+    "phonetic": "AU-then-tic"
+  },
+  {
+    "word": "biography",
+    "definition": "An account of someone's life",
+    "sentence": "I read a biography of Lincoln.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-og-ra-phy",
+    "phonetic": "BI-og-ra-phy"
+  },
+  {
+    "word": "bizarre",
+    "definition": "Very strange or unusual",
+    "sentence": "It was a bizarre situation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-zarre",
+    "phonetic": "BI-zarre"
+  },
+  {
+    "word": "camouflage",
+    "definition": "Disguise to blend with surroundings",
+    "sentence": "The soldier wore camouflage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-ou-flage",
+    "phonetic": "CAM-ou-flage"
+  },
+  {
+    "word": "campaign",
+    "definition": "A series of actions for a goal",
+    "sentence": "The election campaign was intense.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-paign",
+    "phonetic": "CAM-paign"
+  },
+  {
+    "word": "capacity",
+    "definition": "The maximum amount something can hold",
+    "sentence": "The stadium was filled to capacity.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-pac-i-ty",
+    "phonetic": "CA-pac-i-ty"
+  },
+  {
+    "word": "catastrophe",
+    "definition": "A sudden great disaster",
+    "sentence": "The earthquake was a catastrophe.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-tas-tro-phe",
+    "phonetic": "CA-tas-tro-phe"
+  },
+  {
+    "word": "cemetery",
+    "definition": "A place for burying the dead",
+    "sentence": "They visited the old cemetery.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cem-e-ter-y",
+    "phonetic": "CEM-e-ter-y"
+  },
+  {
+    "word": "ceremony",
+    "definition": "A formal religious or public occasion",
+    "sentence": "The graduation ceremony is tomorrow.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cer-e-mo-ny",
+    "phonetic": "CER-e-mo-ny"
+  },
+  {
+    "word": "chameleon",
+    "definition": "A lizard that changes color",
+    "sentence": "The chameleon turned green.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cha-me-le-on",
+    "phonetic": "CHA-me-le-on"
+  },
+  {
+    "word": "chandelier",
+    "definition": "A decorative hanging light",
+    "sentence": "A crystal chandelier hung in the hall.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chan-de-lier",
+    "phonetic": "CHAN-de-lier"
+  },
+  {
+    "word": "character",
+    "definition": "A person in a novel or movie",
+    "sentence": "Who is your favorite character?",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "char-ac-ter",
+    "phonetic": "CHAR-ac-ter"
+  },
+  {
+    "word": "chemistry",
+    "definition": "Science of substances and reactions",
+    "sentence": "We did experiments in chemistry class.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chem-is-try",
+    "phonetic": "CHEM-is-try"
+  }
+]

--- a/public/data/words/grade-12.json
+++ b/public/data/words/grade-12.json
@@ -1,459 +1,452 @@
-{
-  "grade": 12,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 50,
-  "words": [
-    {
-      "word": "accommodate",
-      "definition": "To provide lodging or adjust to",
-      "example": "The hotel can accommodate 200 guests.",
-      "phonetic": "AC-com-mo-date",
-      "syllables": "ac-com-mo-date",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bureaucracy",
-      "definition": "Administrative government system",
-      "example": "The bureaucracy slowed the process.",
-      "phonetic": "BU-reau-cra-cy",
-      "syllables": "bu-reau-cra-cy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conscientious",
-      "definition": "Thorough and careful",
-      "example": "She is a conscientious worker.",
-      "phonetic": "CON-sci-en-tious",
-      "syllables": "con-sci-en-tious",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "entrepreneur",
-      "definition": "A business founder",
-      "example": "The entrepreneur started three companies.",
-      "phonetic": "EN-tre-pre-neur",
-      "syllables": "en-tre-pre-neur",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "fluorescent",
-      "definition": "Emitting bright light",
-      "example": "The fluorescent lights buzzed overhead.",
-      "phonetic": "FLU-o-res-cent",
-      "syllables": "flu-o-res-cent",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "guarantee",
-      "definition": "A formal promise",
-      "example": "The product comes with a guarantee.",
-      "phonetic": "GUAR-an-tee",
-      "syllables": "guar-an-tee",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "hemorrhage",
-      "definition": "Severe bleeding",
-      "example": "The doctor stopped the hemorrhage.",
-      "phonetic": "HEM-or-rhage",
-      "syllables": "hem-or-rhage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "inconvenience",
-      "definition": "Trouble or difficulty",
-      "example": "Sorry for any inconvenience caused.",
-      "phonetic": "IN-con-ven-ience",
-      "syllables": "in-con-ven-ience",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "jeopardize",
-      "definition": "To put at risk",
-      "example": "Don't jeopardize your future.",
-      "phonetic": "JEOP-ar-dize",
-      "syllables": "jeop-ar-dize",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "knowledgeable",
-      "definition": "Well informed",
-      "example": "The guide was very knowledgeable.",
-      "phonetic": "KNOWL-edge-a-ble",
-      "syllables": "knowl-edge-a-ble",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "liaison",
-      "definition": "A person who links groups",
-      "example": "She serves as liaison between departments.",
-      "phonetic": "LI-ai-son",
-      "syllables": "li-ai-son",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "mischievous",
-      "definition": "Playfully troublesome",
-      "example": "The mischievous child hid the keys.",
-      "phonetic": "MIS-chie-vous",
-      "syllables": "mis-chie-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "onomatopoeia",
-      "definition": "Words that imitate sounds",
-      "example": "Buzz is an example of onomatopoeia.",
-      "phonetic": "ON-o-mat-o-poe-ia",
-      "syllables": "on-o-mat-o-poe-ia",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "pharmaceutical",
-      "definition": "Related to medicinal drugs",
-      "example": "The pharmaceutical company developed a vaccine.",
-      "phonetic": "PHAR-ma-ceu-ti-cal",
-      "syllables": "phar-ma-ceu-ti-cal",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "rendezvous",
-      "definition": "A planned meeting",
-      "example": "They arranged a secret rendezvous.",
-      "phonetic": "REN-dez-vous",
-      "syllables": "ren-dez-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "surveillance",
-      "definition": "Close observation",
-      "example": "The building has surveillance cameras.",
-      "phonetic": "SUR-veil-lance",
-      "syllables": "sur-veil-lance",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "tyranny",
-      "definition": "Cruel oppressive rule",
-      "example": "The people rose against tyranny.",
-      "phonetic": "TYR-an-ny",
-      "syllables": "tyr-an-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ubiquitous",
-      "definition": "Present everywhere",
-      "example": "Smartphones are now ubiquitous.",
-      "phonetic": "U-biq-ui-tous",
-      "syllables": "u-biq-ui-tous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "vocabulary",
-      "definition": "Words known or used",
-      "example": "Reading expands your vocabulary.",
-      "phonetic": "VO-cab-u-lar-y",
-      "syllables": "vo-cab-u-lar-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "Wednesday",
-      "definition": "The fourth day of the week",
-      "example": "The meeting is on Wednesday.",
-      "phonetic": "WEDNES-day",
-      "syllables": "Wednes-day",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "achievement",
-      "definition": "Something done successfully",
-      "example": "Winning the game was a great achievement.",
-      "phonetic": "A-chieve-ment",
-      "syllables": "a-chieve-ment",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "acoustic",
-      "definition": "Related to sound or hearing",
-      "example": "He played an acoustic guitar.",
-      "phonetic": "A-cous-tic",
-      "syllables": "a-cous-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "algorithm",
-      "definition": "A set of rules for solving a problem",
-      "example": "The computer uses an algorithm to search.",
-      "phonetic": "AL-go-rithm",
-      "syllables": "al-go-rithm",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "amphibian",
-      "definition": "An animal living on land and water",
-      "example": "A frog is a type of amphibian.",
-      "phonetic": "AM-phib-i-an",
-      "syllables": "am-phib-i-an",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "analysis",
-      "definition": "Detailed examination",
-      "example": "The scientist performed an analysis of the data.",
-      "phonetic": "A-nal-y-sis",
-      "syllables": "a-nal-y-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ancient",
-      "definition": "Belonging to the very distant past",
-      "example": "They visited the ancient ruins.",
-      "phonetic": "AN-cient",
-      "syllables": "an-cient",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anniversary",
-      "definition": "Date on which an event took place",
-      "example": "They celebrated their wedding anniversary.",
-      "phonetic": "AN-ni-ver-sa-ry",
-      "syllables": "an-ni-ver-sa-ry",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anonymous",
-      "definition": "Not identified by name",
-      "example": "The donor chose to remain anonymous.",
-      "phonetic": "A-non-y-mous",
-      "syllables": "a-non-y-mous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "antique",
-      "definition": "A collectible object having a high value",
-      "example": "This chair is a valuable antique.",
-      "phonetic": "AN-tique",
-      "syllables": "an-tique",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anxiety",
-      "definition": "A feeling of worry or nervousness",
-      "example": "He felt anxiety before the test.",
-      "phonetic": "ANX-i-e-ty",
-      "syllables": "anx-i-e-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "appreciate",
-      "definition": "To recognize the full worth of",
-      "example": "I appreciate your help.",
-      "phonetic": "AP-pre-ci-ate",
-      "syllables": "ap-pre-ci-ate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "aquarium",
-      "definition": "A tank of water for fish",
-      "example": "We saw sharks at the aquarium.",
-      "phonetic": "A-quar-i-um",
-      "syllables": "a-quar-i-um",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "architecture",
-      "definition": "The art of designing buildings",
-      "example": "The city has beautiful architecture.",
-      "phonetic": "AR-chi-tec-ture",
-      "syllables": "ar-chi-tec-ture",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "arithmetic",
-      "definition": "The branch of math with numbers",
-      "example": "We learned arithmetic in school.",
-      "phonetic": "A-rith-me-tic",
-      "syllables": "a-rith-me-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "artificial",
-      "definition": "Made by humans, not natural",
-      "example": "The flowers are artificial.",
-      "phonetic": "AR-ti-fi-cial",
-      "syllables": "ar-ti-fi-cial",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "atmosphere",
-      "definition": "Gases surrounding a planet",
-      "example": "The atmosphere protects the Earth.",
-      "phonetic": "AT-mos-phere",
-      "syllables": "at-mos-phere",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "audience",
-      "definition": "Spectators at an event",
-      "example": "The audience clapped loudly.",
-      "phonetic": "AU-di-ence",
-      "syllables": "au-di-ence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "authentic",
-      "definition": "Of undisputed origin; genuine",
-      "example": "This is an authentic painting.",
-      "phonetic": "AU-then-tic",
-      "syllables": "au-then-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "biography",
-      "definition": "An account of someone's life",
-      "example": "I read a biography of Lincoln.",
-      "phonetic": "BI-og-ra-phy",
-      "syllables": "bi-og-ra-phy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bizarre",
-      "definition": "Very strange or unusual",
-      "example": "It was a bizarre situation.",
-      "phonetic": "BI-zarre",
-      "syllables": "bi-zarre",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "camouflage",
-      "definition": "Disguise to blend with surroundings",
-      "example": "The soldier wore camouflage.",
-      "phonetic": "CAM-ou-flage",
-      "syllables": "cam-ou-flage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "campaign",
-      "definition": "A series of actions for a goal",
-      "example": "The election campaign was intense.",
-      "phonetic": "CAM-paign",
-      "syllables": "cam-paign",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "capacity",
-      "definition": "The maximum amount something can hold",
-      "example": "The stadium was filled to capacity.",
-      "phonetic": "CA-pac-i-ty",
-      "syllables": "ca-pac-i-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "catastrophe",
-      "definition": "A sudden great disaster",
-      "example": "The earthquake was a catastrophe.",
-      "phonetic": "CA-tas-tro-phe",
-      "syllables": "ca-tas-tro-phe",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "cemetery",
-      "definition": "A place for burying the dead",
-      "example": "They visited the old cemetery.",
-      "phonetic": "CEM-e-ter-y",
-      "syllables": "cem-e-ter-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ceremony",
-      "definition": "A formal religious or public occasion",
-      "example": "The graduation ceremony is tomorrow.",
-      "phonetic": "CER-e-mo-ny",
-      "syllables": "cer-e-mo-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chameleon",
-      "definition": "A lizard that changes color",
-      "example": "The chameleon turned green.",
-      "phonetic": "CHA-me-le-on",
-      "syllables": "cha-me-le-on",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chandelier",
-      "definition": "A decorative hanging light",
-      "example": "A crystal chandelier hung in the hall.",
-      "phonetic": "CHAN-de-lier",
-      "syllables": "chan-de-lier",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "character",
-      "definition": "A person in a novel or movie",
-      "example": "Who is your favorite character?",
-      "phonetic": "CHAR-ac-ter",
-      "syllables": "char-ac-ter",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chemistry",
-      "definition": "Science of substances and reactions",
-      "example": "We did experiments in chemistry class.",
-      "phonetic": "CHEM-is-try",
-      "syllables": "chem-is-try",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    }
-  ]
-}
+[
+  {
+    "word": "accommodate",
+    "definition": "To provide lodging or adjust to",
+    "sentence": "The hotel can accommodate 200 guests.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ac-com-mo-date",
+    "phonetic": "AC-com-mo-date"
+  },
+  {
+    "word": "bureaucracy",
+    "definition": "Administrative government system",
+    "sentence": "The bureaucracy slowed the process.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bu-reau-cra-cy",
+    "phonetic": "BU-reau-cra-cy"
+  },
+  {
+    "word": "conscientious",
+    "definition": "Thorough and careful",
+    "sentence": "She is a conscientious worker.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-sci-en-tious",
+    "phonetic": "CON-sci-en-tious"
+  },
+  {
+    "word": "entrepreneur",
+    "definition": "A business founder",
+    "sentence": "The entrepreneur started three companies.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "en-tre-pre-neur",
+    "phonetic": "EN-tre-pre-neur"
+  },
+  {
+    "word": "fluorescent",
+    "definition": "Emitting bright light",
+    "sentence": "The fluorescent lights buzzed overhead.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "flu-o-res-cent",
+    "phonetic": "FLU-o-res-cent"
+  },
+  {
+    "word": "guarantee",
+    "definition": "A formal promise",
+    "sentence": "The product comes with a guarantee.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "guar-an-tee",
+    "phonetic": "GUAR-an-tee"
+  },
+  {
+    "word": "hemorrhage",
+    "definition": "Severe bleeding",
+    "sentence": "The doctor stopped the hemorrhage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "hem-or-rhage",
+    "phonetic": "HEM-or-rhage"
+  },
+  {
+    "word": "inconvenience",
+    "definition": "Trouble or difficulty",
+    "sentence": "Sorry for any inconvenience caused.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "in-con-ven-ience",
+    "phonetic": "IN-con-ven-ience"
+  },
+  {
+    "word": "jeopardize",
+    "definition": "To put at risk",
+    "sentence": "Don't jeopardize your future.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "jeop-ar-dize",
+    "phonetic": "JEOP-ar-dize"
+  },
+  {
+    "word": "knowledgeable",
+    "definition": "Well informed",
+    "sentence": "The guide was very knowledgeable.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "knowl-edge-a-ble",
+    "phonetic": "KNOWL-edge-a-ble"
+  },
+  {
+    "word": "liaison",
+    "definition": "A person who links groups",
+    "sentence": "She serves as liaison between departments.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "li-ai-son",
+    "phonetic": "LI-ai-son"
+  },
+  {
+    "word": "mischievous",
+    "definition": "Playfully troublesome",
+    "sentence": "The mischievous child hid the keys.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "mis-chie-vous",
+    "phonetic": "MIS-chie-vous"
+  },
+  {
+    "word": "onomatopoeia",
+    "definition": "Words that imitate sounds",
+    "sentence": "Buzz is an example of onomatopoeia.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "on-o-mat-o-poe-ia",
+    "phonetic": "ON-o-mat-o-poe-ia"
+  },
+  {
+    "word": "pharmaceutical",
+    "definition": "Related to medicinal drugs",
+    "sentence": "The pharmaceutical company developed a vaccine.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "phar-ma-ceu-ti-cal",
+    "phonetic": "PHAR-ma-ceu-ti-cal"
+  },
+  {
+    "word": "rendezvous",
+    "definition": "A planned meeting",
+    "sentence": "They arranged a secret rendezvous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ren-dez-vous",
+    "phonetic": "REN-dez-vous"
+  },
+  {
+    "word": "surveillance",
+    "definition": "Close observation",
+    "sentence": "The building has surveillance cameras.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "sur-veil-lance",
+    "phonetic": "SUR-veil-lance"
+  },
+  {
+    "word": "tyranny",
+    "definition": "Cruel oppressive rule",
+    "sentence": "The people rose against tyranny.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "tyr-an-ny",
+    "phonetic": "TYR-an-ny"
+  },
+  {
+    "word": "ubiquitous",
+    "definition": "Present everywhere",
+    "sentence": "Smartphones are now ubiquitous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "u-biq-ui-tous",
+    "phonetic": "U-biq-ui-tous"
+  },
+  {
+    "word": "vocabulary",
+    "definition": "Words known or used",
+    "sentence": "Reading expands your vocabulary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "vo-cab-u-lar-y",
+    "phonetic": "VO-cab-u-lar-y"
+  },
+  {
+    "word": "Wednesday",
+    "definition": "The fourth day of the week",
+    "sentence": "The meeting is on Wednesday.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "Wednes-day",
+    "phonetic": "WEDNES-day"
+  },
+  {
+    "word": "achievement",
+    "definition": "Something done successfully",
+    "sentence": "Winning the game was a great achievement.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-chieve-ment",
+    "phonetic": "A-chieve-ment"
+  },
+  {
+    "word": "acoustic",
+    "definition": "Related to sound or hearing",
+    "sentence": "He played an acoustic guitar.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-cous-tic",
+    "phonetic": "A-cous-tic"
+  },
+  {
+    "word": "algorithm",
+    "definition": "A set of rules for solving a problem",
+    "sentence": "The computer uses an algorithm to search.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "al-go-rithm",
+    "phonetic": "AL-go-rithm"
+  },
+  {
+    "word": "amphibian",
+    "definition": "An animal living on land and water",
+    "sentence": "A frog is a type of amphibian.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "am-phib-i-an",
+    "phonetic": "AM-phib-i-an"
+  },
+  {
+    "word": "analysis",
+    "definition": "Detailed examination",
+    "sentence": "The scientist performed an analysis of the data.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-nal-y-sis",
+    "phonetic": "A-nal-y-sis"
+  },
+  {
+    "word": "ancient",
+    "definition": "Belonging to the very distant past",
+    "sentence": "They visited the ancient ruins.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-cient",
+    "phonetic": "AN-cient"
+  },
+  {
+    "word": "anniversary",
+    "definition": "Date on which an event took place",
+    "sentence": "They celebrated their wedding anniversary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-ni-ver-sa-ry",
+    "phonetic": "AN-ni-ver-sa-ry"
+  },
+  {
+    "word": "anonymous",
+    "definition": "Not identified by name",
+    "sentence": "The donor chose to remain anonymous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-non-y-mous",
+    "phonetic": "A-non-y-mous"
+  },
+  {
+    "word": "antique",
+    "definition": "A collectible object having a high value",
+    "sentence": "This chair is a valuable antique.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-tique",
+    "phonetic": "AN-tique"
+  },
+  {
+    "word": "anxiety",
+    "definition": "A feeling of worry or nervousness",
+    "sentence": "He felt anxiety before the test.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "anx-i-e-ty",
+    "phonetic": "ANX-i-e-ty"
+  },
+  {
+    "word": "appreciate",
+    "definition": "To recognize the full worth of",
+    "sentence": "I appreciate your help.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ap-pre-ci-ate",
+    "phonetic": "AP-pre-ci-ate"
+  },
+  {
+    "word": "aquarium",
+    "definition": "A tank of water for fish",
+    "sentence": "We saw sharks at the aquarium.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-quar-i-um",
+    "phonetic": "A-quar-i-um"
+  },
+  {
+    "word": "architecture",
+    "definition": "The art of designing buildings",
+    "sentence": "The city has beautiful architecture.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-chi-tec-ture",
+    "phonetic": "AR-chi-tec-ture"
+  },
+  {
+    "word": "arithmetic",
+    "definition": "The branch of math with numbers",
+    "sentence": "We learned arithmetic in school.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-rith-me-tic",
+    "phonetic": "A-rith-me-tic"
+  },
+  {
+    "word": "artificial",
+    "definition": "Made by humans, not natural",
+    "sentence": "The flowers are artificial.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-ti-fi-cial",
+    "phonetic": "AR-ti-fi-cial"
+  },
+  {
+    "word": "atmosphere",
+    "definition": "Gases surrounding a planet",
+    "sentence": "The atmosphere protects the Earth.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "at-mos-phere",
+    "phonetic": "AT-mos-phere"
+  },
+  {
+    "word": "audience",
+    "definition": "Spectators at an event",
+    "sentence": "The audience clapped loudly.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-di-ence",
+    "phonetic": "AU-di-ence"
+  },
+  {
+    "word": "authentic",
+    "definition": "Of undisputed origin; genuine",
+    "sentence": "This is an authentic painting.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-then-tic",
+    "phonetic": "AU-then-tic"
+  },
+  {
+    "word": "biography",
+    "definition": "An account of someone's life",
+    "sentence": "I read a biography of Lincoln.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-og-ra-phy",
+    "phonetic": "BI-og-ra-phy"
+  },
+  {
+    "word": "bizarre",
+    "definition": "Very strange or unusual",
+    "sentence": "It was a bizarre situation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-zarre",
+    "phonetic": "BI-zarre"
+  },
+  {
+    "word": "camouflage",
+    "definition": "Disguise to blend with surroundings",
+    "sentence": "The soldier wore camouflage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-ou-flage",
+    "phonetic": "CAM-ou-flage"
+  },
+  {
+    "word": "campaign",
+    "definition": "A series of actions for a goal",
+    "sentence": "The election campaign was intense.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-paign",
+    "phonetic": "CAM-paign"
+  },
+  {
+    "word": "capacity",
+    "definition": "The maximum amount something can hold",
+    "sentence": "The stadium was filled to capacity.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-pac-i-ty",
+    "phonetic": "CA-pac-i-ty"
+  },
+  {
+    "word": "catastrophe",
+    "definition": "A sudden great disaster",
+    "sentence": "The earthquake was a catastrophe.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-tas-tro-phe",
+    "phonetic": "CA-tas-tro-phe"
+  },
+  {
+    "word": "cemetery",
+    "definition": "A place for burying the dead",
+    "sentence": "They visited the old cemetery.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cem-e-ter-y",
+    "phonetic": "CEM-e-ter-y"
+  },
+  {
+    "word": "ceremony",
+    "definition": "A formal religious or public occasion",
+    "sentence": "The graduation ceremony is tomorrow.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cer-e-mo-ny",
+    "phonetic": "CER-e-mo-ny"
+  },
+  {
+    "word": "chameleon",
+    "definition": "A lizard that changes color",
+    "sentence": "The chameleon turned green.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cha-me-le-on",
+    "phonetic": "CHA-me-le-on"
+  },
+  {
+    "word": "chandelier",
+    "definition": "A decorative hanging light",
+    "sentence": "A crystal chandelier hung in the hall.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chan-de-lier",
+    "phonetic": "CHAN-de-lier"
+  },
+  {
+    "word": "character",
+    "definition": "A person in a novel or movie",
+    "sentence": "Who is your favorite character?",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "char-ac-ter",
+    "phonetic": "CHAR-ac-ter"
+  },
+  {
+    "word": "chemistry",
+    "definition": "Science of substances and reactions",
+    "sentence": "We did experiments in chemistry class.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chem-is-try",
+    "phonetic": "CHEM-is-try"
+  }
+]

--- a/public/data/words/grade-2.json
+++ b/public/data/words/grade-2.json
@@ -1,981 +1,956 @@
-{
-  "grade": 2,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 108,
-  "words": [
-    {
-      "word": "apple",
-      "definition": "A round fruit with red or green skin",
-      "example": "She picked a fresh apple from the tree.",
-      "phonetic": "AP-ple",
-      "syllables": "ap-ple",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "book",
-      "definition": "A written work bound together",
-      "example": "I read a great book last week.",
-      "phonetic": "BOOK",
-      "syllables": "book",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cat",
-      "definition": "A small domesticated feline",
-      "example": "The cat slept on the warm windowsill.",
-      "phonetic": "CAT",
-      "syllables": "cat",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "door",
-      "definition": "A hinged barrier at an entrance",
-      "example": "Please close the door behind you.",
-      "phonetic": "DOOR",
-      "syllables": "door",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "friend",
-      "definition": "A person you know and like",
-      "example": "My best friend lives next door.",
-      "phonetic": "FRIEND",
-      "syllables": "friend",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "garden",
-      "definition": "A piece of ground for growing plants",
-      "example": "We planted tomatoes in the garden.",
-      "phonetic": "GAR-den",
-      "syllables": "gar-den",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "happy",
-      "definition": "Feeling pleasure or contentment",
-      "example": "The children were happy to see snow.",
-      "phonetic": "HAP-py",
-      "syllables": "hap-py",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "kite",
-      "definition": "A toy flown in the wind",
-      "example": "The kite soared high above the park.",
-      "phonetic": "KITE",
-      "syllables": "kite",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lemon",
-      "definition": "A yellow citrus fruit",
-      "example": "She squeezed lemon into her tea.",
-      "phonetic": "LEM-on",
-      "syllables": "lem-on",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "monkey",
-      "definition": "A primate with a long tail",
-      "example": "The monkey swung from branch to branch.",
-      "phonetic": "MON-key",
-      "syllables": "mon-key",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "pencil",
-      "definition": "A writing instrument",
-      "example": "Write your name with a pencil.",
-      "phonetic": "PEN-cil",
-      "syllables": "pen-cil",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "queen",
-      "definition": "A female monarch",
-      "example": "The queen wore a golden crown.",
-      "phonetic": "QUEEN",
-      "syllables": "queen",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "ant",
-      "definition": "A small insect that lives in colonies",
-      "example": "The ant carried a crumb to its hill.",
-      "phonetic": "ANT",
-      "syllables": "ant",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "baby",
-      "definition": "A very young child",
-      "example": "The baby is sleeping in the crib.",
-      "phonetic": "BA-by",
-      "syllables": "ba-by",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "bear",
-      "definition": "A large mammal with fur",
-      "example": "The bear loves to eat honey.",
-      "phonetic": "BEAR",
-      "syllables": "bear",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "bird",
-      "definition": "An animal with feathers and wings",
-      "example": "A blue bird sang in the tree.",
-      "phonetic": "BIRD",
-      "syllables": "bird",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "boat",
-      "definition": "A vehicle for traveling on water",
-      "example": "We rowed the boat across the lake.",
-      "phonetic": "BOAT",
-      "syllables": "boat",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "bread",
-      "definition": "Food made from flour and baked",
-      "example": "I like bread with butter.",
-      "phonetic": "BREAD",
-      "syllables": "bread",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "bus",
-      "definition": "A large vehicle for carrying passengers",
-      "example": "The school bus arrives at 8 AM.",
-      "phonetic": "BUS",
-      "syllables": "bus",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cake",
-      "definition": "A sweet baked dessert",
-      "example": "We ate chocolate cake for his birthday.",
-      "phonetic": "CAKE",
-      "syllables": "cake",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "car",
-      "definition": "A vehicle with four wheels",
-      "example": "My dad drives a red car.",
-      "phonetic": "CAR",
-      "syllables": "car",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "chair",
-      "definition": "A seat with a back",
-      "example": "Please sit on the chair.",
-      "phonetic": "CHAIR",
-      "syllables": "chair",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "chicken",
-      "definition": "A bird raised for food",
-      "example": "The chicken laid an egg.",
-      "phonetic": "CHICK-en",
-      "syllables": "chick-en",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "clock",
-      "definition": "A device that tells time",
-      "example": "The clock struck twelve.",
-      "phonetic": "CLOCK",
-      "syllables": "clock",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "coat",
-      "definition": "Outer clothing worn for warmth",
-      "example": "Wear your coat, it's cold outside.",
-      "phonetic": "COAT",
-      "syllables": "coat",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cow",
-      "definition": "A large farm animal that gives milk",
-      "example": "The cow is eating grass.",
-      "phonetic": "COW",
-      "syllables": "cow",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cup",
-      "definition": "A small bowl for drinking",
-      "example": "I would like a cup of water.",
-      "phonetic": "CUP",
-      "syllables": "cup",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "desk",
-      "definition": "A table for writing or working",
-      "example": "She sat at her desk to study.",
-      "phonetic": "DESK",
-      "syllables": "desk",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "dog",
-      "definition": "A common pet animal",
-      "example": "The dog wagged its tail.",
-      "phonetic": "DOG",
-      "syllables": "dog",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "doll",
-      "definition": "A toy that looks like a person",
-      "example": "She played with her favorite doll.",
-      "phonetic": "DOLL",
-      "syllables": "doll",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "duck",
-      "definition": "A water bird with webbed feet",
-      "example": "The duck swam in the pond.",
-      "phonetic": "DUCK",
-      "syllables": "duck",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "egg",
-      "definition": "An oval object laid by birds",
-      "example": "He ate a boiled egg for breakfast.",
-      "phonetic": "EGG",
-      "syllables": "egg",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "eye",
-      "definition": "The organ of sight",
-      "example": "She closed one eye to aim.",
-      "phonetic": "EYE",
-      "syllables": "eye",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "farm",
-      "definition": "Land used for growing crops",
-      "example": "Animals live on the farm.",
-      "phonetic": "FARM",
-      "syllables": "farm",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "fish",
-      "definition": "An animal that lives in water",
-      "example": "The fish swam in the bowl.",
-      "phonetic": "FISH",
-      "syllables": "fish",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "flower",
-      "definition": "The colorful part of a plant",
-      "example": "He picked a yellow flower.",
-      "phonetic": "FLOW-er",
-      "syllables": "flow-er",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "food",
-      "definition": "What people and animals eat",
-      "example": "We need food to live.",
-      "phonetic": "FOOD",
-      "syllables": "food",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "frog",
-      "definition": "A small green animal that hops",
-      "example": "The frog jumped into the water.",
-      "phonetic": "FROG",
-      "syllables": "frog",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "game",
-      "definition": "An activity played for fun",
-      "example": "Let's play a board game.",
-      "phonetic": "GAME",
-      "syllables": "game",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "girl",
-      "definition": "A female child",
-      "example": "The girl skipped down the street.",
-      "phonetic": "GIRL",
-      "syllables": "girl",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "goat",
-      "definition": "A farm animal with horns",
-      "example": "The goat climbed the rock.",
-      "phonetic": "GOAT",
-      "syllables": "goat",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "grass",
-      "definition": "Green plants covering the ground",
-      "example": "The grass is wet with dew.",
-      "phonetic": "GRASS",
-      "syllables": "grass",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "hand",
-      "definition": "Body part at the end of the arm",
-      "example": "Raise your hand if you know the answer.",
-      "phonetic": "HAND",
-      "syllables": "hand",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "hat",
-      "definition": "A covering for the head",
-      "example": "He wore a hat to block the sun.",
-      "phonetic": "HAT",
-      "syllables": "hat",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "hill",
-      "definition": "A raised area of land",
-      "example": "We rolled down the grassy hill.",
-      "phonetic": "HILL",
-      "syllables": "hill",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "horse",
-      "definition": "A large animal used for riding",
-      "example": "She loves to ride her horse.",
-      "phonetic": "HORSE",
-      "syllables": "horse",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "house",
-      "definition": "A building where people live",
-      "example": "Our house has a red door.",
-      "phonetic": "HOUSE",
-      "syllables": "house",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "ice",
-      "definition": "Frozen water",
-      "example": "Put some ice in my drink.",
-      "phonetic": "ICE",
-      "syllables": "ice",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "juice",
-      "definition": "Liquid from fruit or vegetables",
-      "example": "I drank orange juice with toast.",
-      "phonetic": "JUICE",
-      "syllables": "juice",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lamp",
-      "definition": "A device that gives light",
-      "example": "Turn on the lamp so we can see.",
-      "phonetic": "LAMP",
-      "syllables": "lamp",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "leaf",
-      "definition": "The green part of a plant",
-      "example": "A brown leaf fell from the tree.",
-      "phonetic": "LEAF",
-      "syllables": "leaf",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lion",
-      "definition": "A large wild cat",
-      "example": "The lion roared loudly.",
-      "phonetic": "LI-on",
-      "syllables": "li-on",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "milk",
-      "definition": "White liquid from cows",
-      "example": "Milk is good for your bones.",
-      "phonetic": "MILK",
-      "syllables": "milk",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "moon",
-      "definition": "Object that orbits the Earth",
-      "example": "The full moon shines at night.",
-      "phonetic": "MOON",
-      "syllables": "moon",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "mouse",
-      "definition": "A small rodent",
-      "example": "The mouse ran into a hole.",
-      "phonetic": "MOUSE",
-      "syllables": "mouse",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "nest",
-      "definition": "A home built by a bird",
-      "example": "There are three eggs in the nest.",
-      "phonetic": "NEST",
-      "syllables": "nest",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "nose",
-      "definition": "Body part used for smelling",
-      "example": "My nose is cold.",
-      "phonetic": "NOSE",
-      "syllables": "nose",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "park",
-      "definition": "Public land for recreation",
-      "example": "We played soccer at the park.",
-      "phonetic": "PARK",
-      "syllables": "park",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "pig",
-      "definition": "A farm animal with a pink snout",
-      "example": "The pig played in the mud.",
-      "phonetic": "PIG",
-      "syllables": "pig",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "rain",
-      "definition": "Water falling from clouds",
-      "example": "Take an umbrella in the rain.",
-      "phonetic": "RAIN",
-      "syllables": "rain",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "ring",
-      "definition": "A circular band worn on a finger",
-      "example": "She lost her gold ring.",
-      "phonetic": "RING",
-      "syllables": "ring",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "road",
-      "definition": "A hard surface for vehicles",
-      "example": "Look both ways before crossing the road.",
-      "phonetic": "ROAD",
-      "syllables": "road",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "room",
-      "definition": "A space inside a building",
-      "example": "My room is very messy.",
-      "phonetic": "ROOM",
-      "syllables": "room",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "shoe",
-      "definition": "Footwear",
-      "example": "Tie your shoe lace.",
-      "phonetic": "SHOE",
-      "syllables": "shoe",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "snow",
-      "definition": "Frozen white rain",
-      "example": "The snow covered the ground.",
-      "phonetic": "SNOW",
-      "syllables": "snow",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "star",
-      "definition": "A bright point in the night sky",
-      "example": "Make a wish on a falling star.",
-      "phonetic": "STAR",
-      "syllables": "star",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "sun",
-      "definition": "The star that warms the Earth",
-      "example": "The sun rises in the east.",
-      "phonetic": "SUN",
-      "syllables": "sun",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "acorn",
-      "definition": "The nut of an oak tree",
-      "example": "A squirrel carried the acorn up the tree.",
-      "phonetic": "A-corn",
-      "syllables": "a-corn",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "bubble",
-      "definition": "A thin sphere of liquid filled with air",
-      "example": "The bubble floated and popped.",
-      "phonetic": "BUB-ble",
-      "syllables": "bub-ble",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cabin",
-      "definition": "A small simple house, often in the woods",
-      "example": "They stayed in a cozy cabin by the lake.",
-      "phonetic": "CAB-in",
-      "syllables": "cab-in",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lantern",
-      "definition": "A portable light with a protective cover",
-      "example": "We carried a lantern on the evening walk.",
-      "phonetic": "LAN-tern",
-      "syllables": "lan-tern",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "igloo",
-      "definition": "A dome-shaped shelter made of snow blocks",
-      "example": "The picture book showed an igloo in winter.",
-      "phonetic": "IG-loo",
-      "syllables": "ig-loo",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "glove",
-      "definition": "A hand covering with finger sections",
-      "example": "She wore one warm glove on each hand.",
-      "phonetic": "GLOVE",
-      "syllables": "glove",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "meadow",
-      "definition": "A grassy field",
-      "example": "Wildflowers bloomed in the meadow.",
-      "phonetic": "MEAD-ow",
-      "syllables": "mead-ow",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "pebble",
-      "definition": "A small smooth stone",
-      "example": "He skipped a pebble across the pond.",
-      "phonetic": "PEB-ble",
-      "syllables": "peb-ble",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "thunder",
-      "definition": "The loud sound during a storm",
-      "example": "Thunder rumbled in the distance.",
-      "phonetic": "THUN-der",
-      "syllables": "thun-der",
-      "difficulty": "easy",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "basket",
-      "definition": "A container woven from strips",
-      "example": "She carried apples in a basket.",
-      "phonetic": "BAS-ket",
-      "syllables": "bas-ket",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "blanket",
-      "definition": "A warm cover for a bed",
-      "example": "I pulled the blanket up to my chin.",
-      "phonetic": "BLAN-ket",
-      "syllables": "blan-ket",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "branch",
-      "definition": "A part of a tree that grows from the trunk",
-      "example": "A bird landed on the branch.",
-      "phonetic": "BRANCH",
-      "syllables": "branch",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "cactus",
-      "definition": "A desert plant with spines",
-      "example": "The cactus needs very little water.",
-      "phonetic": "CAC-tus",
-      "syllables": "cac-tus",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "dragon",
-      "definition": "A large mythical creature",
-      "example": "The storybook dragon guarded a cave.",
-      "phonetic": "DRAG-on",
-      "syllables": "drag-on",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "frozen",
-      "definition": "Turned into ice by cold",
-      "example": "The pond was frozen this morning.",
-      "phonetic": "FRO-zen",
-      "syllables": "fro-zen",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "gardenia",
-      "definition": "A fragrant white flower",
-      "example": "A gardenia bloomed near the porch.",
-      "phonetic": "GAR-de-ni-a",
-      "syllables": "gar-de-ni-a",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "helmet",
-      "definition": "A hard hat for protection",
-      "example": "Wear your helmet when riding a bike.",
-      "phonetic": "HEL-met",
-      "syllables": "hel-met",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "kittenish",
-      "definition": "Playful like a kitten",
-      "example": "The puppy made kittenish jumps around us.",
-      "phonetic": "KIT-ten-ish",
-      "syllables": "kit-ten-ish",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lantern",
-      "definition": "A lamp with a protective case",
-      "example": "We carried a lantern on the trail.",
-      "phonetic": "LAN-tern",
-      "syllables": "lan-tern",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "magnet",
-      "definition": "An object that attracts iron",
-      "example": "The magnet pulled the paper clips close.",
-      "phonetic": "MAG-net",
-      "syllables": "mag-net",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "napkin",
-      "definition": "A cloth or paper used at meals",
-      "example": "Put the napkin on your lap.",
-      "phonetic": "NAP-kin",
-      "syllables": "nap-kin",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "planet",
-      "definition": "A large body orbiting a star",
-      "example": "Earth is the planet we live on.",
-      "phonetic": "PLAN-et",
-      "syllables": "plan-et",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "rocket",
-      "definition": "A vehicle that can travel into space",
-      "example": "The toy rocket zoomed across the room.",
-      "phonetic": "ROCK-et",
-      "syllables": "rock-et",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "splash",
-      "definition": "The sound or act of water striking",
-      "example": "The duck made a big splash.",
-      "phonetic": "SPLASH",
-      "syllables": "splash",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "thunder",
-      "definition": "The loud sound after lightning",
-      "example": "Thunder shook the windows last night.",
-      "phonetic": "THUN-der",
-      "syllables": "thun-der",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "trumpet",
-      "definition": "A brass musical instrument",
-      "example": "He practiced trumpet in band class.",
-      "phonetic": "TRUM-pet",
-      "syllables": "trum-pet",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "window",
-      "definition": "An opening in a wall with glass",
-      "example": "Rain tapped on the window.",
-      "phonetic": "WIN-dow",
-      "syllables": "win-dow",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "yellowish",
-      "definition": "Slightly yellow in color",
-      "example": "The old paper looked yellowish.",
-      "phonetic": "YEL-low-ish",
-      "syllables": "yel-low-ish",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "zigzag",
-      "definition": "A pattern with sharp turns",
-      "example": "The path made a zigzag up the hill.",
-      "phonetic": "ZIG-zag",
-      "syllables": "zig-zag",
-      "difficulty": "medium",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "adventure",
-      "definition": "An exciting experience",
-      "example": "Our camping trip was a big adventure.",
-      "phonetic": "AD-ven-ture",
-      "syllables": "ad-ven-ture",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "butterfly",
-      "definition": "An insect with colorful wings",
-      "example": "A butterfly landed on the flower.",
-      "phonetic": "BUT-ter-fly",
-      "syllables": "but-ter-fly",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "chocolate",
-      "definition": "A sweet food made from cocoa",
-      "example": "She shared a piece of chocolate.",
-      "phonetic": "CHOC-o-late",
-      "syllables": "choc-o-late",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "dinosaur",
-      "definition": "A prehistoric reptile",
-      "example": "The dinosaur exhibit was my favorite.",
-      "phonetic": "DI-no-saur",
-      "syllables": "di-no-saur",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "elephant",
-      "definition": "A very large animal with a trunk",
-      "example": "The elephant sprayed water on itself.",
-      "phonetic": "EL-e-phant",
-      "syllables": "el-e-phant",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "fireworks",
-      "definition": "Exploding lights in the sky",
-      "example": "We watched fireworks on the holiday.",
-      "phonetic": "FIRE-works",
-      "syllables": "fire-works",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "giraffe",
-      "definition": "A tall animal with a long neck",
-      "example": "The giraffe reached the highest leaves.",
-      "phonetic": "GI-raffe",
-      "syllables": "gi-raffe",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "hamburger",
-      "definition": "A sandwich with a cooked patty",
-      "example": "He ordered a hamburger for lunch.",
-      "phonetic": "HAM-bur-ger",
-      "syllables": "ham-bur-ger",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "important",
-      "definition": "Having great value or meaning",
-      "example": "It is important to be kind to others.",
-      "phonetic": "IM-por-tant",
-      "syllables": "im-por-tant",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "jellyfish",
-      "definition": "A sea animal with soft body",
-      "example": "A jellyfish drifted near the shore.",
-      "phonetic": "JEL-ly-fish",
-      "syllables": "jel-ly-fish",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "kangaroo",
-      "definition": "A hopping animal from Australia",
-      "example": "The kangaroo carried a joey in its pouch.",
-      "phonetic": "KAN-ga-roo",
-      "syllables": "kan-ga-roo",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    },
-    {
-      "word": "lighthouse",
-      "definition": "A tower with a bright warning light",
-      "example": "The lighthouse guided ships at night.",
-      "phonetic": "LIGHT-house",
-      "syllables": "light-house",
-      "difficulty": "hard",
-      "gradeLevel": "K-2"
-    }
-  ]
-}
+[
+  {
+    "word": "apple",
+    "definition": "A round fruit with red or green skin",
+    "sentence": "She picked a fresh apple from the tree.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "ap-ple",
+    "phonetic": "AP-ple"
+  },
+  {
+    "word": "book",
+    "definition": "A written work bound together",
+    "sentence": "I read a great book last week.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "book",
+    "phonetic": "BOOK"
+  },
+  {
+    "word": "cat",
+    "definition": "A small domesticated feline",
+    "sentence": "The cat slept on the warm windowsill.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "cat",
+    "phonetic": "CAT"
+  },
+  {
+    "word": "door",
+    "definition": "A hinged barrier at an entrance",
+    "sentence": "Please close the door behind you.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "door",
+    "phonetic": "DOOR"
+  },
+  {
+    "word": "friend",
+    "definition": "A person you know and like",
+    "sentence": "My best friend lives next door.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "friend",
+    "phonetic": "FRIEND"
+  },
+  {
+    "word": "garden",
+    "definition": "A piece of ground for growing plants",
+    "sentence": "We planted tomatoes in the garden.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "gar-den",
+    "phonetic": "GAR-den"
+  },
+  {
+    "word": "happy",
+    "definition": "Feeling pleasure or contentment",
+    "sentence": "The children were happy to see snow.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "hap-py",
+    "phonetic": "HAP-py"
+  },
+  {
+    "word": "kite",
+    "definition": "A toy flown in the wind",
+    "sentence": "The kite soared high above the park.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "kite",
+    "phonetic": "KITE"
+  },
+  {
+    "word": "lemon",
+    "definition": "A yellow citrus fruit",
+    "sentence": "She squeezed lemon into her tea.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "lem-on",
+    "phonetic": "LEM-on"
+  },
+  {
+    "word": "monkey",
+    "definition": "A primate with a long tail",
+    "sentence": "The monkey swung from branch to branch.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "mon-key",
+    "phonetic": "MON-key"
+  },
+  {
+    "word": "pencil",
+    "definition": "A writing instrument",
+    "sentence": "Write your name with a pencil.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "pen-cil",
+    "phonetic": "PEN-cil"
+  },
+  {
+    "word": "queen",
+    "definition": "A female monarch",
+    "sentence": "The queen wore a golden crown.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "queen",
+    "phonetic": "QUEEN"
+  },
+  {
+    "word": "ant",
+    "definition": "A small insect that lives in colonies",
+    "sentence": "The ant carried a crumb to its hill.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "ant",
+    "phonetic": "ANT"
+  },
+  {
+    "word": "baby",
+    "definition": "A very young child",
+    "sentence": "The baby is sleeping in the crib.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "ba-by",
+    "phonetic": "BA-by"
+  },
+  {
+    "word": "bear",
+    "definition": "A large mammal with fur",
+    "sentence": "The bear loves to eat honey.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "bear",
+    "phonetic": "BEAR"
+  },
+  {
+    "word": "bird",
+    "definition": "An animal with feathers and wings",
+    "sentence": "A blue bird sang in the tree.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "bird",
+    "phonetic": "BIRD"
+  },
+  {
+    "word": "boat",
+    "definition": "A vehicle for traveling on water",
+    "sentence": "We rowed the boat across the lake.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "boat",
+    "phonetic": "BOAT"
+  },
+  {
+    "word": "bread",
+    "definition": "Food made from flour and baked",
+    "sentence": "I like bread with butter.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "bread",
+    "phonetic": "BREAD"
+  },
+  {
+    "word": "bus",
+    "definition": "A large vehicle for carrying passengers",
+    "sentence": "The school bus arrives at 8 AM.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "bus",
+    "phonetic": "BUS"
+  },
+  {
+    "word": "cake",
+    "definition": "A sweet baked dessert",
+    "sentence": "We ate chocolate cake for his birthday.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "cake",
+    "phonetic": "CAKE"
+  },
+  {
+    "word": "car",
+    "definition": "A vehicle with four wheels",
+    "sentence": "My dad drives a red car.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "car",
+    "phonetic": "CAR"
+  },
+  {
+    "word": "chair",
+    "definition": "A seat with a back",
+    "sentence": "Please sit on the chair.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "chair",
+    "phonetic": "CHAIR"
+  },
+  {
+    "word": "chicken",
+    "definition": "A bird raised for food",
+    "sentence": "The chicken laid an egg.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "chick-en",
+    "phonetic": "CHICK-en"
+  },
+  {
+    "word": "clock",
+    "definition": "A device that tells time",
+    "sentence": "The clock struck twelve.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "clock",
+    "phonetic": "CLOCK"
+  },
+  {
+    "word": "coat",
+    "definition": "Outer clothing worn for warmth",
+    "sentence": "Wear your coat, it's cold outside.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "coat",
+    "phonetic": "COAT"
+  },
+  {
+    "word": "cow",
+    "definition": "A large farm animal that gives milk",
+    "sentence": "The cow is eating grass.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "cow",
+    "phonetic": "COW"
+  },
+  {
+    "word": "cup",
+    "definition": "A small bowl for drinking",
+    "sentence": "I would like a cup of water.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "cup",
+    "phonetic": "CUP"
+  },
+  {
+    "word": "desk",
+    "definition": "A table for writing or working",
+    "sentence": "She sat at her desk to study.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "desk",
+    "phonetic": "DESK"
+  },
+  {
+    "word": "dog",
+    "definition": "A common pet animal",
+    "sentence": "The dog wagged its tail.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "dog",
+    "phonetic": "DOG"
+  },
+  {
+    "word": "doll",
+    "definition": "A toy that looks like a person",
+    "sentence": "She played with her favorite doll.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "doll",
+    "phonetic": "DOLL"
+  },
+  {
+    "word": "duck",
+    "definition": "A water bird with webbed feet",
+    "sentence": "The duck swam in the pond.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "duck",
+    "phonetic": "DUCK"
+  },
+  {
+    "word": "egg",
+    "definition": "An oval object laid by birds",
+    "sentence": "He ate a boiled egg for breakfast.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "egg",
+    "phonetic": "EGG"
+  },
+  {
+    "word": "eye",
+    "definition": "The organ of sight",
+    "sentence": "She closed one eye to aim.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "eye",
+    "phonetic": "EYE"
+  },
+  {
+    "word": "farm",
+    "definition": "Land used for growing crops",
+    "sentence": "Animals live on the farm.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "farm",
+    "phonetic": "FARM"
+  },
+  {
+    "word": "fish",
+    "definition": "An animal that lives in water",
+    "sentence": "The fish swam in the bowl.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "fish",
+    "phonetic": "FISH"
+  },
+  {
+    "word": "flower",
+    "definition": "The colorful part of a plant",
+    "sentence": "He picked a yellow flower.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "flow-er",
+    "phonetic": "FLOW-er"
+  },
+  {
+    "word": "food",
+    "definition": "What people and animals eat",
+    "sentence": "We need food to live.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "food",
+    "phonetic": "FOOD"
+  },
+  {
+    "word": "frog",
+    "definition": "A small green animal that hops",
+    "sentence": "The frog jumped into the water.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "frog",
+    "phonetic": "FROG"
+  },
+  {
+    "word": "game",
+    "definition": "An activity played for fun",
+    "sentence": "Let's play a board game.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "game",
+    "phonetic": "GAME"
+  },
+  {
+    "word": "girl",
+    "definition": "A female child",
+    "sentence": "The girl skipped down the street.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "girl",
+    "phonetic": "GIRL"
+  },
+  {
+    "word": "goat",
+    "definition": "A farm animal with horns",
+    "sentence": "The goat climbed the rock.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "goat",
+    "phonetic": "GOAT"
+  },
+  {
+    "word": "grass",
+    "definition": "Green plants covering the ground",
+    "sentence": "The grass is wet with dew.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "grass",
+    "phonetic": "GRASS"
+  },
+  {
+    "word": "hand",
+    "definition": "Body part at the end of the arm",
+    "sentence": "Raise your hand if you know the answer.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "hand",
+    "phonetic": "HAND"
+  },
+  {
+    "word": "hat",
+    "definition": "A covering for the head",
+    "sentence": "He wore a hat to block the sun.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "hat",
+    "phonetic": "HAT"
+  },
+  {
+    "word": "hill",
+    "definition": "A raised area of land",
+    "sentence": "We rolled down the grassy hill.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "hill",
+    "phonetic": "HILL"
+  },
+  {
+    "word": "horse",
+    "definition": "A large animal used for riding",
+    "sentence": "She loves to ride her horse.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "horse",
+    "phonetic": "HORSE"
+  },
+  {
+    "word": "house",
+    "definition": "A building where people live",
+    "sentence": "Our house has a red door.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "house",
+    "phonetic": "HOUSE"
+  },
+  {
+    "word": "ice",
+    "definition": "Frozen water",
+    "sentence": "Put some ice in my drink.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "ice",
+    "phonetic": "ICE"
+  },
+  {
+    "word": "juice",
+    "definition": "Liquid from fruit or vegetables",
+    "sentence": "I drank orange juice with toast.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "juice",
+    "phonetic": "JUICE"
+  },
+  {
+    "word": "lamp",
+    "definition": "A device that gives light",
+    "sentence": "Turn on the lamp so we can see.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "lamp",
+    "phonetic": "LAMP"
+  },
+  {
+    "word": "leaf",
+    "definition": "The green part of a plant",
+    "sentence": "A brown leaf fell from the tree.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "leaf",
+    "phonetic": "LEAF"
+  },
+  {
+    "word": "lion",
+    "definition": "A large wild cat",
+    "sentence": "The lion roared loudly.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "li-on",
+    "phonetic": "LI-on"
+  },
+  {
+    "word": "milk",
+    "definition": "White liquid from cows",
+    "sentence": "Milk is good for your bones.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "milk",
+    "phonetic": "MILK"
+  },
+  {
+    "word": "moon",
+    "definition": "Object that orbits the Earth",
+    "sentence": "The full moon shines at night.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "moon",
+    "phonetic": "MOON"
+  },
+  {
+    "word": "mouse",
+    "definition": "A small rodent",
+    "sentence": "The mouse ran into a hole.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "mouse",
+    "phonetic": "MOUSE"
+  },
+  {
+    "word": "nest",
+    "definition": "A home built by a bird",
+    "sentence": "There are three eggs in the nest.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "nest",
+    "phonetic": "NEST"
+  },
+  {
+    "word": "nose",
+    "definition": "Body part used for smelling",
+    "sentence": "My nose is cold.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "nose",
+    "phonetic": "NOSE"
+  },
+  {
+    "word": "park",
+    "definition": "Public land for recreation",
+    "sentence": "We played soccer at the park.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "park",
+    "phonetic": "PARK"
+  },
+  {
+    "word": "pig",
+    "definition": "A farm animal with a pink snout",
+    "sentence": "The pig played in the mud.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "pig",
+    "phonetic": "PIG"
+  },
+  {
+    "word": "rain",
+    "definition": "Water falling from clouds",
+    "sentence": "Take an umbrella in the rain.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "rain",
+    "phonetic": "RAIN"
+  },
+  {
+    "word": "ring",
+    "definition": "A circular band worn on a finger",
+    "sentence": "She lost her gold ring.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "ring",
+    "phonetic": "RING"
+  },
+  {
+    "word": "road",
+    "definition": "A hard surface for vehicles",
+    "sentence": "Look both ways before crossing the road.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "road",
+    "phonetic": "ROAD"
+  },
+  {
+    "word": "room",
+    "definition": "A space inside a building",
+    "sentence": "My room is very messy.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "room",
+    "phonetic": "ROOM"
+  },
+  {
+    "word": "shoe",
+    "definition": "Footwear",
+    "sentence": "Tie your shoe lace.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "shoe",
+    "phonetic": "SHOE"
+  },
+  {
+    "word": "snow",
+    "definition": "Frozen white rain",
+    "sentence": "The snow covered the ground.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "snow",
+    "phonetic": "SNOW"
+  },
+  {
+    "word": "star",
+    "definition": "A bright point in the night sky",
+    "sentence": "Make a wish on a falling star.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "star",
+    "phonetic": "STAR"
+  },
+  {
+    "word": "sun",
+    "definition": "The star that warms the Earth",
+    "sentence": "The sun rises in the east.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "sun",
+    "phonetic": "SUN"
+  },
+  {
+    "word": "acorn",
+    "definition": "The nut of an oak tree",
+    "sentence": "A squirrel carried the acorn up the tree.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "a-corn",
+    "phonetic": "A-corn"
+  },
+  {
+    "word": "bubble",
+    "definition": "A thin sphere of liquid filled with air",
+    "sentence": "The bubble floated and popped.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "bub-ble",
+    "phonetic": "BUB-ble"
+  },
+  {
+    "word": "cabin",
+    "definition": "A small simple house, often in the woods",
+    "sentence": "They stayed in a cozy cabin by the lake.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "cab-in",
+    "phonetic": "CAB-in"
+  },
+  {
+    "word": "lantern",
+    "definition": "A portable light with a protective cover",
+    "sentence": "We carried a lantern on the evening walk.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "lan-tern",
+    "phonetic": "LAN-tern"
+  },
+  {
+    "word": "igloo",
+    "definition": "A dome-shaped shelter made of snow blocks",
+    "sentence": "The picture book showed an igloo in winter.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "ig-loo",
+    "phonetic": "IG-loo"
+  },
+  {
+    "word": "glove",
+    "definition": "A hand covering with finger sections",
+    "sentence": "She wore one warm glove on each hand.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "glove",
+    "phonetic": "GLOVE"
+  },
+  {
+    "word": "meadow",
+    "definition": "A grassy field",
+    "sentence": "Wildflowers bloomed in the meadow.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "mead-ow",
+    "phonetic": "MEAD-ow"
+  },
+  {
+    "word": "pebble",
+    "definition": "A small smooth stone",
+    "sentence": "He skipped a pebble across the pond.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "peb-ble",
+    "phonetic": "PEB-ble"
+  },
+  {
+    "word": "thunder",
+    "definition": "The loud sound during a storm",
+    "sentence": "Thunder rumbled in the distance.",
+    "grade": 1,
+    "difficulty": "easy",
+    "syllables": "thun-der",
+    "phonetic": "THUN-der"
+  },
+  {
+    "word": "basket",
+    "definition": "A container woven from strips",
+    "sentence": "She carried apples in a basket.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "bas-ket",
+    "phonetic": "BAS-ket"
+  },
+  {
+    "word": "blanket",
+    "definition": "A warm cover for a bed",
+    "sentence": "I pulled the blanket up to my chin.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "blan-ket",
+    "phonetic": "BLAN-ket"
+  },
+  {
+    "word": "branch",
+    "definition": "A part of a tree that grows from the trunk",
+    "sentence": "A bird landed on the branch.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "branch",
+    "phonetic": "BRANCH"
+  },
+  {
+    "word": "cactus",
+    "definition": "A desert plant with spines",
+    "sentence": "The cactus needs very little water.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "cac-tus",
+    "phonetic": "CAC-tus"
+  },
+  {
+    "word": "dragon",
+    "definition": "A large mythical creature",
+    "sentence": "The storybook dragon guarded a cave.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "drag-on",
+    "phonetic": "DRAG-on"
+  },
+  {
+    "word": "frozen",
+    "definition": "Turned into ice by cold",
+    "sentence": "The pond was frozen this morning.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "fro-zen",
+    "phonetic": "FRO-zen"
+  },
+  {
+    "word": "gardenia",
+    "definition": "A fragrant white flower",
+    "sentence": "A gardenia bloomed near the porch.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "gar-de-ni-a",
+    "phonetic": "GAR-de-ni-a"
+  },
+  {
+    "word": "helmet",
+    "definition": "A hard hat for protection",
+    "sentence": "Wear your helmet when riding a bike.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "hel-met",
+    "phonetic": "HEL-met"
+  },
+  {
+    "word": "kittenish",
+    "definition": "Playful like a kitten",
+    "sentence": "The puppy made kittenish jumps around us.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "kit-ten-ish",
+    "phonetic": "KIT-ten-ish"
+  },
+  {
+    "word": "magnet",
+    "definition": "An object that attracts iron",
+    "sentence": "The magnet pulled the paper clips close.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "mag-net",
+    "phonetic": "MAG-net"
+  },
+  {
+    "word": "napkin",
+    "definition": "A cloth or paper used at meals",
+    "sentence": "Put the napkin on your lap.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "nap-kin",
+    "phonetic": "NAP-kin"
+  },
+  {
+    "word": "planet",
+    "definition": "A large body orbiting a star",
+    "sentence": "Earth is the planet we live on.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "plan-et",
+    "phonetic": "PLAN-et"
+  },
+  {
+    "word": "rocket",
+    "definition": "A vehicle that can travel into space",
+    "sentence": "The toy rocket zoomed across the room.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "rock-et",
+    "phonetic": "ROCK-et"
+  },
+  {
+    "word": "splash",
+    "definition": "The sound or act of water striking",
+    "sentence": "The duck made a big splash.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "splash",
+    "phonetic": "SPLASH"
+  },
+  {
+    "word": "trumpet",
+    "definition": "A brass musical instrument",
+    "sentence": "He practiced trumpet in band class.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "trum-pet",
+    "phonetic": "TRUM-pet"
+  },
+  {
+    "word": "window",
+    "definition": "An opening in a wall with glass",
+    "sentence": "Rain tapped on the window.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "win-dow",
+    "phonetic": "WIN-dow"
+  },
+  {
+    "word": "yellowish",
+    "definition": "Slightly yellow in color",
+    "sentence": "The old paper looked yellowish.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "yel-low-ish",
+    "phonetic": "YEL-low-ish"
+  },
+  {
+    "word": "zigzag",
+    "definition": "A pattern with sharp turns",
+    "sentence": "The path made a zigzag up the hill.",
+    "grade": 1,
+    "difficulty": "medium",
+    "syllables": "zig-zag",
+    "phonetic": "ZIG-zag"
+  },
+  {
+    "word": "adventure",
+    "definition": "An exciting experience",
+    "sentence": "Our camping trip was a big adventure.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "ad-ven-ture",
+    "phonetic": "AD-ven-ture"
+  },
+  {
+    "word": "butterfly",
+    "definition": "An insect with colorful wings",
+    "sentence": "A butterfly landed on the flower.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "but-ter-fly",
+    "phonetic": "BUT-ter-fly"
+  },
+  {
+    "word": "chocolate",
+    "definition": "A sweet food made from cocoa",
+    "sentence": "She shared a piece of chocolate.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "choc-o-late",
+    "phonetic": "CHOC-o-late"
+  },
+  {
+    "word": "dinosaur",
+    "definition": "A prehistoric reptile",
+    "sentence": "The dinosaur exhibit was my favorite.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "di-no-saur",
+    "phonetic": "DI-no-saur"
+  },
+  {
+    "word": "elephant",
+    "definition": "A very large animal with a trunk",
+    "sentence": "The elephant sprayed water on itself.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "el-e-phant",
+    "phonetic": "EL-e-phant"
+  },
+  {
+    "word": "fireworks",
+    "definition": "Exploding lights in the sky",
+    "sentence": "We watched fireworks on the holiday.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "fire-works",
+    "phonetic": "FIRE-works"
+  },
+  {
+    "word": "giraffe",
+    "definition": "A tall animal with a long neck",
+    "sentence": "The giraffe reached the highest leaves.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "gi-raffe",
+    "phonetic": "GI-raffe"
+  },
+  {
+    "word": "hamburger",
+    "definition": "A sandwich with a cooked patty",
+    "sentence": "He ordered a hamburger for lunch.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "ham-bur-ger",
+    "phonetic": "HAM-bur-ger"
+  },
+  {
+    "word": "important",
+    "definition": "Having great value or meaning",
+    "sentence": "It is important to be kind to others.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "im-por-tant",
+    "phonetic": "IM-por-tant"
+  },
+  {
+    "word": "jellyfish",
+    "definition": "A sea animal with soft body",
+    "sentence": "A jellyfish drifted near the shore.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "jel-ly-fish",
+    "phonetic": "JEL-ly-fish"
+  },
+  {
+    "word": "kangaroo",
+    "definition": "A hopping animal from Australia",
+    "sentence": "The kangaroo carried a joey in its pouch.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "kan-ga-roo",
+    "phonetic": "KAN-ga-roo"
+  },
+  {
+    "word": "lighthouse",
+    "definition": "A tower with a bright warning light",
+    "sentence": "The lighthouse guided ships at night.",
+    "grade": 1,
+    "difficulty": "hard",
+    "syllables": "light-house",
+    "phonetic": "LIGHT-house"
+  }
+]

--- a/public/data/words/grade-3.json
+++ b/public/data/words/grade-3.json
@@ -1,963 +1,920 @@
-{
-  "grade": 3,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 106,
-  "words": [
-    {
-      "word": "elephant",
-      "definition": "A large mammal with a trunk",
-      "example": "The elephant sprayed water with its trunk.",
-      "phonetic": "EL-e-phant",
-      "syllables": "el-e-phant",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "island",
-      "definition": "Land surrounded by water",
-      "example": "They sailed to a small island.",
-      "phonetic": "IS-land",
-      "syllables": "is-land",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "jungle",
-      "definition": "Dense tropical forest",
-      "example": "The explorer ventured into the jungle.",
-      "phonetic": "JUN-gle",
-      "syllables": "jun-gle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "night",
-      "definition": "The period of darkness",
-      "example": "Stars appeared in the night sky.",
-      "phonetic": "NIGHT",
-      "syllables": "night",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "orange",
-      "definition": "A round citrus fruit",
-      "example": "He peeled an orange for breakfast.",
-      "phonetic": "OR-ange",
-      "syllables": "or-ange",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "beautiful",
-      "definition": "Pleasing to the senses",
-      "example": "The sunset was absolutely beautiful.",
-      "phonetic": "BEAU-ti-ful",
-      "syllables": "beau-ti-ful",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "calendar",
-      "definition": "A system for organizing days",
-      "example": "Mark the date on your calendar.",
-      "phonetic": "CAL-en-dar",
-      "syllables": "cal-en-dar",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dinosaur",
-      "definition": "An extinct prehistoric reptile",
-      "example": "The museum had a dinosaur skeleton.",
-      "phonetic": "DI-no-saur",
-      "syllables": "di-no-saur",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "emergency",
-      "definition": "A serious unexpected situation",
-      "example": "Call 911 in case of emergency.",
-      "phonetic": "E-mer-gen-cy",
-      "syllables": "e-mer-gen-cy",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "february",
-      "definition": "The second month of the year",
-      "example": "February is the shortest month.",
-      "phonetic": "FEB-ru-ar-y",
-      "syllables": "feb-ru-ar-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "government",
-      "definition": "The ruling body of a nation",
-      "example": "The government passed new legislation.",
-      "phonetic": "GOV-ern-ment",
-      "syllables": "gov-ern-ment",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "hamburger",
-      "definition": "A sandwich with a meat patty",
-      "example": "I ordered a hamburger with fries.",
-      "phonetic": "HAM-bur-ger",
-      "syllables": "ham-bur-ger",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "immediately",
-      "definition": "Without delay",
-      "example": "Please respond immediately.",
-      "phonetic": "IM-me-di-ate-ly",
-      "syllables": "im-me-di-ate-ly",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "jealousy",
-      "definition": "Feeling of envy",
-      "example": "Jealousy can damage relationships.",
-      "phonetic": "JEAL-ous-y",
-      "syllables": "jeal-ous-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "knowledge",
-      "definition": "Information and understanding",
-      "example": "Knowledge is power.",
-      "phonetic": "KNOWL-edge",
-      "syllables": "knowl-edge",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "lieutenant",
-      "definition": "A military rank",
-      "example": "The lieutenant led the platoon.",
-      "phonetic": "LIEU-ten-ant",
-      "syllables": "lieu-ten-ant",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "mysterious",
-      "definition": "Difficult to understand",
-      "example": "A mysterious package arrived.",
-      "phonetic": "MYS-te-ri-ous",
-      "syllables": "mys-te-ri-ous",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "necessary",
-      "definition": "Required or essential",
-      "example": "Water is necessary for life.",
-      "phonetic": "NEC-es-sar-y",
-      "syllables": "nec-es-sar-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "occasion",
-      "definition": "A special event or time",
-      "example": "This is a special occasion.",
-      "phonetic": "OC-ca-sion",
-      "syllables": "oc-ca-sion",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "psychology",
-      "definition": "The study of the mind",
-      "example": "She studied psychology in college.",
-      "phonetic": "PSY-chol-o-gy",
-      "syllables": "psy-chol-o-gy",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "questionnaire",
-      "definition": "A set of written questions",
-      "example": "Please complete this questionnaire.",
-      "phonetic": "QUES-tion-naire",
-      "syllables": "ques-tion-naire",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "restaurant",
-      "definition": "A place to eat meals",
-      "example": "We dined at an Italian restaurant.",
-      "phonetic": "RES-tau-rant",
-      "syllables": "res-tau-rant",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "adventure",
-      "definition": "An exciting or unusual experience",
-      "example": "They went on an adventure in the woods.",
-      "phonetic": "AD-ven-ture",
-      "syllables": "ad-ven-ture",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "alphabet",
-      "definition": "The letters of a language",
-      "example": "She learned to sing the alphabet song.",
-      "phonetic": "AL-pha-bet",
-      "syllables": "al-pha-bet",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "apartment",
-      "definition": "A set of rooms for living in",
-      "example": "We live in an apartment on the third floor.",
-      "phonetic": "A-part-ment",
-      "syllables": "a-part-ment",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "astronaut",
-      "definition": "A person trained to travel in space",
-      "example": "The astronaut walked on the moon.",
-      "phonetic": "AS-tro-naut",
-      "syllables": "as-tro-naut",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "autumn",
-      "definition": "The season after summer",
-      "example": "Leaves turn colors in autumn.",
-      "phonetic": "AU-tumn",
-      "syllables": "au-tumn",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bakery",
-      "definition": "A place where bread and cakes are made",
-      "example": "We bought fresh donuts at the bakery.",
-      "phonetic": "BAK-er-y",
-      "syllables": "bak-er-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "balcony",
-      "definition": "A platform on the outside of a building",
-      "example": "She stood on the balcony to watch the parade.",
-      "phonetic": "BAL-co-ny",
-      "syllables": "bal-co-ny",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "banana",
-      "definition": "A long curved yellow fruit",
-      "example": "Monkeys love to eat a banana.",
-      "phonetic": "BA-nan-a",
-      "syllables": "ba-nan-a",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "basket",
-      "definition": "A container woven from cane or wire",
-      "example": "Put the apples in the basket.",
-      "phonetic": "BAS-ket",
-      "syllables": "bas-ket",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "blanket",
-      "definition": "A soft covering for a bed",
-      "example": "The baby was wrapped in a warm blanket.",
-      "phonetic": "BLAN-ket",
-      "syllables": "blan-ket",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bottle",
-      "definition": "A container with a narrow neck",
-      "example": "He drank water from a plastic bottle.",
-      "phonetic": "BOT-tle",
-      "syllables": "bot-tle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bridge",
-      "definition": "A structure across a river or road",
-      "example": "Cars drove over the bridge.",
-      "phonetic": "BRIDGE",
-      "syllables": "bridge",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "camera",
-      "definition": "A device for taking photos",
-      "example": "Smile for the camera!",
-      "phonetic": "CAM-er-a",
-      "syllables": "cam-er-a",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "candle",
-      "definition": "Wax with a wick that burns",
-      "example": "She blew out the candle on her cake.",
-      "phonetic": "CAN-dle",
-      "syllables": "can-dle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "castle",
-      "definition": "A large fortified building",
-      "example": "The king lived in a stone castle.",
-      "phonetic": "CAS-tle",
-      "syllables": "cas-tle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "caterpillar",
-      "definition": "The larva of a butterfly",
-      "example": "The caterpillar will become a butterfly.",
-      "phonetic": "CAT-er-pil-lar",
-      "syllables": "cat-er-pil-lar",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "chocolate",
-      "definition": "A sweet food made from cacao",
-      "example": "I love dark chocolate.",
-      "phonetic": "CHOC-o-late",
-      "syllables": "choc-o-late",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "circle",
-      "definition": "A round shape",
-      "example": "Draw a circle on the paper.",
-      "phonetic": "CIR-cle",
-      "syllables": "cir-cle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "coffee",
-      "definition": "A hot drink made from roasted beans",
-      "example": "Dad drinks coffee in the morning.",
-      "phonetic": "COF-fee",
-      "syllables": "cof-fee",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "computer",
-      "definition": "An electronic device for processing data",
-      "example": "I use the computer for homework.",
-      "phonetic": "COM-put-er",
-      "syllables": "com-put-er",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "continent",
-      "definition": "A large continuous mass of land",
-      "example": "Africa is a large continent.",
-      "phonetic": "CON-ti-nent",
-      "syllables": "con-ti-nent",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "cucumber",
-      "definition": "A long green vegetable",
-      "example": "She added sliced cucumber to the salad.",
-      "phonetic": "CU-cum-ber",
-      "syllables": "cu-cum-ber",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "curtain",
-      "definition": "Cloth hung to cover a window",
-      "example": "Close the curtain to block the sun.",
-      "phonetic": "CUR-tain",
-      "syllables": "cur-tain",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dangerous",
-      "definition": "Likely to cause harm",
-      "example": "It is dangerous to play in the street.",
-      "phonetic": "DAN-ger-ous",
-      "syllables": "dan-ger-ous",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "daughter",
-      "definition": "A female child",
-      "example": "She is her mother's daughter.",
-      "phonetic": "DAUGH-ter",
-      "syllables": "daugh-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dentist",
-      "definition": "A doctor for teeth",
-      "example": "The dentist checked for cavities.",
-      "phonetic": "DEN-tist",
-      "syllables": "den-tist",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "diamond",
-      "definition": "A precious clear stone",
-      "example": "Her ring has a sparkling diamond.",
-      "phonetic": "DI-a-mond",
-      "syllables": "di-a-mond",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "difficult",
-      "definition": "Hard to do or understand",
-      "example": "The math problem was very difficult.",
-      "phonetic": "DIF-fi-cult",
-      "syllables": "dif-fi-cult",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "direction",
-      "definition": "The path something moves along",
-      "example": "Which direction is north?",
-      "phonetic": "DI-rec-tion",
-      "syllables": "di-rec-tion",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "doctor",
-      "definition": "A person who treats sick people",
-      "example": "The doctor gave me medicine.",
-      "phonetic": "DOC-tor",
-      "syllables": "doc-tor",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dolphin",
-      "definition": "A smart marine mammal",
-      "example": "The dolphin jumped out of the water.",
-      "phonetic": "DOL-phin",
-      "syllables": "dol-phin",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dragon",
-      "definition": "A mythical fire-breathing monster",
-      "example": "The knight fought the dragon.",
-      "phonetic": "DRAG-on",
-      "syllables": "drag-on",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "elevator",
-      "definition": "A machine for lifting people",
-      "example": "Take the elevator to the tenth floor.",
-      "phonetic": "EL-e-va-tor",
-      "syllables": "el-e-va-tor",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "engine",
-      "definition": "A machine with moving parts",
-      "example": "The car engine is running.",
-      "phonetic": "EN-gine",
-      "syllables": "en-gine",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "envelope",
-      "definition": "A paper container for a letter",
-      "example": "Put the stamp on the envelope.",
-      "phonetic": "EN-ve-lope",
-      "syllables": "en-ve-lope",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "exercise",
-      "definition": "Physical activity",
-      "example": "Running is good exercise.",
-      "phonetic": "EX-er-cise",
-      "syllables": "ex-er-cise",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "factory",
-      "definition": "A place where goods are made",
-      "example": "Cars are built in a factory.",
-      "phonetic": "FAC-to-ry",
-      "syllables": "fac-to-ry",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "family",
-      "definition": "Parents and children",
-      "example": "My family likes to go camping.",
-      "phonetic": "FAM-i-ly",
-      "syllables": "fam-i-ly",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "feather",
-      "definition": "Light growth covering a bird",
-      "example": "The feather floated to the ground.",
-      "phonetic": "FEATH-er",
-      "syllables": "feath-er",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "festival",
-      "definition": "A day or period of celebration",
-      "example": "We danced at the music festival.",
-      "phonetic": "FES-ti-val",
-      "syllables": "fes-ti-val",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "fingerprint",
-      "definition": "The mark left by a finger",
-      "example": "Everyone has a unique fingerprint.",
-      "phonetic": "FIN-ger-print",
-      "syllables": "fin-ger-print",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "fireplace",
-      "definition": "A place for a fire in a house",
-      "example": "We sat by the warm fireplace.",
-      "phonetic": "FIRE-place",
-      "syllables": "fire-place",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "forest",
-      "definition": "A large area of trees",
-      "example": "Animals hide in the forest.",
-      "phonetic": "FOR-est",
-      "syllables": "for-est",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "furniture",
-      "definition": "Movable items like chairs and tables",
-      "example": "We bought new furniture for the living room.",
-      "phonetic": "FUR-ni-ture",
-      "syllables": "fur-ni-ture",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "galaxy",
-      "definition": "A huge system of stars",
-      "example": "The Milky Way is our galaxy.",
-      "phonetic": "GAL-ax-y",
-      "syllables": "gal-ax-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "garage",
-      "definition": "A building for parking cars",
-      "example": "Park the car in the garage.",
-      "phonetic": "GA-rage",
-      "syllables": "ga-rage",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "geography",
-      "definition": "Study of the earth's surface",
-      "example": "We learned about maps in geography.",
-      "phonetic": "GE-og-ra-phy",
-      "syllables": "ge-og-ra-phy",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "giraffe",
-      "definition": "A tall animal with a long neck",
-      "example": "The giraffe ate leaves from the tall tree.",
-      "phonetic": "GI-raffe",
-      "syllables": "gi-raffe",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "glasses",
-      "definition": "Lenses worn to help see",
-      "example": "He needs glasses to read.",
-      "phonetic": "GLASS-es",
-      "syllables": "glass-es",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "guitar",
-      "definition": "A stringed musical instrument",
-      "example": "She played a song on her guitar.",
-      "phonetic": "GUI-tar",
-      "syllables": "gui-tar",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "helicopter",
-      "definition": "A type of aircraft",
-      "example": "The helicopter landed on the roof.",
-      "phonetic": "HEL-i-cop-ter",
-      "syllables": "hel-i-cop-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "holiday",
-      "definition": "A day of celebration",
-      "example": "Christmas is my favorite holiday.",
-      "phonetic": "HOL-i-day",
-      "syllables": "hol-i-day",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "hospital",
-      "definition": "A place for medical treatment",
-      "example": "The ambulance went to the hospital.",
-      "phonetic": "HOS-pi-tal",
-      "syllables": "hos-pi-tal",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "hurricane",
-      "definition": "A violent tropical storm",
-      "example": "The hurricane brought strong winds.",
-      "phonetic": "HUR-ri-cane",
-      "syllables": "hur-ri-cane",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "instrument",
-      "definition": "A tool or device for music",
-      "example": "Which musical instrument do you play?",
-      "phonetic": "IN-stru-ment",
-      "syllables": "in-stru-ment",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "backpack",
-      "definition": "A bag carried on the back",
-      "example": "He packed his backpack for school.",
-      "phonetic": "BACK-pack",
-      "syllables": "back-pack",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "celebrate",
-      "definition": "To honor a special event",
-      "example": "We celebrate birthdays with cake.",
-      "phonetic": "CEL-e-brate",
-      "syllables": "cel-e-brate",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "disappear",
-      "definition": "To vanish from sight",
-      "example": "The rabbit seemed to disappear.",
-      "phonetic": "DIS-ap-pear",
-      "syllables": "dis-ap-pear",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "favorite",
-      "definition": "Preferred above all others",
-      "example": "Purple is my favorite color.",
-      "phonetic": "FA-vor-ite",
-      "syllables": "fa-vor-ite",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "horizon",
-      "definition": "The line where earth and sky appear to meet",
-      "example": "The sun sank below the horizon.",
-      "phonetic": "HO-ri-zon",
-      "syllables": "ho-ri-zon",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "laughter",
-      "definition": "The sound of laughing",
-      "example": "The room filled with laughter.",
-      "phonetic": "LAUGH-ter",
-      "syllables": "laugh-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "question",
-      "definition": "A sentence asked to get information",
-      "example": "She raised her hand to ask a question.",
-      "phonetic": "QUES-tion",
-      "syllables": "ques-tion",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "shelter",
-      "definition": "A place that gives protection",
-      "example": "The hikers found shelter from the rain.",
-      "phonetic": "SHEL-ter",
-      "syllables": "shel-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "whisper",
-      "definition": "To speak very softly",
-      "example": "Please whisper in the library.",
-      "phonetic": "WHIS-per",
-      "syllables": "whis-per",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "breeze",
-      "definition": "A gentle wind",
-      "example": "A cool breeze blew across the field.",
-      "phonetic": "BREE-ze",
-      "syllables": "bree-ze",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "candle",
-      "definition": "A stick of wax with a wick",
-      "example": "We lit a candle during the power outage.",
-      "phonetic": "CAN-dle",
-      "syllables": "can-dle",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "forest",
-      "definition": "A large area covered with trees",
-      "example": "We hiked through the forest trail.",
-      "phonetic": "FOR-est",
-      "syllables": "for-est",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "guitar",
-      "definition": "A stringed musical instrument",
-      "example": "She practiced guitar after school.",
-      "phonetic": "GUI-tar",
-      "syllables": "gui-tar",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "harbor",
-      "definition": "A sheltered place for ships",
-      "example": "Fishing boats returned to the harbor.",
-      "phonetic": "HAR-bor",
-      "syllables": "har-bor",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "kitten",
-      "definition": "A young cat",
-      "example": "The kitten chased a ball of yarn.",
-      "phonetic": "KIT-ten",
-      "syllables": "kit-ten",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "ladder",
-      "definition": "A tool with steps for climbing",
-      "example": "He used a ladder to reach the shelf.",
-      "phonetic": "LAD-der",
-      "syllables": "lad-der",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "marble",
-      "definition": "A small glass ball used in games",
-      "example": "I found a blue marble on the playground.",
-      "phonetic": "MAR-ble",
-      "syllables": "mar-ble",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "nectar",
-      "definition": "Sweet liquid in flowers",
-      "example": "Bees collect nectar from bright flowers.",
-      "phonetic": "NEC-tar",
-      "syllables": "nec-tar",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "ocean",
-      "definition": "A vast body of salt water",
-      "example": "The ocean waves crashed on the shore.",
-      "phonetic": "O-cean",
-      "syllables": "o-cean",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "pencil",
-      "definition": "A tool for writing or drawing",
-      "example": "Sharpen your pencil before the quiz.",
-      "phonetic": "PEN-cil",
-      "syllables": "pen-cil",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "quartz",
-      "definition": "A hard mineral found in rocks",
-      "example": "This rock has shiny pieces of quartz.",
-      "phonetic": "QUARTZ",
-      "syllables": "quartz",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "rocket",
-      "definition": "A vehicle that travels into space",
-      "example": "The rocket launched with a loud roar.",
-      "phonetic": "ROCK-et",
-      "syllables": "rock-et",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "sunset",
-      "definition": "The daily disappearance of the sun",
-      "example": "We watched the sunset turn the sky orange.",
-      "phonetic": "SUN-set",
-      "syllables": "sun-set",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "ticket",
-      "definition": "A pass that allows entry",
-      "example": "Keep your ticket for the school play.",
-      "phonetic": "TICK-et",
-      "syllables": "tick-et",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "vacuum",
-      "definition": "A machine that cleans floors",
-      "example": "Dad used the vacuum in the living room.",
-      "phonetic": "VAC-u-um",
-      "syllables": "vac-u-um",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "window",
-      "definition": "An opening in a wall with glass",
-      "example": "Please open the window for fresh air.",
-      "phonetic": "WIN-dow",
-      "syllables": "win-dow",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "yellow",
-      "definition": "A bright color like the sun",
-      "example": "Her backpack is yellow and easy to spot.",
-      "phonetic": "YEL-low",
-      "syllables": "yel-low",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "zigzag",
-      "definition": "A line with sharp turns",
-      "example": "The skier made a zigzag down the hill.",
-      "phonetic": "ZIG-zag",
-      "syllables": "zig-zag",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bridge",
-      "definition": "A structure built over water or roads",
-      "example": "We crossed the bridge on our bike ride.",
-      "phonetic": "BRIDGE",
-      "syllables": "bridge",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    }
-  ]
-}
+[
+  {
+    "word": "elephant",
+    "definition": "A large mammal with a trunk",
+    "sentence": "The elephant sprayed water with its trunk.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "el-e-phant",
+    "phonetic": "EL-e-phant"
+  },
+  {
+    "word": "island",
+    "definition": "Land surrounded by water",
+    "sentence": "They sailed to a small island.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "is-land",
+    "phonetic": "IS-land"
+  },
+  {
+    "word": "jungle",
+    "definition": "Dense tropical forest",
+    "sentence": "The explorer ventured into the jungle.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "jun-gle",
+    "phonetic": "JUN-gle"
+  },
+  {
+    "word": "night",
+    "definition": "The period of darkness",
+    "sentence": "Stars appeared in the night sky.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "night",
+    "phonetic": "NIGHT"
+  },
+  {
+    "word": "orange",
+    "definition": "A round citrus fruit",
+    "sentence": "He peeled an orange for breakfast.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "or-ange",
+    "phonetic": "OR-ange"
+  },
+  {
+    "word": "beautiful",
+    "definition": "Pleasing to the senses",
+    "sentence": "The sunset was absolutely beautiful.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "beau-ti-ful",
+    "phonetic": "BEAU-ti-ful"
+  },
+  {
+    "word": "calendar",
+    "definition": "A system for organizing days",
+    "sentence": "Mark the date on your calendar.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cal-en-dar",
+    "phonetic": "CAL-en-dar"
+  },
+  {
+    "word": "dinosaur",
+    "definition": "An extinct prehistoric reptile",
+    "sentence": "The museum had a dinosaur skeleton.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "di-no-saur",
+    "phonetic": "DI-no-saur"
+  },
+  {
+    "word": "emergency",
+    "definition": "A serious unexpected situation",
+    "sentence": "Call 911 in case of emergency.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "e-mer-gen-cy",
+    "phonetic": "E-mer-gen-cy"
+  },
+  {
+    "word": "february",
+    "definition": "The second month of the year",
+    "sentence": "February is the shortest month.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "feb-ru-ar-y",
+    "phonetic": "FEB-ru-ar-y"
+  },
+  {
+    "word": "government",
+    "definition": "The ruling body of a nation",
+    "sentence": "The government passed new legislation.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gov-ern-ment",
+    "phonetic": "GOV-ern-ment"
+  },
+  {
+    "word": "hamburger",
+    "definition": "A sandwich with a meat patty",
+    "sentence": "I ordered a hamburger with fries.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ham-bur-ger",
+    "phonetic": "HAM-bur-ger"
+  },
+  {
+    "word": "immediately",
+    "definition": "Without delay",
+    "sentence": "Please respond immediately.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "im-me-di-ate-ly",
+    "phonetic": "IM-me-di-ate-ly"
+  },
+  {
+    "word": "jealousy",
+    "definition": "Feeling of envy",
+    "sentence": "Jealousy can damage relationships.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "jeal-ous-y",
+    "phonetic": "JEAL-ous-y"
+  },
+  {
+    "word": "knowledge",
+    "definition": "Information and understanding",
+    "sentence": "Knowledge is power.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "knowl-edge",
+    "phonetic": "KNOWL-edge"
+  },
+  {
+    "word": "lieutenant",
+    "definition": "A military rank",
+    "sentence": "The lieutenant led the platoon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "lieu-ten-ant",
+    "phonetic": "LIEU-ten-ant"
+  },
+  {
+    "word": "mysterious",
+    "definition": "Difficult to understand",
+    "sentence": "A mysterious package arrived.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "mys-te-ri-ous",
+    "phonetic": "MYS-te-ri-ous"
+  },
+  {
+    "word": "necessary",
+    "definition": "Required or essential",
+    "sentence": "Water is necessary for life.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "nec-es-sar-y",
+    "phonetic": "NEC-es-sar-y"
+  },
+  {
+    "word": "occasion",
+    "definition": "A special event or time",
+    "sentence": "This is a special occasion.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "oc-ca-sion",
+    "phonetic": "OC-ca-sion"
+  },
+  {
+    "word": "psychology",
+    "definition": "The study of the mind",
+    "sentence": "She studied psychology in college.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "psy-chol-o-gy",
+    "phonetic": "PSY-chol-o-gy"
+  },
+  {
+    "word": "questionnaire",
+    "definition": "A set of written questions",
+    "sentence": "Please complete this questionnaire.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ques-tion-naire",
+    "phonetic": "QUES-tion-naire"
+  },
+  {
+    "word": "restaurant",
+    "definition": "A place to eat meals",
+    "sentence": "We dined at an Italian restaurant.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "res-tau-rant",
+    "phonetic": "RES-tau-rant"
+  },
+  {
+    "word": "adventure",
+    "definition": "An exciting or unusual experience",
+    "sentence": "They went on an adventure in the woods.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ad-ven-ture",
+    "phonetic": "AD-ven-ture"
+  },
+  {
+    "word": "alphabet",
+    "definition": "The letters of a language",
+    "sentence": "She learned to sing the alphabet song.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "al-pha-bet",
+    "phonetic": "AL-pha-bet"
+  },
+  {
+    "word": "apartment",
+    "definition": "A set of rooms for living in",
+    "sentence": "We live in an apartment on the third floor.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "a-part-ment",
+    "phonetic": "A-part-ment"
+  },
+  {
+    "word": "astronaut",
+    "definition": "A person trained to travel in space",
+    "sentence": "The astronaut walked on the moon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "as-tro-naut",
+    "phonetic": "AS-tro-naut"
+  },
+  {
+    "word": "autumn",
+    "definition": "The season after summer",
+    "sentence": "Leaves turn colors in autumn.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "au-tumn",
+    "phonetic": "AU-tumn"
+  },
+  {
+    "word": "bakery",
+    "definition": "A place where bread and cakes are made",
+    "sentence": "We bought fresh donuts at the bakery.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bak-er-y",
+    "phonetic": "BAK-er-y"
+  },
+  {
+    "word": "balcony",
+    "definition": "A platform on the outside of a building",
+    "sentence": "She stood on the balcony to watch the parade.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bal-co-ny",
+    "phonetic": "BAL-co-ny"
+  },
+  {
+    "word": "banana",
+    "definition": "A long curved yellow fruit",
+    "sentence": "Monkeys love to eat a banana.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ba-nan-a",
+    "phonetic": "BA-nan-a"
+  },
+  {
+    "word": "basket",
+    "definition": "A container woven from cane or wire",
+    "sentence": "Put the apples in the basket.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bas-ket",
+    "phonetic": "BAS-ket"
+  },
+  {
+    "word": "blanket",
+    "definition": "A soft covering for a bed",
+    "sentence": "The baby was wrapped in a warm blanket.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "blan-ket",
+    "phonetic": "BLAN-ket"
+  },
+  {
+    "word": "bottle",
+    "definition": "A container with a narrow neck",
+    "sentence": "He drank water from a plastic bottle.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bot-tle",
+    "phonetic": "BOT-tle"
+  },
+  {
+    "word": "bridge",
+    "definition": "A structure across a river or road",
+    "sentence": "Cars drove over the bridge.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bridge",
+    "phonetic": "BRIDGE"
+  },
+  {
+    "word": "camera",
+    "definition": "A device for taking photos",
+    "sentence": "Smile for the camera!",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cam-er-a",
+    "phonetic": "CAM-er-a"
+  },
+  {
+    "word": "candle",
+    "definition": "Wax with a wick that burns",
+    "sentence": "She blew out the candle on her cake.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "can-dle",
+    "phonetic": "CAN-dle"
+  },
+  {
+    "word": "castle",
+    "definition": "A large fortified building",
+    "sentence": "The king lived in a stone castle.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cas-tle",
+    "phonetic": "CAS-tle"
+  },
+  {
+    "word": "caterpillar",
+    "definition": "The larva of a butterfly",
+    "sentence": "The caterpillar will become a butterfly.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cat-er-pil-lar",
+    "phonetic": "CAT-er-pil-lar"
+  },
+  {
+    "word": "chocolate",
+    "definition": "A sweet food made from cacao",
+    "sentence": "I love dark chocolate.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "choc-o-late",
+    "phonetic": "CHOC-o-late"
+  },
+  {
+    "word": "circle",
+    "definition": "A round shape",
+    "sentence": "Draw a circle on the paper.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cir-cle",
+    "phonetic": "CIR-cle"
+  },
+  {
+    "word": "coffee",
+    "definition": "A hot drink made from roasted beans",
+    "sentence": "Dad drinks coffee in the morning.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cof-fee",
+    "phonetic": "COF-fee"
+  },
+  {
+    "word": "computer",
+    "definition": "An electronic device for processing data",
+    "sentence": "I use the computer for homework.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "com-put-er",
+    "phonetic": "COM-put-er"
+  },
+  {
+    "word": "continent",
+    "definition": "A large continuous mass of land",
+    "sentence": "Africa is a large continent.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "con-ti-nent",
+    "phonetic": "CON-ti-nent"
+  },
+  {
+    "word": "cucumber",
+    "definition": "A long green vegetable",
+    "sentence": "She added sliced cucumber to the salad.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cu-cum-ber",
+    "phonetic": "CU-cum-ber"
+  },
+  {
+    "word": "curtain",
+    "definition": "Cloth hung to cover a window",
+    "sentence": "Close the curtain to block the sun.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cur-tain",
+    "phonetic": "CUR-tain"
+  },
+  {
+    "word": "dangerous",
+    "definition": "Likely to cause harm",
+    "sentence": "It is dangerous to play in the street.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dan-ger-ous",
+    "phonetic": "DAN-ger-ous"
+  },
+  {
+    "word": "daughter",
+    "definition": "A female child",
+    "sentence": "She is her mother's daughter.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "daugh-ter",
+    "phonetic": "DAUGH-ter"
+  },
+  {
+    "word": "dentist",
+    "definition": "A doctor for teeth",
+    "sentence": "The dentist checked for cavities.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "den-tist",
+    "phonetic": "DEN-tist"
+  },
+  {
+    "word": "diamond",
+    "definition": "A precious clear stone",
+    "sentence": "Her ring has a sparkling diamond.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "di-a-mond",
+    "phonetic": "DI-a-mond"
+  },
+  {
+    "word": "difficult",
+    "definition": "Hard to do or understand",
+    "sentence": "The math problem was very difficult.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dif-fi-cult",
+    "phonetic": "DIF-fi-cult"
+  },
+  {
+    "word": "direction",
+    "definition": "The path something moves along",
+    "sentence": "Which direction is north?",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "di-rec-tion",
+    "phonetic": "DI-rec-tion"
+  },
+  {
+    "word": "doctor",
+    "definition": "A person who treats sick people",
+    "sentence": "The doctor gave me medicine.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "doc-tor",
+    "phonetic": "DOC-tor"
+  },
+  {
+    "word": "dolphin",
+    "definition": "A smart marine mammal",
+    "sentence": "The dolphin jumped out of the water.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dol-phin",
+    "phonetic": "DOL-phin"
+  },
+  {
+    "word": "dragon",
+    "definition": "A mythical fire-breathing monster",
+    "sentence": "The knight fought the dragon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "drag-on",
+    "phonetic": "DRAG-on"
+  },
+  {
+    "word": "elevator",
+    "definition": "A machine for lifting people",
+    "sentence": "Take the elevator to the tenth floor.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "el-e-va-tor",
+    "phonetic": "EL-e-va-tor"
+  },
+  {
+    "word": "engine",
+    "definition": "A machine with moving parts",
+    "sentence": "The car engine is running.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "en-gine",
+    "phonetic": "EN-gine"
+  },
+  {
+    "word": "envelope",
+    "definition": "A paper container for a letter",
+    "sentence": "Put the stamp on the envelope.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "en-ve-lope",
+    "phonetic": "EN-ve-lope"
+  },
+  {
+    "word": "exercise",
+    "definition": "Physical activity",
+    "sentence": "Running is good exercise.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ex-er-cise",
+    "phonetic": "EX-er-cise"
+  },
+  {
+    "word": "factory",
+    "definition": "A place where goods are made",
+    "sentence": "Cars are built in a factory.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fac-to-ry",
+    "phonetic": "FAC-to-ry"
+  },
+  {
+    "word": "family",
+    "definition": "Parents and children",
+    "sentence": "My family likes to go camping.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fam-i-ly",
+    "phonetic": "FAM-i-ly"
+  },
+  {
+    "word": "feather",
+    "definition": "Light growth covering a bird",
+    "sentence": "The feather floated to the ground.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "feath-er",
+    "phonetic": "FEATH-er"
+  },
+  {
+    "word": "festival",
+    "definition": "A day or period of celebration",
+    "sentence": "We danced at the music festival.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fes-ti-val",
+    "phonetic": "FES-ti-val"
+  },
+  {
+    "word": "fingerprint",
+    "definition": "The mark left by a finger",
+    "sentence": "Everyone has a unique fingerprint.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fin-ger-print",
+    "phonetic": "FIN-ger-print"
+  },
+  {
+    "word": "fireplace",
+    "definition": "A place for a fire in a house",
+    "sentence": "We sat by the warm fireplace.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fire-place",
+    "phonetic": "FIRE-place"
+  },
+  {
+    "word": "forest",
+    "definition": "A large area of trees",
+    "sentence": "Animals hide in the forest.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "for-est",
+    "phonetic": "FOR-est"
+  },
+  {
+    "word": "furniture",
+    "definition": "Movable items like chairs and tables",
+    "sentence": "We bought new furniture for the living room.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fur-ni-ture",
+    "phonetic": "FUR-ni-ture"
+  },
+  {
+    "word": "galaxy",
+    "definition": "A huge system of stars",
+    "sentence": "The Milky Way is our galaxy.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gal-ax-y",
+    "phonetic": "GAL-ax-y"
+  },
+  {
+    "word": "garage",
+    "definition": "A building for parking cars",
+    "sentence": "Park the car in the garage.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ga-rage",
+    "phonetic": "GA-rage"
+  },
+  {
+    "word": "geography",
+    "definition": "Study of the earth's surface",
+    "sentence": "We learned about maps in geography.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ge-og-ra-phy",
+    "phonetic": "GE-og-ra-phy"
+  },
+  {
+    "word": "giraffe",
+    "definition": "A tall animal with a long neck",
+    "sentence": "The giraffe ate leaves from the tall tree.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gi-raffe",
+    "phonetic": "GI-raffe"
+  },
+  {
+    "word": "glasses",
+    "definition": "Lenses worn to help see",
+    "sentence": "He needs glasses to read.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "glass-es",
+    "phonetic": "GLASS-es"
+  },
+  {
+    "word": "guitar",
+    "definition": "A stringed musical instrument",
+    "sentence": "She played a song on her guitar.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gui-tar",
+    "phonetic": "GUI-tar"
+  },
+  {
+    "word": "helicopter",
+    "definition": "A type of aircraft",
+    "sentence": "The helicopter landed on the roof.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hel-i-cop-ter",
+    "phonetic": "HEL-i-cop-ter"
+  },
+  {
+    "word": "holiday",
+    "definition": "A day of celebration",
+    "sentence": "Christmas is my favorite holiday.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hol-i-day",
+    "phonetic": "HOL-i-day"
+  },
+  {
+    "word": "hospital",
+    "definition": "A place for medical treatment",
+    "sentence": "The ambulance went to the hospital.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hos-pi-tal",
+    "phonetic": "HOS-pi-tal"
+  },
+  {
+    "word": "hurricane",
+    "definition": "A violent tropical storm",
+    "sentence": "The hurricane brought strong winds.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hur-ri-cane",
+    "phonetic": "HUR-ri-cane"
+  },
+  {
+    "word": "instrument",
+    "definition": "A tool or device for music",
+    "sentence": "Which musical instrument do you play?",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "in-stru-ment",
+    "phonetic": "IN-stru-ment"
+  },
+  {
+    "word": "backpack",
+    "definition": "A bag carried on the back",
+    "sentence": "He packed his backpack for school.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "back-pack",
+    "phonetic": "BACK-pack"
+  },
+  {
+    "word": "celebrate",
+    "definition": "To honor a special event",
+    "sentence": "We celebrate birthdays with cake.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cel-e-brate",
+    "phonetic": "CEL-e-brate"
+  },
+  {
+    "word": "disappear",
+    "definition": "To vanish from sight",
+    "sentence": "The rabbit seemed to disappear.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dis-ap-pear",
+    "phonetic": "DIS-ap-pear"
+  },
+  {
+    "word": "favorite",
+    "definition": "Preferred above all others",
+    "sentence": "Purple is my favorite color.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fa-vor-ite",
+    "phonetic": "FA-vor-ite"
+  },
+  {
+    "word": "horizon",
+    "definition": "The line where earth and sky appear to meet",
+    "sentence": "The sun sank below the horizon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ho-ri-zon",
+    "phonetic": "HO-ri-zon"
+  },
+  {
+    "word": "laughter",
+    "definition": "The sound of laughing",
+    "sentence": "The room filled with laughter.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "laugh-ter",
+    "phonetic": "LAUGH-ter"
+  },
+  {
+    "word": "question",
+    "definition": "A sentence asked to get information",
+    "sentence": "She raised her hand to ask a question.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ques-tion",
+    "phonetic": "QUES-tion"
+  },
+  {
+    "word": "shelter",
+    "definition": "A place that gives protection",
+    "sentence": "The hikers found shelter from the rain.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "shel-ter",
+    "phonetic": "SHEL-ter"
+  },
+  {
+    "word": "whisper",
+    "definition": "To speak very softly",
+    "sentence": "Please whisper in the library.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "whis-per",
+    "phonetic": "WHIS-per"
+  },
+  {
+    "word": "breeze",
+    "definition": "A gentle wind",
+    "sentence": "A cool breeze blew across the field.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "bree-ze",
+    "phonetic": "BREE-ze"
+  },
+  {
+    "word": "harbor",
+    "definition": "A sheltered place for ships",
+    "sentence": "Fishing boats returned to the harbor.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "har-bor",
+    "phonetic": "HAR-bor"
+  },
+  {
+    "word": "kitten",
+    "definition": "A young cat",
+    "sentence": "The kitten chased a ball of yarn.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "kit-ten",
+    "phonetic": "KIT-ten"
+  },
+  {
+    "word": "ladder",
+    "definition": "A tool with steps for climbing",
+    "sentence": "He used a ladder to reach the shelf.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "lad-der",
+    "phonetic": "LAD-der"
+  },
+  {
+    "word": "marble",
+    "definition": "A small glass ball used in games",
+    "sentence": "I found a blue marble on the playground.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "mar-ble",
+    "phonetic": "MAR-ble"
+  },
+  {
+    "word": "nectar",
+    "definition": "Sweet liquid in flowers",
+    "sentence": "Bees collect nectar from bright flowers.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "nec-tar",
+    "phonetic": "NEC-tar"
+  },
+  {
+    "word": "ocean",
+    "definition": "A vast body of salt water",
+    "sentence": "The ocean waves crashed on the shore.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "o-cean",
+    "phonetic": "O-cean"
+  },
+  {
+    "word": "pencil",
+    "definition": "A tool for writing or drawing",
+    "sentence": "Sharpen your pencil before the quiz.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "pen-cil",
+    "phonetic": "PEN-cil"
+  },
+  {
+    "word": "quartz",
+    "definition": "A hard mineral found in rocks",
+    "sentence": "This rock has shiny pieces of quartz.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "quartz",
+    "phonetic": "QUARTZ"
+  },
+  {
+    "word": "rocket",
+    "definition": "A vehicle that travels into space",
+    "sentence": "The rocket launched with a loud roar.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "rock-et",
+    "phonetic": "ROCK-et"
+  },
+  {
+    "word": "sunset",
+    "definition": "The daily disappearance of the sun",
+    "sentence": "We watched the sunset turn the sky orange.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "sun-set",
+    "phonetic": "SUN-set"
+  },
+  {
+    "word": "ticket",
+    "definition": "A pass that allows entry",
+    "sentence": "Keep your ticket for the school play.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "tick-et",
+    "phonetic": "TICK-et"
+  },
+  {
+    "word": "vacuum",
+    "definition": "A machine that cleans floors",
+    "sentence": "Dad used the vacuum in the living room.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "vac-u-um",
+    "phonetic": "VAC-u-um"
+  },
+  {
+    "word": "window",
+    "definition": "An opening in a wall with glass",
+    "sentence": "Please open the window for fresh air.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "win-dow",
+    "phonetic": "WIN-dow"
+  },
+  {
+    "word": "yellow",
+    "definition": "A bright color like the sun",
+    "sentence": "Her backpack is yellow and easy to spot.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "yel-low",
+    "phonetic": "YEL-low"
+  },
+  {
+    "word": "zigzag",
+    "definition": "A line with sharp turns",
+    "sentence": "The skier made a zigzag down the hill.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "zig-zag",
+    "phonetic": "ZIG-zag"
+  }
+]

--- a/public/data/words/grade-4.json
+++ b/public/data/words/grade-4.json
@@ -1,963 +1,920 @@
-{
-  "grade": 4,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 106,
-  "words": [
-    {
-      "word": "elephant",
-      "definition": "A large mammal with a trunk",
-      "example": "The elephant sprayed water with its trunk.",
-      "phonetic": "EL-e-phant",
-      "syllables": "el-e-phant",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "island",
-      "definition": "Land surrounded by water",
-      "example": "They sailed to a small island.",
-      "phonetic": "IS-land",
-      "syllables": "is-land",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "jungle",
-      "definition": "Dense tropical forest",
-      "example": "The explorer ventured into the jungle.",
-      "phonetic": "JUN-gle",
-      "syllables": "jun-gle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "night",
-      "definition": "The period of darkness",
-      "example": "Stars appeared in the night sky.",
-      "phonetic": "NIGHT",
-      "syllables": "night",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "orange",
-      "definition": "A round citrus fruit",
-      "example": "He peeled an orange for breakfast.",
-      "phonetic": "OR-ange",
-      "syllables": "or-ange",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "beautiful",
-      "definition": "Pleasing to the senses",
-      "example": "The sunset was absolutely beautiful.",
-      "phonetic": "BEAU-ti-ful",
-      "syllables": "beau-ti-ful",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "calendar",
-      "definition": "A system for organizing days",
-      "example": "Mark the date on your calendar.",
-      "phonetic": "CAL-en-dar",
-      "syllables": "cal-en-dar",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dinosaur",
-      "definition": "An extinct prehistoric reptile",
-      "example": "The museum had a dinosaur skeleton.",
-      "phonetic": "DI-no-saur",
-      "syllables": "di-no-saur",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "emergency",
-      "definition": "A serious unexpected situation",
-      "example": "Call 911 in case of emergency.",
-      "phonetic": "E-mer-gen-cy",
-      "syllables": "e-mer-gen-cy",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "february",
-      "definition": "The second month of the year",
-      "example": "February is the shortest month.",
-      "phonetic": "FEB-ru-ar-y",
-      "syllables": "feb-ru-ar-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "government",
-      "definition": "The ruling body of a nation",
-      "example": "The government passed new legislation.",
-      "phonetic": "GOV-ern-ment",
-      "syllables": "gov-ern-ment",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "hamburger",
-      "definition": "A sandwich with a meat patty",
-      "example": "I ordered a hamburger with fries.",
-      "phonetic": "HAM-bur-ger",
-      "syllables": "ham-bur-ger",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "immediately",
-      "definition": "Without delay",
-      "example": "Please respond immediately.",
-      "phonetic": "IM-me-di-ate-ly",
-      "syllables": "im-me-di-ate-ly",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "jealousy",
-      "definition": "Feeling of envy",
-      "example": "Jealousy can damage relationships.",
-      "phonetic": "JEAL-ous-y",
-      "syllables": "jeal-ous-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "knowledge",
-      "definition": "Information and understanding",
-      "example": "Knowledge is power.",
-      "phonetic": "KNOWL-edge",
-      "syllables": "knowl-edge",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "lieutenant",
-      "definition": "A military rank",
-      "example": "The lieutenant led the platoon.",
-      "phonetic": "LIEU-ten-ant",
-      "syllables": "lieu-ten-ant",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "mysterious",
-      "definition": "Difficult to understand",
-      "example": "A mysterious package arrived.",
-      "phonetic": "MYS-te-ri-ous",
-      "syllables": "mys-te-ri-ous",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "necessary",
-      "definition": "Required or essential",
-      "example": "Water is necessary for life.",
-      "phonetic": "NEC-es-sar-y",
-      "syllables": "nec-es-sar-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "occasion",
-      "definition": "A special event or time",
-      "example": "This is a special occasion.",
-      "phonetic": "OC-ca-sion",
-      "syllables": "oc-ca-sion",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "psychology",
-      "definition": "The study of the mind",
-      "example": "She studied psychology in college.",
-      "phonetic": "PSY-chol-o-gy",
-      "syllables": "psy-chol-o-gy",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "questionnaire",
-      "definition": "A set of written questions",
-      "example": "Please complete this questionnaire.",
-      "phonetic": "QUES-tion-naire",
-      "syllables": "ques-tion-naire",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "restaurant",
-      "definition": "A place to eat meals",
-      "example": "We dined at an Italian restaurant.",
-      "phonetic": "RES-tau-rant",
-      "syllables": "res-tau-rant",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "adventure",
-      "definition": "An exciting or unusual experience",
-      "example": "They went on an adventure in the woods.",
-      "phonetic": "AD-ven-ture",
-      "syllables": "ad-ven-ture",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "alphabet",
-      "definition": "The letters of a language",
-      "example": "She learned to sing the alphabet song.",
-      "phonetic": "AL-pha-bet",
-      "syllables": "al-pha-bet",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "apartment",
-      "definition": "A set of rooms for living in",
-      "example": "We live in an apartment on the third floor.",
-      "phonetic": "A-part-ment",
-      "syllables": "a-part-ment",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "astronaut",
-      "definition": "A person trained to travel in space",
-      "example": "The astronaut walked on the moon.",
-      "phonetic": "AS-tro-naut",
-      "syllables": "as-tro-naut",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "autumn",
-      "definition": "The season after summer",
-      "example": "Leaves turn colors in autumn.",
-      "phonetic": "AU-tumn",
-      "syllables": "au-tumn",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bakery",
-      "definition": "A place where bread and cakes are made",
-      "example": "We bought fresh donuts at the bakery.",
-      "phonetic": "BAK-er-y",
-      "syllables": "bak-er-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "balcony",
-      "definition": "A platform on the outside of a building",
-      "example": "She stood on the balcony to watch the parade.",
-      "phonetic": "BAL-co-ny",
-      "syllables": "bal-co-ny",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "banana",
-      "definition": "A long curved yellow fruit",
-      "example": "Monkeys love to eat a banana.",
-      "phonetic": "BA-nan-a",
-      "syllables": "ba-nan-a",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "basket",
-      "definition": "A container woven from cane or wire",
-      "example": "Put the apples in the basket.",
-      "phonetic": "BAS-ket",
-      "syllables": "bas-ket",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "blanket",
-      "definition": "A soft covering for a bed",
-      "example": "The baby was wrapped in a warm blanket.",
-      "phonetic": "BLAN-ket",
-      "syllables": "blan-ket",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bottle",
-      "definition": "A container with a narrow neck",
-      "example": "He drank water from a plastic bottle.",
-      "phonetic": "BOT-tle",
-      "syllables": "bot-tle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bridge",
-      "definition": "A structure across a river or road",
-      "example": "Cars drove over the bridge.",
-      "phonetic": "BRIDGE",
-      "syllables": "bridge",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "camera",
-      "definition": "A device for taking photos",
-      "example": "Smile for the camera!",
-      "phonetic": "CAM-er-a",
-      "syllables": "cam-er-a",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "candle",
-      "definition": "Wax with a wick that burns",
-      "example": "She blew out the candle on her cake.",
-      "phonetic": "CAN-dle",
-      "syllables": "can-dle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "castle",
-      "definition": "A large fortified building",
-      "example": "The king lived in a stone castle.",
-      "phonetic": "CAS-tle",
-      "syllables": "cas-tle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "caterpillar",
-      "definition": "The larva of a butterfly",
-      "example": "The caterpillar will become a butterfly.",
-      "phonetic": "CAT-er-pil-lar",
-      "syllables": "cat-er-pil-lar",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "chocolate",
-      "definition": "A sweet food made from cacao",
-      "example": "I love dark chocolate.",
-      "phonetic": "CHOC-o-late",
-      "syllables": "choc-o-late",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "circle",
-      "definition": "A round shape",
-      "example": "Draw a circle on the paper.",
-      "phonetic": "CIR-cle",
-      "syllables": "cir-cle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "coffee",
-      "definition": "A hot drink made from roasted beans",
-      "example": "Dad drinks coffee in the morning.",
-      "phonetic": "COF-fee",
-      "syllables": "cof-fee",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "computer",
-      "definition": "An electronic device for processing data",
-      "example": "I use the computer for homework.",
-      "phonetic": "COM-put-er",
-      "syllables": "com-put-er",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "continent",
-      "definition": "A large continuous mass of land",
-      "example": "Africa is a large continent.",
-      "phonetic": "CON-ti-nent",
-      "syllables": "con-ti-nent",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "cucumber",
-      "definition": "A long green vegetable",
-      "example": "She added sliced cucumber to the salad.",
-      "phonetic": "CU-cum-ber",
-      "syllables": "cu-cum-ber",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "curtain",
-      "definition": "Cloth hung to cover a window",
-      "example": "Close the curtain to block the sun.",
-      "phonetic": "CUR-tain",
-      "syllables": "cur-tain",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dangerous",
-      "definition": "Likely to cause harm",
-      "example": "It is dangerous to play in the street.",
-      "phonetic": "DAN-ger-ous",
-      "syllables": "dan-ger-ous",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "daughter",
-      "definition": "A female child",
-      "example": "She is her mother's daughter.",
-      "phonetic": "DAUGH-ter",
-      "syllables": "daugh-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dentist",
-      "definition": "A doctor for teeth",
-      "example": "The dentist checked for cavities.",
-      "phonetic": "DEN-tist",
-      "syllables": "den-tist",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "diamond",
-      "definition": "A precious clear stone",
-      "example": "Her ring has a sparkling diamond.",
-      "phonetic": "DI-a-mond",
-      "syllables": "di-a-mond",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "difficult",
-      "definition": "Hard to do or understand",
-      "example": "The math problem was very difficult.",
-      "phonetic": "DIF-fi-cult",
-      "syllables": "dif-fi-cult",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "direction",
-      "definition": "The path something moves along",
-      "example": "Which direction is north?",
-      "phonetic": "DI-rec-tion",
-      "syllables": "di-rec-tion",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "doctor",
-      "definition": "A person who treats sick people",
-      "example": "The doctor gave me medicine.",
-      "phonetic": "DOC-tor",
-      "syllables": "doc-tor",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dolphin",
-      "definition": "A smart marine mammal",
-      "example": "The dolphin jumped out of the water.",
-      "phonetic": "DOL-phin",
-      "syllables": "dol-phin",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dragon",
-      "definition": "A mythical fire-breathing monster",
-      "example": "The knight fought the dragon.",
-      "phonetic": "DRAG-on",
-      "syllables": "drag-on",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "elevator",
-      "definition": "A machine for lifting people",
-      "example": "Take the elevator to the tenth floor.",
-      "phonetic": "EL-e-va-tor",
-      "syllables": "el-e-va-tor",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "engine",
-      "definition": "A machine with moving parts",
-      "example": "The car engine is running.",
-      "phonetic": "EN-gine",
-      "syllables": "en-gine",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "envelope",
-      "definition": "A paper container for a letter",
-      "example": "Put the stamp on the envelope.",
-      "phonetic": "EN-ve-lope",
-      "syllables": "en-ve-lope",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "exercise",
-      "definition": "Physical activity",
-      "example": "Running is good exercise.",
-      "phonetic": "EX-er-cise",
-      "syllables": "ex-er-cise",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "factory",
-      "definition": "A place where goods are made",
-      "example": "Cars are built in a factory.",
-      "phonetic": "FAC-to-ry",
-      "syllables": "fac-to-ry",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "family",
-      "definition": "Parents and children",
-      "example": "My family likes to go camping.",
-      "phonetic": "FAM-i-ly",
-      "syllables": "fam-i-ly",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "feather",
-      "definition": "Light growth covering a bird",
-      "example": "The feather floated to the ground.",
-      "phonetic": "FEATH-er",
-      "syllables": "feath-er",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "festival",
-      "definition": "A day or period of celebration",
-      "example": "We danced at the music festival.",
-      "phonetic": "FES-ti-val",
-      "syllables": "fes-ti-val",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "fingerprint",
-      "definition": "The mark left by a finger",
-      "example": "Everyone has a unique fingerprint.",
-      "phonetic": "FIN-ger-print",
-      "syllables": "fin-ger-print",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "fireplace",
-      "definition": "A place for a fire in a house",
-      "example": "We sat by the warm fireplace.",
-      "phonetic": "FIRE-place",
-      "syllables": "fire-place",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "forest",
-      "definition": "A large area of trees",
-      "example": "Animals hide in the forest.",
-      "phonetic": "FOR-est",
-      "syllables": "for-est",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "furniture",
-      "definition": "Movable items like chairs and tables",
-      "example": "We bought new furniture for the living room.",
-      "phonetic": "FUR-ni-ture",
-      "syllables": "fur-ni-ture",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "galaxy",
-      "definition": "A huge system of stars",
-      "example": "The Milky Way is our galaxy.",
-      "phonetic": "GAL-ax-y",
-      "syllables": "gal-ax-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "garage",
-      "definition": "A building for parking cars",
-      "example": "Park the car in the garage.",
-      "phonetic": "GA-rage",
-      "syllables": "ga-rage",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "geography",
-      "definition": "Study of the earth's surface",
-      "example": "We learned about maps in geography.",
-      "phonetic": "GE-og-ra-phy",
-      "syllables": "ge-og-ra-phy",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "giraffe",
-      "definition": "A tall animal with a long neck",
-      "example": "The giraffe ate leaves from the tall tree.",
-      "phonetic": "GI-raffe",
-      "syllables": "gi-raffe",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "glasses",
-      "definition": "Lenses worn to help see",
-      "example": "He needs glasses to read.",
-      "phonetic": "GLASS-es",
-      "syllables": "glass-es",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "guitar",
-      "definition": "A stringed musical instrument",
-      "example": "She played a song on her guitar.",
-      "phonetic": "GUI-tar",
-      "syllables": "gui-tar",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "helicopter",
-      "definition": "A type of aircraft",
-      "example": "The helicopter landed on the roof.",
-      "phonetic": "HEL-i-cop-ter",
-      "syllables": "hel-i-cop-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "holiday",
-      "definition": "A day of celebration",
-      "example": "Christmas is my favorite holiday.",
-      "phonetic": "HOL-i-day",
-      "syllables": "hol-i-day",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "hospital",
-      "definition": "A place for medical treatment",
-      "example": "The ambulance went to the hospital.",
-      "phonetic": "HOS-pi-tal",
-      "syllables": "hos-pi-tal",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "hurricane",
-      "definition": "A violent tropical storm",
-      "example": "The hurricane brought strong winds.",
-      "phonetic": "HUR-ri-cane",
-      "syllables": "hur-ri-cane",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "instrument",
-      "definition": "A tool or device for music",
-      "example": "Which musical instrument do you play?",
-      "phonetic": "IN-stru-ment",
-      "syllables": "in-stru-ment",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "backpack",
-      "definition": "A bag carried on the back",
-      "example": "He packed his backpack for school.",
-      "phonetic": "BACK-pack",
-      "syllables": "back-pack",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "celebrate",
-      "definition": "To honor a special event",
-      "example": "We celebrate birthdays with cake.",
-      "phonetic": "CEL-e-brate",
-      "syllables": "cel-e-brate",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "disappear",
-      "definition": "To vanish from sight",
-      "example": "The rabbit seemed to disappear.",
-      "phonetic": "DIS-ap-pear",
-      "syllables": "dis-ap-pear",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "favorite",
-      "definition": "Preferred above all others",
-      "example": "Purple is my favorite color.",
-      "phonetic": "FA-vor-ite",
-      "syllables": "fa-vor-ite",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "horizon",
-      "definition": "The line where earth and sky appear to meet",
-      "example": "The sun sank below the horizon.",
-      "phonetic": "HO-ri-zon",
-      "syllables": "ho-ri-zon",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "laughter",
-      "definition": "The sound of laughing",
-      "example": "The room filled with laughter.",
-      "phonetic": "LAUGH-ter",
-      "syllables": "laugh-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "question",
-      "definition": "A sentence asked to get information",
-      "example": "She raised her hand to ask a question.",
-      "phonetic": "QUES-tion",
-      "syllables": "ques-tion",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "shelter",
-      "definition": "A place that gives protection",
-      "example": "The hikers found shelter from the rain.",
-      "phonetic": "SHEL-ter",
-      "syllables": "shel-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "whisper",
-      "definition": "To speak very softly",
-      "example": "Please whisper in the library.",
-      "phonetic": "WHIS-per",
-      "syllables": "whis-per",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "breeze",
-      "definition": "A gentle wind",
-      "example": "A cool breeze blew across the field.",
-      "phonetic": "BREE-ze",
-      "syllables": "bree-ze",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "candle",
-      "definition": "A stick of wax with a wick",
-      "example": "We lit a candle during the power outage.",
-      "phonetic": "CAN-dle",
-      "syllables": "can-dle",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "forest",
-      "definition": "A large area covered with trees",
-      "example": "We hiked through the forest trail.",
-      "phonetic": "FOR-est",
-      "syllables": "for-est",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "guitar",
-      "definition": "A stringed musical instrument",
-      "example": "She practiced guitar after school.",
-      "phonetic": "GUI-tar",
-      "syllables": "gui-tar",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "harbor",
-      "definition": "A sheltered place for ships",
-      "example": "Fishing boats returned to the harbor.",
-      "phonetic": "HAR-bor",
-      "syllables": "har-bor",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "kitten",
-      "definition": "A young cat",
-      "example": "The kitten chased a ball of yarn.",
-      "phonetic": "KIT-ten",
-      "syllables": "kit-ten",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "ladder",
-      "definition": "A tool with steps for climbing",
-      "example": "He used a ladder to reach the shelf.",
-      "phonetic": "LAD-der",
-      "syllables": "lad-der",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "marble",
-      "definition": "A small glass ball used in games",
-      "example": "I found a blue marble on the playground.",
-      "phonetic": "MAR-ble",
-      "syllables": "mar-ble",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "nectar",
-      "definition": "Sweet liquid in flowers",
-      "example": "Bees collect nectar from bright flowers.",
-      "phonetic": "NEC-tar",
-      "syllables": "nec-tar",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "ocean",
-      "definition": "A vast body of salt water",
-      "example": "The ocean waves crashed on the shore.",
-      "phonetic": "O-cean",
-      "syllables": "o-cean",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "pencil",
-      "definition": "A tool for writing or drawing",
-      "example": "Sharpen your pencil before the quiz.",
-      "phonetic": "PEN-cil",
-      "syllables": "pen-cil",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "quartz",
-      "definition": "A hard mineral found in rocks",
-      "example": "This rock has shiny pieces of quartz.",
-      "phonetic": "QUARTZ",
-      "syllables": "quartz",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "rocket",
-      "definition": "A vehicle that travels into space",
-      "example": "The rocket launched with a loud roar.",
-      "phonetic": "ROCK-et",
-      "syllables": "rock-et",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "sunset",
-      "definition": "The daily disappearance of the sun",
-      "example": "We watched the sunset turn the sky orange.",
-      "phonetic": "SUN-set",
-      "syllables": "sun-set",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "ticket",
-      "definition": "A pass that allows entry",
-      "example": "Keep your ticket for the school play.",
-      "phonetic": "TICK-et",
-      "syllables": "tick-et",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "vacuum",
-      "definition": "A machine that cleans floors",
-      "example": "Dad used the vacuum in the living room.",
-      "phonetic": "VAC-u-um",
-      "syllables": "vac-u-um",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "window",
-      "definition": "An opening in a wall with glass",
-      "example": "Please open the window for fresh air.",
-      "phonetic": "WIN-dow",
-      "syllables": "win-dow",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "yellow",
-      "definition": "A bright color like the sun",
-      "example": "Her backpack is yellow and easy to spot.",
-      "phonetic": "YEL-low",
-      "syllables": "yel-low",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "zigzag",
-      "definition": "A line with sharp turns",
-      "example": "The skier made a zigzag down the hill.",
-      "phonetic": "ZIG-zag",
-      "syllables": "zig-zag",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bridge",
-      "definition": "A structure built over water or roads",
-      "example": "We crossed the bridge on our bike ride.",
-      "phonetic": "BRIDGE",
-      "syllables": "bridge",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    }
-  ]
-}
+[
+  {
+    "word": "elephant",
+    "definition": "A large mammal with a trunk",
+    "sentence": "The elephant sprayed water with its trunk.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "el-e-phant",
+    "phonetic": "EL-e-phant"
+  },
+  {
+    "word": "island",
+    "definition": "Land surrounded by water",
+    "sentence": "They sailed to a small island.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "is-land",
+    "phonetic": "IS-land"
+  },
+  {
+    "word": "jungle",
+    "definition": "Dense tropical forest",
+    "sentence": "The explorer ventured into the jungle.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "jun-gle",
+    "phonetic": "JUN-gle"
+  },
+  {
+    "word": "night",
+    "definition": "The period of darkness",
+    "sentence": "Stars appeared in the night sky.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "night",
+    "phonetic": "NIGHT"
+  },
+  {
+    "word": "orange",
+    "definition": "A round citrus fruit",
+    "sentence": "He peeled an orange for breakfast.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "or-ange",
+    "phonetic": "OR-ange"
+  },
+  {
+    "word": "beautiful",
+    "definition": "Pleasing to the senses",
+    "sentence": "The sunset was absolutely beautiful.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "beau-ti-ful",
+    "phonetic": "BEAU-ti-ful"
+  },
+  {
+    "word": "calendar",
+    "definition": "A system for organizing days",
+    "sentence": "Mark the date on your calendar.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cal-en-dar",
+    "phonetic": "CAL-en-dar"
+  },
+  {
+    "word": "dinosaur",
+    "definition": "An extinct prehistoric reptile",
+    "sentence": "The museum had a dinosaur skeleton.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "di-no-saur",
+    "phonetic": "DI-no-saur"
+  },
+  {
+    "word": "emergency",
+    "definition": "A serious unexpected situation",
+    "sentence": "Call 911 in case of emergency.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "e-mer-gen-cy",
+    "phonetic": "E-mer-gen-cy"
+  },
+  {
+    "word": "february",
+    "definition": "The second month of the year",
+    "sentence": "February is the shortest month.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "feb-ru-ar-y",
+    "phonetic": "FEB-ru-ar-y"
+  },
+  {
+    "word": "government",
+    "definition": "The ruling body of a nation",
+    "sentence": "The government passed new legislation.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gov-ern-ment",
+    "phonetic": "GOV-ern-ment"
+  },
+  {
+    "word": "hamburger",
+    "definition": "A sandwich with a meat patty",
+    "sentence": "I ordered a hamburger with fries.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ham-bur-ger",
+    "phonetic": "HAM-bur-ger"
+  },
+  {
+    "word": "immediately",
+    "definition": "Without delay",
+    "sentence": "Please respond immediately.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "im-me-di-ate-ly",
+    "phonetic": "IM-me-di-ate-ly"
+  },
+  {
+    "word": "jealousy",
+    "definition": "Feeling of envy",
+    "sentence": "Jealousy can damage relationships.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "jeal-ous-y",
+    "phonetic": "JEAL-ous-y"
+  },
+  {
+    "word": "knowledge",
+    "definition": "Information and understanding",
+    "sentence": "Knowledge is power.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "knowl-edge",
+    "phonetic": "KNOWL-edge"
+  },
+  {
+    "word": "lieutenant",
+    "definition": "A military rank",
+    "sentence": "The lieutenant led the platoon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "lieu-ten-ant",
+    "phonetic": "LIEU-ten-ant"
+  },
+  {
+    "word": "mysterious",
+    "definition": "Difficult to understand",
+    "sentence": "A mysterious package arrived.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "mys-te-ri-ous",
+    "phonetic": "MYS-te-ri-ous"
+  },
+  {
+    "word": "necessary",
+    "definition": "Required or essential",
+    "sentence": "Water is necessary for life.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "nec-es-sar-y",
+    "phonetic": "NEC-es-sar-y"
+  },
+  {
+    "word": "occasion",
+    "definition": "A special event or time",
+    "sentence": "This is a special occasion.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "oc-ca-sion",
+    "phonetic": "OC-ca-sion"
+  },
+  {
+    "word": "psychology",
+    "definition": "The study of the mind",
+    "sentence": "She studied psychology in college.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "psy-chol-o-gy",
+    "phonetic": "PSY-chol-o-gy"
+  },
+  {
+    "word": "questionnaire",
+    "definition": "A set of written questions",
+    "sentence": "Please complete this questionnaire.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ques-tion-naire",
+    "phonetic": "QUES-tion-naire"
+  },
+  {
+    "word": "restaurant",
+    "definition": "A place to eat meals",
+    "sentence": "We dined at an Italian restaurant.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "res-tau-rant",
+    "phonetic": "RES-tau-rant"
+  },
+  {
+    "word": "adventure",
+    "definition": "An exciting or unusual experience",
+    "sentence": "They went on an adventure in the woods.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ad-ven-ture",
+    "phonetic": "AD-ven-ture"
+  },
+  {
+    "word": "alphabet",
+    "definition": "The letters of a language",
+    "sentence": "She learned to sing the alphabet song.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "al-pha-bet",
+    "phonetic": "AL-pha-bet"
+  },
+  {
+    "word": "apartment",
+    "definition": "A set of rooms for living in",
+    "sentence": "We live in an apartment on the third floor.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "a-part-ment",
+    "phonetic": "A-part-ment"
+  },
+  {
+    "word": "astronaut",
+    "definition": "A person trained to travel in space",
+    "sentence": "The astronaut walked on the moon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "as-tro-naut",
+    "phonetic": "AS-tro-naut"
+  },
+  {
+    "word": "autumn",
+    "definition": "The season after summer",
+    "sentence": "Leaves turn colors in autumn.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "au-tumn",
+    "phonetic": "AU-tumn"
+  },
+  {
+    "word": "bakery",
+    "definition": "A place where bread and cakes are made",
+    "sentence": "We bought fresh donuts at the bakery.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bak-er-y",
+    "phonetic": "BAK-er-y"
+  },
+  {
+    "word": "balcony",
+    "definition": "A platform on the outside of a building",
+    "sentence": "She stood on the balcony to watch the parade.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bal-co-ny",
+    "phonetic": "BAL-co-ny"
+  },
+  {
+    "word": "banana",
+    "definition": "A long curved yellow fruit",
+    "sentence": "Monkeys love to eat a banana.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ba-nan-a",
+    "phonetic": "BA-nan-a"
+  },
+  {
+    "word": "basket",
+    "definition": "A container woven from cane or wire",
+    "sentence": "Put the apples in the basket.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bas-ket",
+    "phonetic": "BAS-ket"
+  },
+  {
+    "word": "blanket",
+    "definition": "A soft covering for a bed",
+    "sentence": "The baby was wrapped in a warm blanket.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "blan-ket",
+    "phonetic": "BLAN-ket"
+  },
+  {
+    "word": "bottle",
+    "definition": "A container with a narrow neck",
+    "sentence": "He drank water from a plastic bottle.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bot-tle",
+    "phonetic": "BOT-tle"
+  },
+  {
+    "word": "bridge",
+    "definition": "A structure across a river or road",
+    "sentence": "Cars drove over the bridge.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bridge",
+    "phonetic": "BRIDGE"
+  },
+  {
+    "word": "camera",
+    "definition": "A device for taking photos",
+    "sentence": "Smile for the camera!",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cam-er-a",
+    "phonetic": "CAM-er-a"
+  },
+  {
+    "word": "candle",
+    "definition": "Wax with a wick that burns",
+    "sentence": "She blew out the candle on her cake.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "can-dle",
+    "phonetic": "CAN-dle"
+  },
+  {
+    "word": "castle",
+    "definition": "A large fortified building",
+    "sentence": "The king lived in a stone castle.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cas-tle",
+    "phonetic": "CAS-tle"
+  },
+  {
+    "word": "caterpillar",
+    "definition": "The larva of a butterfly",
+    "sentence": "The caterpillar will become a butterfly.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cat-er-pil-lar",
+    "phonetic": "CAT-er-pil-lar"
+  },
+  {
+    "word": "chocolate",
+    "definition": "A sweet food made from cacao",
+    "sentence": "I love dark chocolate.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "choc-o-late",
+    "phonetic": "CHOC-o-late"
+  },
+  {
+    "word": "circle",
+    "definition": "A round shape",
+    "sentence": "Draw a circle on the paper.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cir-cle",
+    "phonetic": "CIR-cle"
+  },
+  {
+    "word": "coffee",
+    "definition": "A hot drink made from roasted beans",
+    "sentence": "Dad drinks coffee in the morning.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cof-fee",
+    "phonetic": "COF-fee"
+  },
+  {
+    "word": "computer",
+    "definition": "An electronic device for processing data",
+    "sentence": "I use the computer for homework.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "com-put-er",
+    "phonetic": "COM-put-er"
+  },
+  {
+    "word": "continent",
+    "definition": "A large continuous mass of land",
+    "sentence": "Africa is a large continent.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "con-ti-nent",
+    "phonetic": "CON-ti-nent"
+  },
+  {
+    "word": "cucumber",
+    "definition": "A long green vegetable",
+    "sentence": "She added sliced cucumber to the salad.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cu-cum-ber",
+    "phonetic": "CU-cum-ber"
+  },
+  {
+    "word": "curtain",
+    "definition": "Cloth hung to cover a window",
+    "sentence": "Close the curtain to block the sun.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cur-tain",
+    "phonetic": "CUR-tain"
+  },
+  {
+    "word": "dangerous",
+    "definition": "Likely to cause harm",
+    "sentence": "It is dangerous to play in the street.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dan-ger-ous",
+    "phonetic": "DAN-ger-ous"
+  },
+  {
+    "word": "daughter",
+    "definition": "A female child",
+    "sentence": "She is her mother's daughter.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "daugh-ter",
+    "phonetic": "DAUGH-ter"
+  },
+  {
+    "word": "dentist",
+    "definition": "A doctor for teeth",
+    "sentence": "The dentist checked for cavities.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "den-tist",
+    "phonetic": "DEN-tist"
+  },
+  {
+    "word": "diamond",
+    "definition": "A precious clear stone",
+    "sentence": "Her ring has a sparkling diamond.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "di-a-mond",
+    "phonetic": "DI-a-mond"
+  },
+  {
+    "word": "difficult",
+    "definition": "Hard to do or understand",
+    "sentence": "The math problem was very difficult.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dif-fi-cult",
+    "phonetic": "DIF-fi-cult"
+  },
+  {
+    "word": "direction",
+    "definition": "The path something moves along",
+    "sentence": "Which direction is north?",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "di-rec-tion",
+    "phonetic": "DI-rec-tion"
+  },
+  {
+    "word": "doctor",
+    "definition": "A person who treats sick people",
+    "sentence": "The doctor gave me medicine.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "doc-tor",
+    "phonetic": "DOC-tor"
+  },
+  {
+    "word": "dolphin",
+    "definition": "A smart marine mammal",
+    "sentence": "The dolphin jumped out of the water.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dol-phin",
+    "phonetic": "DOL-phin"
+  },
+  {
+    "word": "dragon",
+    "definition": "A mythical fire-breathing monster",
+    "sentence": "The knight fought the dragon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "drag-on",
+    "phonetic": "DRAG-on"
+  },
+  {
+    "word": "elevator",
+    "definition": "A machine for lifting people",
+    "sentence": "Take the elevator to the tenth floor.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "el-e-va-tor",
+    "phonetic": "EL-e-va-tor"
+  },
+  {
+    "word": "engine",
+    "definition": "A machine with moving parts",
+    "sentence": "The car engine is running.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "en-gine",
+    "phonetic": "EN-gine"
+  },
+  {
+    "word": "envelope",
+    "definition": "A paper container for a letter",
+    "sentence": "Put the stamp on the envelope.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "en-ve-lope",
+    "phonetic": "EN-ve-lope"
+  },
+  {
+    "word": "exercise",
+    "definition": "Physical activity",
+    "sentence": "Running is good exercise.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ex-er-cise",
+    "phonetic": "EX-er-cise"
+  },
+  {
+    "word": "factory",
+    "definition": "A place where goods are made",
+    "sentence": "Cars are built in a factory.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fac-to-ry",
+    "phonetic": "FAC-to-ry"
+  },
+  {
+    "word": "family",
+    "definition": "Parents and children",
+    "sentence": "My family likes to go camping.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fam-i-ly",
+    "phonetic": "FAM-i-ly"
+  },
+  {
+    "word": "feather",
+    "definition": "Light growth covering a bird",
+    "sentence": "The feather floated to the ground.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "feath-er",
+    "phonetic": "FEATH-er"
+  },
+  {
+    "word": "festival",
+    "definition": "A day or period of celebration",
+    "sentence": "We danced at the music festival.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fes-ti-val",
+    "phonetic": "FES-ti-val"
+  },
+  {
+    "word": "fingerprint",
+    "definition": "The mark left by a finger",
+    "sentence": "Everyone has a unique fingerprint.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fin-ger-print",
+    "phonetic": "FIN-ger-print"
+  },
+  {
+    "word": "fireplace",
+    "definition": "A place for a fire in a house",
+    "sentence": "We sat by the warm fireplace.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fire-place",
+    "phonetic": "FIRE-place"
+  },
+  {
+    "word": "forest",
+    "definition": "A large area of trees",
+    "sentence": "Animals hide in the forest.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "for-est",
+    "phonetic": "FOR-est"
+  },
+  {
+    "word": "furniture",
+    "definition": "Movable items like chairs and tables",
+    "sentence": "We bought new furniture for the living room.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fur-ni-ture",
+    "phonetic": "FUR-ni-ture"
+  },
+  {
+    "word": "galaxy",
+    "definition": "A huge system of stars",
+    "sentence": "The Milky Way is our galaxy.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gal-ax-y",
+    "phonetic": "GAL-ax-y"
+  },
+  {
+    "word": "garage",
+    "definition": "A building for parking cars",
+    "sentence": "Park the car in the garage.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ga-rage",
+    "phonetic": "GA-rage"
+  },
+  {
+    "word": "geography",
+    "definition": "Study of the earth's surface",
+    "sentence": "We learned about maps in geography.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ge-og-ra-phy",
+    "phonetic": "GE-og-ra-phy"
+  },
+  {
+    "word": "giraffe",
+    "definition": "A tall animal with a long neck",
+    "sentence": "The giraffe ate leaves from the tall tree.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gi-raffe",
+    "phonetic": "GI-raffe"
+  },
+  {
+    "word": "glasses",
+    "definition": "Lenses worn to help see",
+    "sentence": "He needs glasses to read.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "glass-es",
+    "phonetic": "GLASS-es"
+  },
+  {
+    "word": "guitar",
+    "definition": "A stringed musical instrument",
+    "sentence": "She played a song on her guitar.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gui-tar",
+    "phonetic": "GUI-tar"
+  },
+  {
+    "word": "helicopter",
+    "definition": "A type of aircraft",
+    "sentence": "The helicopter landed on the roof.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hel-i-cop-ter",
+    "phonetic": "HEL-i-cop-ter"
+  },
+  {
+    "word": "holiday",
+    "definition": "A day of celebration",
+    "sentence": "Christmas is my favorite holiday.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hol-i-day",
+    "phonetic": "HOL-i-day"
+  },
+  {
+    "word": "hospital",
+    "definition": "A place for medical treatment",
+    "sentence": "The ambulance went to the hospital.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hos-pi-tal",
+    "phonetic": "HOS-pi-tal"
+  },
+  {
+    "word": "hurricane",
+    "definition": "A violent tropical storm",
+    "sentence": "The hurricane brought strong winds.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hur-ri-cane",
+    "phonetic": "HUR-ri-cane"
+  },
+  {
+    "word": "instrument",
+    "definition": "A tool or device for music",
+    "sentence": "Which musical instrument do you play?",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "in-stru-ment",
+    "phonetic": "IN-stru-ment"
+  },
+  {
+    "word": "backpack",
+    "definition": "A bag carried on the back",
+    "sentence": "He packed his backpack for school.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "back-pack",
+    "phonetic": "BACK-pack"
+  },
+  {
+    "word": "celebrate",
+    "definition": "To honor a special event",
+    "sentence": "We celebrate birthdays with cake.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cel-e-brate",
+    "phonetic": "CEL-e-brate"
+  },
+  {
+    "word": "disappear",
+    "definition": "To vanish from sight",
+    "sentence": "The rabbit seemed to disappear.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dis-ap-pear",
+    "phonetic": "DIS-ap-pear"
+  },
+  {
+    "word": "favorite",
+    "definition": "Preferred above all others",
+    "sentence": "Purple is my favorite color.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fa-vor-ite",
+    "phonetic": "FA-vor-ite"
+  },
+  {
+    "word": "horizon",
+    "definition": "The line where earth and sky appear to meet",
+    "sentence": "The sun sank below the horizon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ho-ri-zon",
+    "phonetic": "HO-ri-zon"
+  },
+  {
+    "word": "laughter",
+    "definition": "The sound of laughing",
+    "sentence": "The room filled with laughter.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "laugh-ter",
+    "phonetic": "LAUGH-ter"
+  },
+  {
+    "word": "question",
+    "definition": "A sentence asked to get information",
+    "sentence": "She raised her hand to ask a question.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ques-tion",
+    "phonetic": "QUES-tion"
+  },
+  {
+    "word": "shelter",
+    "definition": "A place that gives protection",
+    "sentence": "The hikers found shelter from the rain.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "shel-ter",
+    "phonetic": "SHEL-ter"
+  },
+  {
+    "word": "whisper",
+    "definition": "To speak very softly",
+    "sentence": "Please whisper in the library.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "whis-per",
+    "phonetic": "WHIS-per"
+  },
+  {
+    "word": "breeze",
+    "definition": "A gentle wind",
+    "sentence": "A cool breeze blew across the field.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "bree-ze",
+    "phonetic": "BREE-ze"
+  },
+  {
+    "word": "harbor",
+    "definition": "A sheltered place for ships",
+    "sentence": "Fishing boats returned to the harbor.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "har-bor",
+    "phonetic": "HAR-bor"
+  },
+  {
+    "word": "kitten",
+    "definition": "A young cat",
+    "sentence": "The kitten chased a ball of yarn.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "kit-ten",
+    "phonetic": "KIT-ten"
+  },
+  {
+    "word": "ladder",
+    "definition": "A tool with steps for climbing",
+    "sentence": "He used a ladder to reach the shelf.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "lad-der",
+    "phonetic": "LAD-der"
+  },
+  {
+    "word": "marble",
+    "definition": "A small glass ball used in games",
+    "sentence": "I found a blue marble on the playground.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "mar-ble",
+    "phonetic": "MAR-ble"
+  },
+  {
+    "word": "nectar",
+    "definition": "Sweet liquid in flowers",
+    "sentence": "Bees collect nectar from bright flowers.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "nec-tar",
+    "phonetic": "NEC-tar"
+  },
+  {
+    "word": "ocean",
+    "definition": "A vast body of salt water",
+    "sentence": "The ocean waves crashed on the shore.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "o-cean",
+    "phonetic": "O-cean"
+  },
+  {
+    "word": "pencil",
+    "definition": "A tool for writing or drawing",
+    "sentence": "Sharpen your pencil before the quiz.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "pen-cil",
+    "phonetic": "PEN-cil"
+  },
+  {
+    "word": "quartz",
+    "definition": "A hard mineral found in rocks",
+    "sentence": "This rock has shiny pieces of quartz.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "quartz",
+    "phonetic": "QUARTZ"
+  },
+  {
+    "word": "rocket",
+    "definition": "A vehicle that travels into space",
+    "sentence": "The rocket launched with a loud roar.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "rock-et",
+    "phonetic": "ROCK-et"
+  },
+  {
+    "word": "sunset",
+    "definition": "The daily disappearance of the sun",
+    "sentence": "We watched the sunset turn the sky orange.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "sun-set",
+    "phonetic": "SUN-set"
+  },
+  {
+    "word": "ticket",
+    "definition": "A pass that allows entry",
+    "sentence": "Keep your ticket for the school play.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "tick-et",
+    "phonetic": "TICK-et"
+  },
+  {
+    "word": "vacuum",
+    "definition": "A machine that cleans floors",
+    "sentence": "Dad used the vacuum in the living room.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "vac-u-um",
+    "phonetic": "VAC-u-um"
+  },
+  {
+    "word": "window",
+    "definition": "An opening in a wall with glass",
+    "sentence": "Please open the window for fresh air.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "win-dow",
+    "phonetic": "WIN-dow"
+  },
+  {
+    "word": "yellow",
+    "definition": "A bright color like the sun",
+    "sentence": "Her backpack is yellow and easy to spot.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "yel-low",
+    "phonetic": "YEL-low"
+  },
+  {
+    "word": "zigzag",
+    "definition": "A line with sharp turns",
+    "sentence": "The skier made a zigzag down the hill.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "zig-zag",
+    "phonetic": "ZIG-zag"
+  }
+]

--- a/public/data/words/grade-5.json
+++ b/public/data/words/grade-5.json
@@ -1,963 +1,920 @@
-{
-  "grade": 5,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 106,
-  "words": [
-    {
-      "word": "elephant",
-      "definition": "A large mammal with a trunk",
-      "example": "The elephant sprayed water with its trunk.",
-      "phonetic": "EL-e-phant",
-      "syllables": "el-e-phant",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "island",
-      "definition": "Land surrounded by water",
-      "example": "They sailed to a small island.",
-      "phonetic": "IS-land",
-      "syllables": "is-land",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "jungle",
-      "definition": "Dense tropical forest",
-      "example": "The explorer ventured into the jungle.",
-      "phonetic": "JUN-gle",
-      "syllables": "jun-gle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "night",
-      "definition": "The period of darkness",
-      "example": "Stars appeared in the night sky.",
-      "phonetic": "NIGHT",
-      "syllables": "night",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "orange",
-      "definition": "A round citrus fruit",
-      "example": "He peeled an orange for breakfast.",
-      "phonetic": "OR-ange",
-      "syllables": "or-ange",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "beautiful",
-      "definition": "Pleasing to the senses",
-      "example": "The sunset was absolutely beautiful.",
-      "phonetic": "BEAU-ti-ful",
-      "syllables": "beau-ti-ful",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "calendar",
-      "definition": "A system for organizing days",
-      "example": "Mark the date on your calendar.",
-      "phonetic": "CAL-en-dar",
-      "syllables": "cal-en-dar",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dinosaur",
-      "definition": "An extinct prehistoric reptile",
-      "example": "The museum had a dinosaur skeleton.",
-      "phonetic": "DI-no-saur",
-      "syllables": "di-no-saur",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "emergency",
-      "definition": "A serious unexpected situation",
-      "example": "Call 911 in case of emergency.",
-      "phonetic": "E-mer-gen-cy",
-      "syllables": "e-mer-gen-cy",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "february",
-      "definition": "The second month of the year",
-      "example": "February is the shortest month.",
-      "phonetic": "FEB-ru-ar-y",
-      "syllables": "feb-ru-ar-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "government",
-      "definition": "The ruling body of a nation",
-      "example": "The government passed new legislation.",
-      "phonetic": "GOV-ern-ment",
-      "syllables": "gov-ern-ment",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "hamburger",
-      "definition": "A sandwich with a meat patty",
-      "example": "I ordered a hamburger with fries.",
-      "phonetic": "HAM-bur-ger",
-      "syllables": "ham-bur-ger",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "immediately",
-      "definition": "Without delay",
-      "example": "Please respond immediately.",
-      "phonetic": "IM-me-di-ate-ly",
-      "syllables": "im-me-di-ate-ly",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "jealousy",
-      "definition": "Feeling of envy",
-      "example": "Jealousy can damage relationships.",
-      "phonetic": "JEAL-ous-y",
-      "syllables": "jeal-ous-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "knowledge",
-      "definition": "Information and understanding",
-      "example": "Knowledge is power.",
-      "phonetic": "KNOWL-edge",
-      "syllables": "knowl-edge",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "lieutenant",
-      "definition": "A military rank",
-      "example": "The lieutenant led the platoon.",
-      "phonetic": "LIEU-ten-ant",
-      "syllables": "lieu-ten-ant",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "mysterious",
-      "definition": "Difficult to understand",
-      "example": "A mysterious package arrived.",
-      "phonetic": "MYS-te-ri-ous",
-      "syllables": "mys-te-ri-ous",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "necessary",
-      "definition": "Required or essential",
-      "example": "Water is necessary for life.",
-      "phonetic": "NEC-es-sar-y",
-      "syllables": "nec-es-sar-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "occasion",
-      "definition": "A special event or time",
-      "example": "This is a special occasion.",
-      "phonetic": "OC-ca-sion",
-      "syllables": "oc-ca-sion",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "psychology",
-      "definition": "The study of the mind",
-      "example": "She studied psychology in college.",
-      "phonetic": "PSY-chol-o-gy",
-      "syllables": "psy-chol-o-gy",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "questionnaire",
-      "definition": "A set of written questions",
-      "example": "Please complete this questionnaire.",
-      "phonetic": "QUES-tion-naire",
-      "syllables": "ques-tion-naire",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "restaurant",
-      "definition": "A place to eat meals",
-      "example": "We dined at an Italian restaurant.",
-      "phonetic": "RES-tau-rant",
-      "syllables": "res-tau-rant",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "adventure",
-      "definition": "An exciting or unusual experience",
-      "example": "They went on an adventure in the woods.",
-      "phonetic": "AD-ven-ture",
-      "syllables": "ad-ven-ture",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "alphabet",
-      "definition": "The letters of a language",
-      "example": "She learned to sing the alphabet song.",
-      "phonetic": "AL-pha-bet",
-      "syllables": "al-pha-bet",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "apartment",
-      "definition": "A set of rooms for living in",
-      "example": "We live in an apartment on the third floor.",
-      "phonetic": "A-part-ment",
-      "syllables": "a-part-ment",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "astronaut",
-      "definition": "A person trained to travel in space",
-      "example": "The astronaut walked on the moon.",
-      "phonetic": "AS-tro-naut",
-      "syllables": "as-tro-naut",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "autumn",
-      "definition": "The season after summer",
-      "example": "Leaves turn colors in autumn.",
-      "phonetic": "AU-tumn",
-      "syllables": "au-tumn",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bakery",
-      "definition": "A place where bread and cakes are made",
-      "example": "We bought fresh donuts at the bakery.",
-      "phonetic": "BAK-er-y",
-      "syllables": "bak-er-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "balcony",
-      "definition": "A platform on the outside of a building",
-      "example": "She stood on the balcony to watch the parade.",
-      "phonetic": "BAL-co-ny",
-      "syllables": "bal-co-ny",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "banana",
-      "definition": "A long curved yellow fruit",
-      "example": "Monkeys love to eat a banana.",
-      "phonetic": "BA-nan-a",
-      "syllables": "ba-nan-a",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "basket",
-      "definition": "A container woven from cane or wire",
-      "example": "Put the apples in the basket.",
-      "phonetic": "BAS-ket",
-      "syllables": "bas-ket",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "blanket",
-      "definition": "A soft covering for a bed",
-      "example": "The baby was wrapped in a warm blanket.",
-      "phonetic": "BLAN-ket",
-      "syllables": "blan-ket",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bottle",
-      "definition": "A container with a narrow neck",
-      "example": "He drank water from a plastic bottle.",
-      "phonetic": "BOT-tle",
-      "syllables": "bot-tle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bridge",
-      "definition": "A structure across a river or road",
-      "example": "Cars drove over the bridge.",
-      "phonetic": "BRIDGE",
-      "syllables": "bridge",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "camera",
-      "definition": "A device for taking photos",
-      "example": "Smile for the camera!",
-      "phonetic": "CAM-er-a",
-      "syllables": "cam-er-a",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "candle",
-      "definition": "Wax with a wick that burns",
-      "example": "She blew out the candle on her cake.",
-      "phonetic": "CAN-dle",
-      "syllables": "can-dle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "castle",
-      "definition": "A large fortified building",
-      "example": "The king lived in a stone castle.",
-      "phonetic": "CAS-tle",
-      "syllables": "cas-tle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "caterpillar",
-      "definition": "The larva of a butterfly",
-      "example": "The caterpillar will become a butterfly.",
-      "phonetic": "CAT-er-pil-lar",
-      "syllables": "cat-er-pil-lar",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "chocolate",
-      "definition": "A sweet food made from cacao",
-      "example": "I love dark chocolate.",
-      "phonetic": "CHOC-o-late",
-      "syllables": "choc-o-late",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "circle",
-      "definition": "A round shape",
-      "example": "Draw a circle on the paper.",
-      "phonetic": "CIR-cle",
-      "syllables": "cir-cle",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "coffee",
-      "definition": "A hot drink made from roasted beans",
-      "example": "Dad drinks coffee in the morning.",
-      "phonetic": "COF-fee",
-      "syllables": "cof-fee",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "computer",
-      "definition": "An electronic device for processing data",
-      "example": "I use the computer for homework.",
-      "phonetic": "COM-put-er",
-      "syllables": "com-put-er",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "continent",
-      "definition": "A large continuous mass of land",
-      "example": "Africa is a large continent.",
-      "phonetic": "CON-ti-nent",
-      "syllables": "con-ti-nent",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "cucumber",
-      "definition": "A long green vegetable",
-      "example": "She added sliced cucumber to the salad.",
-      "phonetic": "CU-cum-ber",
-      "syllables": "cu-cum-ber",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "curtain",
-      "definition": "Cloth hung to cover a window",
-      "example": "Close the curtain to block the sun.",
-      "phonetic": "CUR-tain",
-      "syllables": "cur-tain",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dangerous",
-      "definition": "Likely to cause harm",
-      "example": "It is dangerous to play in the street.",
-      "phonetic": "DAN-ger-ous",
-      "syllables": "dan-ger-ous",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "daughter",
-      "definition": "A female child",
-      "example": "She is her mother's daughter.",
-      "phonetic": "DAUGH-ter",
-      "syllables": "daugh-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dentist",
-      "definition": "A doctor for teeth",
-      "example": "The dentist checked for cavities.",
-      "phonetic": "DEN-tist",
-      "syllables": "den-tist",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "diamond",
-      "definition": "A precious clear stone",
-      "example": "Her ring has a sparkling diamond.",
-      "phonetic": "DI-a-mond",
-      "syllables": "di-a-mond",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "difficult",
-      "definition": "Hard to do or understand",
-      "example": "The math problem was very difficult.",
-      "phonetic": "DIF-fi-cult",
-      "syllables": "dif-fi-cult",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "direction",
-      "definition": "The path something moves along",
-      "example": "Which direction is north?",
-      "phonetic": "DI-rec-tion",
-      "syllables": "di-rec-tion",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "doctor",
-      "definition": "A person who treats sick people",
-      "example": "The doctor gave me medicine.",
-      "phonetic": "DOC-tor",
-      "syllables": "doc-tor",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dolphin",
-      "definition": "A smart marine mammal",
-      "example": "The dolphin jumped out of the water.",
-      "phonetic": "DOL-phin",
-      "syllables": "dol-phin",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "dragon",
-      "definition": "A mythical fire-breathing monster",
-      "example": "The knight fought the dragon.",
-      "phonetic": "DRAG-on",
-      "syllables": "drag-on",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "elevator",
-      "definition": "A machine for lifting people",
-      "example": "Take the elevator to the tenth floor.",
-      "phonetic": "EL-e-va-tor",
-      "syllables": "el-e-va-tor",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "engine",
-      "definition": "A machine with moving parts",
-      "example": "The car engine is running.",
-      "phonetic": "EN-gine",
-      "syllables": "en-gine",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "envelope",
-      "definition": "A paper container for a letter",
-      "example": "Put the stamp on the envelope.",
-      "phonetic": "EN-ve-lope",
-      "syllables": "en-ve-lope",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "exercise",
-      "definition": "Physical activity",
-      "example": "Running is good exercise.",
-      "phonetic": "EX-er-cise",
-      "syllables": "ex-er-cise",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "factory",
-      "definition": "A place where goods are made",
-      "example": "Cars are built in a factory.",
-      "phonetic": "FAC-to-ry",
-      "syllables": "fac-to-ry",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "family",
-      "definition": "Parents and children",
-      "example": "My family likes to go camping.",
-      "phonetic": "FAM-i-ly",
-      "syllables": "fam-i-ly",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "feather",
-      "definition": "Light growth covering a bird",
-      "example": "The feather floated to the ground.",
-      "phonetic": "FEATH-er",
-      "syllables": "feath-er",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "festival",
-      "definition": "A day or period of celebration",
-      "example": "We danced at the music festival.",
-      "phonetic": "FES-ti-val",
-      "syllables": "fes-ti-val",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "fingerprint",
-      "definition": "The mark left by a finger",
-      "example": "Everyone has a unique fingerprint.",
-      "phonetic": "FIN-ger-print",
-      "syllables": "fin-ger-print",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "fireplace",
-      "definition": "A place for a fire in a house",
-      "example": "We sat by the warm fireplace.",
-      "phonetic": "FIRE-place",
-      "syllables": "fire-place",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "forest",
-      "definition": "A large area of trees",
-      "example": "Animals hide in the forest.",
-      "phonetic": "FOR-est",
-      "syllables": "for-est",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "furniture",
-      "definition": "Movable items like chairs and tables",
-      "example": "We bought new furniture for the living room.",
-      "phonetic": "FUR-ni-ture",
-      "syllables": "fur-ni-ture",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "galaxy",
-      "definition": "A huge system of stars",
-      "example": "The Milky Way is our galaxy.",
-      "phonetic": "GAL-ax-y",
-      "syllables": "gal-ax-y",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "garage",
-      "definition": "A building for parking cars",
-      "example": "Park the car in the garage.",
-      "phonetic": "GA-rage",
-      "syllables": "ga-rage",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "geography",
-      "definition": "Study of the earth's surface",
-      "example": "We learned about maps in geography.",
-      "phonetic": "GE-og-ra-phy",
-      "syllables": "ge-og-ra-phy",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "giraffe",
-      "definition": "A tall animal with a long neck",
-      "example": "The giraffe ate leaves from the tall tree.",
-      "phonetic": "GI-raffe",
-      "syllables": "gi-raffe",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "glasses",
-      "definition": "Lenses worn to help see",
-      "example": "He needs glasses to read.",
-      "phonetic": "GLASS-es",
-      "syllables": "glass-es",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "guitar",
-      "definition": "A stringed musical instrument",
-      "example": "She played a song on her guitar.",
-      "phonetic": "GUI-tar",
-      "syllables": "gui-tar",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "helicopter",
-      "definition": "A type of aircraft",
-      "example": "The helicopter landed on the roof.",
-      "phonetic": "HEL-i-cop-ter",
-      "syllables": "hel-i-cop-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "holiday",
-      "definition": "A day of celebration",
-      "example": "Christmas is my favorite holiday.",
-      "phonetic": "HOL-i-day",
-      "syllables": "hol-i-day",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "hospital",
-      "definition": "A place for medical treatment",
-      "example": "The ambulance went to the hospital.",
-      "phonetic": "HOS-pi-tal",
-      "syllables": "hos-pi-tal",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "hurricane",
-      "definition": "A violent tropical storm",
-      "example": "The hurricane brought strong winds.",
-      "phonetic": "HUR-ri-cane",
-      "syllables": "hur-ri-cane",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "instrument",
-      "definition": "A tool or device for music",
-      "example": "Which musical instrument do you play?",
-      "phonetic": "IN-stru-ment",
-      "syllables": "in-stru-ment",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "backpack",
-      "definition": "A bag carried on the back",
-      "example": "He packed his backpack for school.",
-      "phonetic": "BACK-pack",
-      "syllables": "back-pack",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "celebrate",
-      "definition": "To honor a special event",
-      "example": "We celebrate birthdays with cake.",
-      "phonetic": "CEL-e-brate",
-      "syllables": "cel-e-brate",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "disappear",
-      "definition": "To vanish from sight",
-      "example": "The rabbit seemed to disappear.",
-      "phonetic": "DIS-ap-pear",
-      "syllables": "dis-ap-pear",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "favorite",
-      "definition": "Preferred above all others",
-      "example": "Purple is my favorite color.",
-      "phonetic": "FA-vor-ite",
-      "syllables": "fa-vor-ite",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "horizon",
-      "definition": "The line where earth and sky appear to meet",
-      "example": "The sun sank below the horizon.",
-      "phonetic": "HO-ri-zon",
-      "syllables": "ho-ri-zon",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "laughter",
-      "definition": "The sound of laughing",
-      "example": "The room filled with laughter.",
-      "phonetic": "LAUGH-ter",
-      "syllables": "laugh-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "question",
-      "definition": "A sentence asked to get information",
-      "example": "She raised her hand to ask a question.",
-      "phonetic": "QUES-tion",
-      "syllables": "ques-tion",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "shelter",
-      "definition": "A place that gives protection",
-      "example": "The hikers found shelter from the rain.",
-      "phonetic": "SHEL-ter",
-      "syllables": "shel-ter",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "whisper",
-      "definition": "To speak very softly",
-      "example": "Please whisper in the library.",
-      "phonetic": "WHIS-per",
-      "syllables": "whis-per",
-      "difficulty": "medium",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "breeze",
-      "definition": "A gentle wind",
-      "example": "A cool breeze blew across the field.",
-      "phonetic": "BREE-ze",
-      "syllables": "bree-ze",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "candle",
-      "definition": "A stick of wax with a wick",
-      "example": "We lit a candle during the power outage.",
-      "phonetic": "CAN-dle",
-      "syllables": "can-dle",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "forest",
-      "definition": "A large area covered with trees",
-      "example": "We hiked through the forest trail.",
-      "phonetic": "FOR-est",
-      "syllables": "for-est",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "guitar",
-      "definition": "A stringed musical instrument",
-      "example": "She practiced guitar after school.",
-      "phonetic": "GUI-tar",
-      "syllables": "gui-tar",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "harbor",
-      "definition": "A sheltered place for ships",
-      "example": "Fishing boats returned to the harbor.",
-      "phonetic": "HAR-bor",
-      "syllables": "har-bor",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "kitten",
-      "definition": "A young cat",
-      "example": "The kitten chased a ball of yarn.",
-      "phonetic": "KIT-ten",
-      "syllables": "kit-ten",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "ladder",
-      "definition": "A tool with steps for climbing",
-      "example": "He used a ladder to reach the shelf.",
-      "phonetic": "LAD-der",
-      "syllables": "lad-der",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "marble",
-      "definition": "A small glass ball used in games",
-      "example": "I found a blue marble on the playground.",
-      "phonetic": "MAR-ble",
-      "syllables": "mar-ble",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "nectar",
-      "definition": "Sweet liquid in flowers",
-      "example": "Bees collect nectar from bright flowers.",
-      "phonetic": "NEC-tar",
-      "syllables": "nec-tar",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "ocean",
-      "definition": "A vast body of salt water",
-      "example": "The ocean waves crashed on the shore.",
-      "phonetic": "O-cean",
-      "syllables": "o-cean",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "pencil",
-      "definition": "A tool for writing or drawing",
-      "example": "Sharpen your pencil before the quiz.",
-      "phonetic": "PEN-cil",
-      "syllables": "pen-cil",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "quartz",
-      "definition": "A hard mineral found in rocks",
-      "example": "This rock has shiny pieces of quartz.",
-      "phonetic": "QUARTZ",
-      "syllables": "quartz",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "rocket",
-      "definition": "A vehicle that travels into space",
-      "example": "The rocket launched with a loud roar.",
-      "phonetic": "ROCK-et",
-      "syllables": "rock-et",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "sunset",
-      "definition": "The daily disappearance of the sun",
-      "example": "We watched the sunset turn the sky orange.",
-      "phonetic": "SUN-set",
-      "syllables": "sun-set",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "ticket",
-      "definition": "A pass that allows entry",
-      "example": "Keep your ticket for the school play.",
-      "phonetic": "TICK-et",
-      "syllables": "tick-et",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "vacuum",
-      "definition": "A machine that cleans floors",
-      "example": "Dad used the vacuum in the living room.",
-      "phonetic": "VAC-u-um",
-      "syllables": "vac-u-um",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "window",
-      "definition": "An opening in a wall with glass",
-      "example": "Please open the window for fresh air.",
-      "phonetic": "WIN-dow",
-      "syllables": "win-dow",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "yellow",
-      "definition": "A bright color like the sun",
-      "example": "Her backpack is yellow and easy to spot.",
-      "phonetic": "YEL-low",
-      "syllables": "yel-low",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "zigzag",
-      "definition": "A line with sharp turns",
-      "example": "The skier made a zigzag down the hill.",
-      "phonetic": "ZIG-zag",
-      "syllables": "zig-zag",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    },
-    {
-      "word": "bridge",
-      "definition": "A structure built over water or roads",
-      "example": "We crossed the bridge on our bike ride.",
-      "phonetic": "BRIDGE",
-      "syllables": "bridge",
-      "difficulty": "easy",
-      "gradeLevel": "3-5"
-    }
-  ]
-}
+[
+  {
+    "word": "elephant",
+    "definition": "A large mammal with a trunk",
+    "sentence": "The elephant sprayed water with its trunk.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "el-e-phant",
+    "phonetic": "EL-e-phant"
+  },
+  {
+    "word": "island",
+    "definition": "Land surrounded by water",
+    "sentence": "They sailed to a small island.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "is-land",
+    "phonetic": "IS-land"
+  },
+  {
+    "word": "jungle",
+    "definition": "Dense tropical forest",
+    "sentence": "The explorer ventured into the jungle.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "jun-gle",
+    "phonetic": "JUN-gle"
+  },
+  {
+    "word": "night",
+    "definition": "The period of darkness",
+    "sentence": "Stars appeared in the night sky.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "night",
+    "phonetic": "NIGHT"
+  },
+  {
+    "word": "orange",
+    "definition": "A round citrus fruit",
+    "sentence": "He peeled an orange for breakfast.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "or-ange",
+    "phonetic": "OR-ange"
+  },
+  {
+    "word": "beautiful",
+    "definition": "Pleasing to the senses",
+    "sentence": "The sunset was absolutely beautiful.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "beau-ti-ful",
+    "phonetic": "BEAU-ti-ful"
+  },
+  {
+    "word": "calendar",
+    "definition": "A system for organizing days",
+    "sentence": "Mark the date on your calendar.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cal-en-dar",
+    "phonetic": "CAL-en-dar"
+  },
+  {
+    "word": "dinosaur",
+    "definition": "An extinct prehistoric reptile",
+    "sentence": "The museum had a dinosaur skeleton.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "di-no-saur",
+    "phonetic": "DI-no-saur"
+  },
+  {
+    "word": "emergency",
+    "definition": "A serious unexpected situation",
+    "sentence": "Call 911 in case of emergency.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "e-mer-gen-cy",
+    "phonetic": "E-mer-gen-cy"
+  },
+  {
+    "word": "february",
+    "definition": "The second month of the year",
+    "sentence": "February is the shortest month.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "feb-ru-ar-y",
+    "phonetic": "FEB-ru-ar-y"
+  },
+  {
+    "word": "government",
+    "definition": "The ruling body of a nation",
+    "sentence": "The government passed new legislation.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gov-ern-ment",
+    "phonetic": "GOV-ern-ment"
+  },
+  {
+    "word": "hamburger",
+    "definition": "A sandwich with a meat patty",
+    "sentence": "I ordered a hamburger with fries.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ham-bur-ger",
+    "phonetic": "HAM-bur-ger"
+  },
+  {
+    "word": "immediately",
+    "definition": "Without delay",
+    "sentence": "Please respond immediately.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "im-me-di-ate-ly",
+    "phonetic": "IM-me-di-ate-ly"
+  },
+  {
+    "word": "jealousy",
+    "definition": "Feeling of envy",
+    "sentence": "Jealousy can damage relationships.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "jeal-ous-y",
+    "phonetic": "JEAL-ous-y"
+  },
+  {
+    "word": "knowledge",
+    "definition": "Information and understanding",
+    "sentence": "Knowledge is power.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "knowl-edge",
+    "phonetic": "KNOWL-edge"
+  },
+  {
+    "word": "lieutenant",
+    "definition": "A military rank",
+    "sentence": "The lieutenant led the platoon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "lieu-ten-ant",
+    "phonetic": "LIEU-ten-ant"
+  },
+  {
+    "word": "mysterious",
+    "definition": "Difficult to understand",
+    "sentence": "A mysterious package arrived.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "mys-te-ri-ous",
+    "phonetic": "MYS-te-ri-ous"
+  },
+  {
+    "word": "necessary",
+    "definition": "Required or essential",
+    "sentence": "Water is necessary for life.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "nec-es-sar-y",
+    "phonetic": "NEC-es-sar-y"
+  },
+  {
+    "word": "occasion",
+    "definition": "A special event or time",
+    "sentence": "This is a special occasion.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "oc-ca-sion",
+    "phonetic": "OC-ca-sion"
+  },
+  {
+    "word": "psychology",
+    "definition": "The study of the mind",
+    "sentence": "She studied psychology in college.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "psy-chol-o-gy",
+    "phonetic": "PSY-chol-o-gy"
+  },
+  {
+    "word": "questionnaire",
+    "definition": "A set of written questions",
+    "sentence": "Please complete this questionnaire.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ques-tion-naire",
+    "phonetic": "QUES-tion-naire"
+  },
+  {
+    "word": "restaurant",
+    "definition": "A place to eat meals",
+    "sentence": "We dined at an Italian restaurant.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "res-tau-rant",
+    "phonetic": "RES-tau-rant"
+  },
+  {
+    "word": "adventure",
+    "definition": "An exciting or unusual experience",
+    "sentence": "They went on an adventure in the woods.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ad-ven-ture",
+    "phonetic": "AD-ven-ture"
+  },
+  {
+    "word": "alphabet",
+    "definition": "The letters of a language",
+    "sentence": "She learned to sing the alphabet song.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "al-pha-bet",
+    "phonetic": "AL-pha-bet"
+  },
+  {
+    "word": "apartment",
+    "definition": "A set of rooms for living in",
+    "sentence": "We live in an apartment on the third floor.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "a-part-ment",
+    "phonetic": "A-part-ment"
+  },
+  {
+    "word": "astronaut",
+    "definition": "A person trained to travel in space",
+    "sentence": "The astronaut walked on the moon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "as-tro-naut",
+    "phonetic": "AS-tro-naut"
+  },
+  {
+    "word": "autumn",
+    "definition": "The season after summer",
+    "sentence": "Leaves turn colors in autumn.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "au-tumn",
+    "phonetic": "AU-tumn"
+  },
+  {
+    "word": "bakery",
+    "definition": "A place where bread and cakes are made",
+    "sentence": "We bought fresh donuts at the bakery.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bak-er-y",
+    "phonetic": "BAK-er-y"
+  },
+  {
+    "word": "balcony",
+    "definition": "A platform on the outside of a building",
+    "sentence": "She stood on the balcony to watch the parade.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bal-co-ny",
+    "phonetic": "BAL-co-ny"
+  },
+  {
+    "word": "banana",
+    "definition": "A long curved yellow fruit",
+    "sentence": "Monkeys love to eat a banana.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ba-nan-a",
+    "phonetic": "BA-nan-a"
+  },
+  {
+    "word": "basket",
+    "definition": "A container woven from cane or wire",
+    "sentence": "Put the apples in the basket.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bas-ket",
+    "phonetic": "BAS-ket"
+  },
+  {
+    "word": "blanket",
+    "definition": "A soft covering for a bed",
+    "sentence": "The baby was wrapped in a warm blanket.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "blan-ket",
+    "phonetic": "BLAN-ket"
+  },
+  {
+    "word": "bottle",
+    "definition": "A container with a narrow neck",
+    "sentence": "He drank water from a plastic bottle.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bot-tle",
+    "phonetic": "BOT-tle"
+  },
+  {
+    "word": "bridge",
+    "definition": "A structure across a river or road",
+    "sentence": "Cars drove over the bridge.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "bridge",
+    "phonetic": "BRIDGE"
+  },
+  {
+    "word": "camera",
+    "definition": "A device for taking photos",
+    "sentence": "Smile for the camera!",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cam-er-a",
+    "phonetic": "CAM-er-a"
+  },
+  {
+    "word": "candle",
+    "definition": "Wax with a wick that burns",
+    "sentence": "She blew out the candle on her cake.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "can-dle",
+    "phonetic": "CAN-dle"
+  },
+  {
+    "word": "castle",
+    "definition": "A large fortified building",
+    "sentence": "The king lived in a stone castle.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cas-tle",
+    "phonetic": "CAS-tle"
+  },
+  {
+    "word": "caterpillar",
+    "definition": "The larva of a butterfly",
+    "sentence": "The caterpillar will become a butterfly.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cat-er-pil-lar",
+    "phonetic": "CAT-er-pil-lar"
+  },
+  {
+    "word": "chocolate",
+    "definition": "A sweet food made from cacao",
+    "sentence": "I love dark chocolate.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "choc-o-late",
+    "phonetic": "CHOC-o-late"
+  },
+  {
+    "word": "circle",
+    "definition": "A round shape",
+    "sentence": "Draw a circle on the paper.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cir-cle",
+    "phonetic": "CIR-cle"
+  },
+  {
+    "word": "coffee",
+    "definition": "A hot drink made from roasted beans",
+    "sentence": "Dad drinks coffee in the morning.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cof-fee",
+    "phonetic": "COF-fee"
+  },
+  {
+    "word": "computer",
+    "definition": "An electronic device for processing data",
+    "sentence": "I use the computer for homework.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "com-put-er",
+    "phonetic": "COM-put-er"
+  },
+  {
+    "word": "continent",
+    "definition": "A large continuous mass of land",
+    "sentence": "Africa is a large continent.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "con-ti-nent",
+    "phonetic": "CON-ti-nent"
+  },
+  {
+    "word": "cucumber",
+    "definition": "A long green vegetable",
+    "sentence": "She added sliced cucumber to the salad.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cu-cum-ber",
+    "phonetic": "CU-cum-ber"
+  },
+  {
+    "word": "curtain",
+    "definition": "Cloth hung to cover a window",
+    "sentence": "Close the curtain to block the sun.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cur-tain",
+    "phonetic": "CUR-tain"
+  },
+  {
+    "word": "dangerous",
+    "definition": "Likely to cause harm",
+    "sentence": "It is dangerous to play in the street.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dan-ger-ous",
+    "phonetic": "DAN-ger-ous"
+  },
+  {
+    "word": "daughter",
+    "definition": "A female child",
+    "sentence": "She is her mother's daughter.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "daugh-ter",
+    "phonetic": "DAUGH-ter"
+  },
+  {
+    "word": "dentist",
+    "definition": "A doctor for teeth",
+    "sentence": "The dentist checked for cavities.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "den-tist",
+    "phonetic": "DEN-tist"
+  },
+  {
+    "word": "diamond",
+    "definition": "A precious clear stone",
+    "sentence": "Her ring has a sparkling diamond.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "di-a-mond",
+    "phonetic": "DI-a-mond"
+  },
+  {
+    "word": "difficult",
+    "definition": "Hard to do or understand",
+    "sentence": "The math problem was very difficult.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dif-fi-cult",
+    "phonetic": "DIF-fi-cult"
+  },
+  {
+    "word": "direction",
+    "definition": "The path something moves along",
+    "sentence": "Which direction is north?",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "di-rec-tion",
+    "phonetic": "DI-rec-tion"
+  },
+  {
+    "word": "doctor",
+    "definition": "A person who treats sick people",
+    "sentence": "The doctor gave me medicine.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "doc-tor",
+    "phonetic": "DOC-tor"
+  },
+  {
+    "word": "dolphin",
+    "definition": "A smart marine mammal",
+    "sentence": "The dolphin jumped out of the water.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dol-phin",
+    "phonetic": "DOL-phin"
+  },
+  {
+    "word": "dragon",
+    "definition": "A mythical fire-breathing monster",
+    "sentence": "The knight fought the dragon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "drag-on",
+    "phonetic": "DRAG-on"
+  },
+  {
+    "word": "elevator",
+    "definition": "A machine for lifting people",
+    "sentence": "Take the elevator to the tenth floor.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "el-e-va-tor",
+    "phonetic": "EL-e-va-tor"
+  },
+  {
+    "word": "engine",
+    "definition": "A machine with moving parts",
+    "sentence": "The car engine is running.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "en-gine",
+    "phonetic": "EN-gine"
+  },
+  {
+    "word": "envelope",
+    "definition": "A paper container for a letter",
+    "sentence": "Put the stamp on the envelope.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "en-ve-lope",
+    "phonetic": "EN-ve-lope"
+  },
+  {
+    "word": "exercise",
+    "definition": "Physical activity",
+    "sentence": "Running is good exercise.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ex-er-cise",
+    "phonetic": "EX-er-cise"
+  },
+  {
+    "word": "factory",
+    "definition": "A place where goods are made",
+    "sentence": "Cars are built in a factory.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fac-to-ry",
+    "phonetic": "FAC-to-ry"
+  },
+  {
+    "word": "family",
+    "definition": "Parents and children",
+    "sentence": "My family likes to go camping.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fam-i-ly",
+    "phonetic": "FAM-i-ly"
+  },
+  {
+    "word": "feather",
+    "definition": "Light growth covering a bird",
+    "sentence": "The feather floated to the ground.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "feath-er",
+    "phonetic": "FEATH-er"
+  },
+  {
+    "word": "festival",
+    "definition": "A day or period of celebration",
+    "sentence": "We danced at the music festival.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fes-ti-val",
+    "phonetic": "FES-ti-val"
+  },
+  {
+    "word": "fingerprint",
+    "definition": "The mark left by a finger",
+    "sentence": "Everyone has a unique fingerprint.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fin-ger-print",
+    "phonetic": "FIN-ger-print"
+  },
+  {
+    "word": "fireplace",
+    "definition": "A place for a fire in a house",
+    "sentence": "We sat by the warm fireplace.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fire-place",
+    "phonetic": "FIRE-place"
+  },
+  {
+    "word": "forest",
+    "definition": "A large area of trees",
+    "sentence": "Animals hide in the forest.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "for-est",
+    "phonetic": "FOR-est"
+  },
+  {
+    "word": "furniture",
+    "definition": "Movable items like chairs and tables",
+    "sentence": "We bought new furniture for the living room.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fur-ni-ture",
+    "phonetic": "FUR-ni-ture"
+  },
+  {
+    "word": "galaxy",
+    "definition": "A huge system of stars",
+    "sentence": "The Milky Way is our galaxy.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gal-ax-y",
+    "phonetic": "GAL-ax-y"
+  },
+  {
+    "word": "garage",
+    "definition": "A building for parking cars",
+    "sentence": "Park the car in the garage.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ga-rage",
+    "phonetic": "GA-rage"
+  },
+  {
+    "word": "geography",
+    "definition": "Study of the earth's surface",
+    "sentence": "We learned about maps in geography.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ge-og-ra-phy",
+    "phonetic": "GE-og-ra-phy"
+  },
+  {
+    "word": "giraffe",
+    "definition": "A tall animal with a long neck",
+    "sentence": "The giraffe ate leaves from the tall tree.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gi-raffe",
+    "phonetic": "GI-raffe"
+  },
+  {
+    "word": "glasses",
+    "definition": "Lenses worn to help see",
+    "sentence": "He needs glasses to read.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "glass-es",
+    "phonetic": "GLASS-es"
+  },
+  {
+    "word": "guitar",
+    "definition": "A stringed musical instrument",
+    "sentence": "She played a song on her guitar.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "gui-tar",
+    "phonetic": "GUI-tar"
+  },
+  {
+    "word": "helicopter",
+    "definition": "A type of aircraft",
+    "sentence": "The helicopter landed on the roof.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hel-i-cop-ter",
+    "phonetic": "HEL-i-cop-ter"
+  },
+  {
+    "word": "holiday",
+    "definition": "A day of celebration",
+    "sentence": "Christmas is my favorite holiday.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hol-i-day",
+    "phonetic": "HOL-i-day"
+  },
+  {
+    "word": "hospital",
+    "definition": "A place for medical treatment",
+    "sentence": "The ambulance went to the hospital.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hos-pi-tal",
+    "phonetic": "HOS-pi-tal"
+  },
+  {
+    "word": "hurricane",
+    "definition": "A violent tropical storm",
+    "sentence": "The hurricane brought strong winds.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "hur-ri-cane",
+    "phonetic": "HUR-ri-cane"
+  },
+  {
+    "word": "instrument",
+    "definition": "A tool or device for music",
+    "sentence": "Which musical instrument do you play?",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "in-stru-ment",
+    "phonetic": "IN-stru-ment"
+  },
+  {
+    "word": "backpack",
+    "definition": "A bag carried on the back",
+    "sentence": "He packed his backpack for school.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "back-pack",
+    "phonetic": "BACK-pack"
+  },
+  {
+    "word": "celebrate",
+    "definition": "To honor a special event",
+    "sentence": "We celebrate birthdays with cake.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "cel-e-brate",
+    "phonetic": "CEL-e-brate"
+  },
+  {
+    "word": "disappear",
+    "definition": "To vanish from sight",
+    "sentence": "The rabbit seemed to disappear.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "dis-ap-pear",
+    "phonetic": "DIS-ap-pear"
+  },
+  {
+    "word": "favorite",
+    "definition": "Preferred above all others",
+    "sentence": "Purple is my favorite color.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "fa-vor-ite",
+    "phonetic": "FA-vor-ite"
+  },
+  {
+    "word": "horizon",
+    "definition": "The line where earth and sky appear to meet",
+    "sentence": "The sun sank below the horizon.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ho-ri-zon",
+    "phonetic": "HO-ri-zon"
+  },
+  {
+    "word": "laughter",
+    "definition": "The sound of laughing",
+    "sentence": "The room filled with laughter.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "laugh-ter",
+    "phonetic": "LAUGH-ter"
+  },
+  {
+    "word": "question",
+    "definition": "A sentence asked to get information",
+    "sentence": "She raised her hand to ask a question.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "ques-tion",
+    "phonetic": "QUES-tion"
+  },
+  {
+    "word": "shelter",
+    "definition": "A place that gives protection",
+    "sentence": "The hikers found shelter from the rain.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "shel-ter",
+    "phonetic": "SHEL-ter"
+  },
+  {
+    "word": "whisper",
+    "definition": "To speak very softly",
+    "sentence": "Please whisper in the library.",
+    "grade": 3,
+    "difficulty": "medium",
+    "syllables": "whis-per",
+    "phonetic": "WHIS-per"
+  },
+  {
+    "word": "breeze",
+    "definition": "A gentle wind",
+    "sentence": "A cool breeze blew across the field.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "bree-ze",
+    "phonetic": "BREE-ze"
+  },
+  {
+    "word": "harbor",
+    "definition": "A sheltered place for ships",
+    "sentence": "Fishing boats returned to the harbor.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "har-bor",
+    "phonetic": "HAR-bor"
+  },
+  {
+    "word": "kitten",
+    "definition": "A young cat",
+    "sentence": "The kitten chased a ball of yarn.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "kit-ten",
+    "phonetic": "KIT-ten"
+  },
+  {
+    "word": "ladder",
+    "definition": "A tool with steps for climbing",
+    "sentence": "He used a ladder to reach the shelf.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "lad-der",
+    "phonetic": "LAD-der"
+  },
+  {
+    "word": "marble",
+    "definition": "A small glass ball used in games",
+    "sentence": "I found a blue marble on the playground.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "mar-ble",
+    "phonetic": "MAR-ble"
+  },
+  {
+    "word": "nectar",
+    "definition": "Sweet liquid in flowers",
+    "sentence": "Bees collect nectar from bright flowers.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "nec-tar",
+    "phonetic": "NEC-tar"
+  },
+  {
+    "word": "ocean",
+    "definition": "A vast body of salt water",
+    "sentence": "The ocean waves crashed on the shore.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "o-cean",
+    "phonetic": "O-cean"
+  },
+  {
+    "word": "pencil",
+    "definition": "A tool for writing or drawing",
+    "sentence": "Sharpen your pencil before the quiz.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "pen-cil",
+    "phonetic": "PEN-cil"
+  },
+  {
+    "word": "quartz",
+    "definition": "A hard mineral found in rocks",
+    "sentence": "This rock has shiny pieces of quartz.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "quartz",
+    "phonetic": "QUARTZ"
+  },
+  {
+    "word": "rocket",
+    "definition": "A vehicle that travels into space",
+    "sentence": "The rocket launched with a loud roar.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "rock-et",
+    "phonetic": "ROCK-et"
+  },
+  {
+    "word": "sunset",
+    "definition": "The daily disappearance of the sun",
+    "sentence": "We watched the sunset turn the sky orange.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "sun-set",
+    "phonetic": "SUN-set"
+  },
+  {
+    "word": "ticket",
+    "definition": "A pass that allows entry",
+    "sentence": "Keep your ticket for the school play.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "tick-et",
+    "phonetic": "TICK-et"
+  },
+  {
+    "word": "vacuum",
+    "definition": "A machine that cleans floors",
+    "sentence": "Dad used the vacuum in the living room.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "vac-u-um",
+    "phonetic": "VAC-u-um"
+  },
+  {
+    "word": "window",
+    "definition": "An opening in a wall with glass",
+    "sentence": "Please open the window for fresh air.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "win-dow",
+    "phonetic": "WIN-dow"
+  },
+  {
+    "word": "yellow",
+    "definition": "A bright color like the sun",
+    "sentence": "Her backpack is yellow and easy to spot.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "yel-low",
+    "phonetic": "YEL-low"
+  },
+  {
+    "word": "zigzag",
+    "definition": "A line with sharp turns",
+    "sentence": "The skier made a zigzag down the hill.",
+    "grade": 3,
+    "difficulty": "easy",
+    "syllables": "zig-zag",
+    "phonetic": "ZIG-zag"
+  }
+]

--- a/public/data/words/grade-6.json
+++ b/public/data/words/grade-6.json
@@ -1,1125 +1,1118 @@
-{
-  "grade": 6,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 124,
-  "words": [
-    {
-      "word": "accommodate",
-      "definition": "To provide lodging or adjust to",
-      "example": "The hotel can accommodate 200 guests.",
-      "phonetic": "AC-com-mo-date",
-      "syllables": "ac-com-mo-date",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bureaucracy",
-      "definition": "Administrative government system",
-      "example": "The bureaucracy slowed the process.",
-      "phonetic": "BU-reau-cra-cy",
-      "syllables": "bu-reau-cra-cy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conscientious",
-      "definition": "Thorough and careful",
-      "example": "She is a conscientious worker.",
-      "phonetic": "CON-sci-en-tious",
-      "syllables": "con-sci-en-tious",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "entrepreneur",
-      "definition": "A business founder",
-      "example": "The entrepreneur started three companies.",
-      "phonetic": "EN-tre-pre-neur",
-      "syllables": "en-tre-pre-neur",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "fluorescent",
-      "definition": "Emitting bright light",
-      "example": "The fluorescent lights buzzed overhead.",
-      "phonetic": "FLU-o-res-cent",
-      "syllables": "flu-o-res-cent",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "guarantee",
-      "definition": "A formal promise",
-      "example": "The product comes with a guarantee.",
-      "phonetic": "GUAR-an-tee",
-      "syllables": "guar-an-tee",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "hemorrhage",
-      "definition": "Severe bleeding",
-      "example": "The doctor stopped the hemorrhage.",
-      "phonetic": "HEM-or-rhage",
-      "syllables": "hem-or-rhage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "inconvenience",
-      "definition": "Trouble or difficulty",
-      "example": "Sorry for any inconvenience caused.",
-      "phonetic": "IN-con-ven-ience",
-      "syllables": "in-con-ven-ience",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "jeopardize",
-      "definition": "To put at risk",
-      "example": "Don't jeopardize your future.",
-      "phonetic": "JEOP-ar-dize",
-      "syllables": "jeop-ar-dize",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "knowledgeable",
-      "definition": "Well informed",
-      "example": "The guide was very knowledgeable.",
-      "phonetic": "KNOWL-edge-a-ble",
-      "syllables": "knowl-edge-a-ble",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "liaison",
-      "definition": "A person who links groups",
-      "example": "She serves as liaison between departments.",
-      "phonetic": "LI-ai-son",
-      "syllables": "li-ai-son",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "mischievous",
-      "definition": "Playfully troublesome",
-      "example": "The mischievous child hid the keys.",
-      "phonetic": "MIS-chie-vous",
-      "syllables": "mis-chie-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "onomatopoeia",
-      "definition": "Words that imitate sounds",
-      "example": "Buzz is an example of onomatopoeia.",
-      "phonetic": "ON-o-mat-o-poe-ia",
-      "syllables": "on-o-mat-o-poe-ia",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "pharmaceutical",
-      "definition": "Related to medicinal drugs",
-      "example": "The pharmaceutical company developed a vaccine.",
-      "phonetic": "PHAR-ma-ceu-ti-cal",
-      "syllables": "phar-ma-ceu-ti-cal",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "rendezvous",
-      "definition": "A planned meeting",
-      "example": "They arranged a secret rendezvous.",
-      "phonetic": "REN-dez-vous",
-      "syllables": "ren-dez-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "surveillance",
-      "definition": "Close observation",
-      "example": "The building has surveillance cameras.",
-      "phonetic": "SUR-veil-lance",
-      "syllables": "sur-veil-lance",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "tyranny",
-      "definition": "Cruel oppressive rule",
-      "example": "The people rose against tyranny.",
-      "phonetic": "TYR-an-ny",
-      "syllables": "tyr-an-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ubiquitous",
-      "definition": "Present everywhere",
-      "example": "Smartphones are now ubiquitous.",
-      "phonetic": "U-biq-ui-tous",
-      "syllables": "u-biq-ui-tous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "vocabulary",
-      "definition": "Words known or used",
-      "example": "Reading expands your vocabulary.",
-      "phonetic": "VO-cab-u-lar-y",
-      "syllables": "vo-cab-u-lar-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "Wednesday",
-      "definition": "The fourth day of the week",
-      "example": "The meeting is on Wednesday.",
-      "phonetic": "WEDNES-day",
-      "syllables": "Wednes-day",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "achievement",
-      "definition": "Something done successfully",
-      "example": "Winning the game was a great achievement.",
-      "phonetic": "A-chieve-ment",
-      "syllables": "a-chieve-ment",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "acoustic",
-      "definition": "Related to sound or hearing",
-      "example": "He played an acoustic guitar.",
-      "phonetic": "A-cous-tic",
-      "syllables": "a-cous-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "algorithm",
-      "definition": "A set of rules for solving a problem",
-      "example": "The computer uses an algorithm to search.",
-      "phonetic": "AL-go-rithm",
-      "syllables": "al-go-rithm",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "amphibian",
-      "definition": "An animal living on land and water",
-      "example": "A frog is a type of amphibian.",
-      "phonetic": "AM-phib-i-an",
-      "syllables": "am-phib-i-an",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "analysis",
-      "definition": "Detailed examination",
-      "example": "The scientist performed an analysis of the data.",
-      "phonetic": "A-nal-y-sis",
-      "syllables": "a-nal-y-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ancient",
-      "definition": "Belonging to the very distant past",
-      "example": "They visited the ancient ruins.",
-      "phonetic": "AN-cient",
-      "syllables": "an-cient",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anniversary",
-      "definition": "Date on which an event took place",
-      "example": "They celebrated their wedding anniversary.",
-      "phonetic": "AN-ni-ver-sa-ry",
-      "syllables": "an-ni-ver-sa-ry",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anonymous",
-      "definition": "Not identified by name",
-      "example": "The donor chose to remain anonymous.",
-      "phonetic": "A-non-y-mous",
-      "syllables": "a-non-y-mous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "antique",
-      "definition": "A collectible object having a high value",
-      "example": "This chair is a valuable antique.",
-      "phonetic": "AN-tique",
-      "syllables": "an-tique",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anxiety",
-      "definition": "A feeling of worry or nervousness",
-      "example": "He felt anxiety before the test.",
-      "phonetic": "ANX-i-e-ty",
-      "syllables": "anx-i-e-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "appreciate",
-      "definition": "To recognize the full worth of",
-      "example": "I appreciate your help.",
-      "phonetic": "AP-pre-ci-ate",
-      "syllables": "ap-pre-ci-ate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "aquarium",
-      "definition": "A tank of water for fish",
-      "example": "We saw sharks at the aquarium.",
-      "phonetic": "A-quar-i-um",
-      "syllables": "a-quar-i-um",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "architecture",
-      "definition": "The art of designing buildings",
-      "example": "The city has beautiful architecture.",
-      "phonetic": "AR-chi-tec-ture",
-      "syllables": "ar-chi-tec-ture",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "arithmetic",
-      "definition": "The branch of math with numbers",
-      "example": "We learned arithmetic in school.",
-      "phonetic": "A-rith-me-tic",
-      "syllables": "a-rith-me-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "artificial",
-      "definition": "Made by humans, not natural",
-      "example": "The flowers are artificial.",
-      "phonetic": "AR-ti-fi-cial",
-      "syllables": "ar-ti-fi-cial",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "atmosphere",
-      "definition": "Gases surrounding a planet",
-      "example": "The atmosphere protects the Earth.",
-      "phonetic": "AT-mos-phere",
-      "syllables": "at-mos-phere",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "audience",
-      "definition": "Spectators at an event",
-      "example": "The audience clapped loudly.",
-      "phonetic": "AU-di-ence",
-      "syllables": "au-di-ence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "authentic",
-      "definition": "Of undisputed origin; genuine",
-      "example": "This is an authentic painting.",
-      "phonetic": "AU-then-tic",
-      "syllables": "au-then-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "biography",
-      "definition": "An account of someone's life",
-      "example": "I read a biography of Lincoln.",
-      "phonetic": "BI-og-ra-phy",
-      "syllables": "bi-og-ra-phy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bizarre",
-      "definition": "Very strange or unusual",
-      "example": "It was a bizarre situation.",
-      "phonetic": "BI-zarre",
-      "syllables": "bi-zarre",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "camouflage",
-      "definition": "Disguise to blend with surroundings",
-      "example": "The soldier wore camouflage.",
-      "phonetic": "CAM-ou-flage",
-      "syllables": "cam-ou-flage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "campaign",
-      "definition": "A series of actions for a goal",
-      "example": "The election campaign was intense.",
-      "phonetic": "CAM-paign",
-      "syllables": "cam-paign",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "capacity",
-      "definition": "The maximum amount something can hold",
-      "example": "The stadium was filled to capacity.",
-      "phonetic": "CA-pac-i-ty",
-      "syllables": "ca-pac-i-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "catastrophe",
-      "definition": "A sudden great disaster",
-      "example": "The earthquake was a catastrophe.",
-      "phonetic": "CA-tas-tro-phe",
-      "syllables": "ca-tas-tro-phe",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "cemetery",
-      "definition": "A place for burying the dead",
-      "example": "They visited the old cemetery.",
-      "phonetic": "CEM-e-ter-y",
-      "syllables": "cem-e-ter-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ceremony",
-      "definition": "A formal religious or public occasion",
-      "example": "The graduation ceremony is tomorrow.",
-      "phonetic": "CER-e-mo-ny",
-      "syllables": "cer-e-mo-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chameleon",
-      "definition": "A lizard that changes color",
-      "example": "The chameleon turned green.",
-      "phonetic": "CHA-me-le-on",
-      "syllables": "cha-me-le-on",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chandelier",
-      "definition": "A decorative hanging light",
-      "example": "A crystal chandelier hung in the hall.",
-      "phonetic": "CHAN-de-lier",
-      "syllables": "chan-de-lier",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "character",
-      "definition": "A person in a novel or movie",
-      "example": "Who is your favorite character?",
-      "phonetic": "CHAR-ac-ter",
-      "syllables": "char-ac-ter",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chemistry",
-      "definition": "Science of substances and reactions",
-      "example": "We did experiments in chemistry class.",
-      "phonetic": "CHEM-is-try",
-      "syllables": "chem-is-try",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "choreography",
-      "definition": "The sequence of steps in dance",
-      "example": "The ballet choreography was complex.",
-      "phonetic": "CHO-re-og-ra-phy",
-      "syllables": "cho-re-og-ra-phy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "circumference",
-      "definition": "The distance around a circle",
-      "example": "Measure the circumference of the ball.",
-      "phonetic": "CIR-cum-fer-ence",
-      "syllables": "cir-cum-fer-ence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "civilization",
-      "definition": "Advanced stage of human social development",
-      "example": "Ancient Rome was a great civilization.",
-      "phonetic": "CIV-i-li-za-tion",
-      "syllables": "civ-i-li-za-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "coincidence",
-      "definition": "Events happening together by chance",
-      "example": "It was a coincidence that we met.",
-      "phonetic": "CO-in-ci-dence",
-      "syllables": "co-in-ci-dence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "collaborate",
-      "definition": "Work jointly on an activity",
-      "example": "We will collaborate on the project.",
-      "phonetic": "COL-lab-o-rate",
-      "syllables": "col-lab-o-rate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "collision",
-      "definition": "An instance of one moving object striking another",
-      "example": "The car collision caused a traffic jam.",
-      "phonetic": "COL-li-sion",
-      "syllables": "col-li-sion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "column",
-      "definition": "An upright pillar",
-      "example": "The roof was supported by a stone column.",
-      "phonetic": "COL-umn",
-      "syllables": "col-umn",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "committee",
-      "definition": "A group of people appointed for a function",
-      "example": "The committee will vote on the issue.",
-      "phonetic": "COM-mit-tee",
-      "syllables": "com-mit-tee",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "communicate",
-      "definition": "Share or exchange information",
-      "example": "We communicate by email.",
-      "phonetic": "COM-mu-ni-cate",
-      "syllables": "com-mu-ni-cate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "community",
-      "definition": "A group of people living in the same place",
-      "example": "We have a friendly community.",
-      "phonetic": "COM-mu-ni-ty",
-      "syllables": "com-mu-ni-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "competition",
-      "definition": "The activity of competing",
-      "example": "She won the swimming competition.",
-      "phonetic": "COM-pe-ti-tion",
-      "syllables": "com-pe-ti-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "complicated",
-      "definition": "Consisting of many interconnecting parts",
-      "example": "The instructions were very complicated.",
-      "phonetic": "COM-pli-cat-ed",
-      "syllables": "com-pli-cat-ed",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "concentrate",
-      "definition": "Focus one's attention",
-      "example": "I need to concentrate on my work.",
-      "phonetic": "CON-cen-trate",
-      "syllables": "con-cen-trate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conclusion",
-      "definition": "The end or finish of an event",
-      "example": "The conclusion of the story was sad.",
-      "phonetic": "CON-clu-sion",
-      "syllables": "con-clu-sion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "confident",
-      "definition": "Feeling certain about ability",
-      "example": "He is confident he will pass.",
-      "phonetic": "CON-fi-dent",
-      "syllables": "con-fi-dent",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "consequence",
-      "definition": "A result or effect of an action",
-      "example": "Every action has a consequence.",
-      "phonetic": "CON-se-quence",
-      "syllables": "con-se-quence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "constellation",
-      "definition": "A group of stars forming a pattern",
-      "example": "Can you find the Big Dipper constellation?",
-      "phonetic": "CON-stel-la-tion",
-      "syllables": "con-stel-la-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "contagious",
-      "definition": "Spread from one person to another",
-      "example": "The flu is very contagious.",
-      "phonetic": "CON-ta-gious",
-      "syllables": "con-ta-gious",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "controversial",
-      "definition": "Giving rise to public disagreement",
-      "example": "It was a controversial decision.",
-      "phonetic": "CON-tro-ver-sial",
-      "syllables": "con-tro-ver-sial",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "convenient",
-      "definition": "Fitting in well with needs",
-      "example": "It is convenient to live near the store.",
-      "phonetic": "CON-ven-ient",
-      "syllables": "con-ven-ient",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conversation",
-      "definition": "A talk between two or more people",
-      "example": "They had a long conversation.",
-      "phonetic": "CON-ver-sa-tion",
-      "syllables": "con-ver-sa-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "cooperation",
-      "definition": "The process of working together",
-      "example": "The project requires cooperation.",
-      "phonetic": "CO-op-er-a-tion",
-      "syllables": "co-op-er-a-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "corporation",
-      "definition": "A large company",
-      "example": "She works for a major corporation.",
-      "phonetic": "COR-po-ra-tion",
-      "syllables": "cor-po-ra-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "courageous",
-      "definition": "Not deterred by danger or pain",
-      "example": "The firefighter was very courageous.",
-      "phonetic": "COUR-a-geous",
-      "syllables": "cour-a-geous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "criticism",
-      "definition": "Expression of disapproval",
-      "example": "He accepted the criticism gracefully.",
-      "phonetic": "CRIT-i-cism",
-      "syllables": "crit-i-cism",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "biodiversity",
-      "definition": "The variety of plant and animal life in an area",
-      "example": "Rainforests are known for rich biodiversity.",
-      "phonetic": "BI-o-di-ver-si-ty",
-      "syllables": "bi-o-di-ver-si-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "collaboration",
-      "definition": "Working jointly with others",
-      "example": "The project succeeded through collaboration.",
-      "phonetic": "COL-lab-o-ra-tion",
-      "syllables": "col-lab-o-ra-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "determination",
-      "definition": "Firmness of purpose",
-      "example": "Her determination helped her finish the race.",
-      "phonetic": "DE-ter-mi-na-tion",
-      "syllables": "de-ter-mi-na-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "geothermal",
-      "definition": "Relating to heat produced inside the earth",
-      "example": "Iceland uses geothermal energy for power.",
-      "phonetic": "GE-o-ther-mal",
-      "syllables": "ge-o-ther-mal",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "hypothesis",
-      "definition": "A proposed explanation for testing",
-      "example": "The class tested each hypothesis in the lab.",
-      "phonetic": "HY-poth-e-sis",
-      "syllables": "hy-poth-e-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "metamorphosis",
-      "definition": "A major change in form during development",
-      "example": "A butterfly emerges after metamorphosis.",
-      "phonetic": "MET-a-mor-pho-sis",
-      "syllables": "met-a-mor-pho-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "resilience",
-      "definition": "The ability to recover from difficulty",
-      "example": "Resilience helps people handle setbacks.",
-      "phonetic": "RE-sil-ience",
-      "syllables": "re-sil-ience",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "sustainability",
-      "definition": "Using resources in a way that avoids long-term harm",
-      "example": "The city adopted sustainability goals.",
-      "phonetic": "SUS-tain-a-bil-i-ty",
-      "syllables": "sus-tain-a-bil-i-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "wordsmith",
-      "definition": "A person skilled at using words effectively",
-      "example": "The poet was praised as a talented wordsmith.",
-      "phonetic": "WORD-smith",
-      "syllables": "word-smith",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ability",
-      "definition": "The power to do something",
-      "example": "Practice improves your ability to solve problems.",
-      "phonetic": "A-bil-i-ty",
-      "syllables": "a-bil-i-ty",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "balance",
-      "definition": "A steady position without falling",
-      "example": "Yoga helps improve balance and focus.",
-      "phonetic": "BAL-ance",
-      "syllables": "bal-ance",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "capture",
-      "definition": "To catch or record something",
-      "example": "The camera can capture clear photos at night.",
-      "phonetic": "CAP-ture",
-      "syllables": "cap-ture",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "decide",
-      "definition": "To make a choice",
-      "example": "You should decide which topic to research.",
-      "phonetic": "DE-cide",
-      "syllables": "de-cide",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "effort",
-      "definition": "Hard work toward a goal",
-      "example": "Her effort showed in the final project.",
-      "phonetic": "EF-fort",
-      "syllables": "ef-fort",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "factual",
-      "definition": "Based on proven information",
-      "example": "The report should be factual and clear.",
-      "phonetic": "FAC-tu-al",
-      "syllables": "fac-tu-al",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "glacier",
-      "definition": "A slow-moving mass of ice",
-      "example": "The glacier carved a deep valley.",
-      "phonetic": "GLA-cier",
-      "syllables": "gla-cier",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "harvest",
-      "definition": "The process of gathering crops",
-      "example": "Farmers begin harvest in early autumn.",
-      "phonetic": "HAR-vest",
-      "syllables": "har-vest",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "imagine",
-      "definition": "To form a picture in your mind",
-      "example": "Imagine building a city on the moon.",
-      "phonetic": "IM-ag-ine",
-      "syllables": "im-ag-ine",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "journey",
-      "definition": "A trip from one place to another",
-      "example": "Our journey to the museum took two hours.",
-      "phonetic": "JOUR-ney",
-      "syllables": "jour-ney",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "kingdom",
-      "definition": "A country ruled by a king or queen",
-      "example": "The story takes place in a distant kingdom.",
-      "phonetic": "KING-dom",
-      "syllables": "king-dom",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "logical",
-      "definition": "Reasonable and based on clear thinking",
-      "example": "Use a logical method to solve the puzzle.",
-      "phonetic": "LOG-i-cal",
-      "syllables": "log-i-cal",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "miracle",
-      "definition": "An amazing event that seems impossible",
-      "example": "Doctors called her recovery a miracle.",
-      "phonetic": "MIR-a-cle",
-      "syllables": "mir-a-cle",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "natural",
-      "definition": "Existing in nature and not made by people",
-      "example": "Wool is a natural material.",
-      "phonetic": "NAT-u-ral",
-      "syllables": "nat-u-ral",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "outcome",
-      "definition": "The final result of an action",
-      "example": "The outcome of the experiment surprised us.",
-      "phonetic": "OUT-come",
-      "syllables": "out-come",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "patient",
-      "definition": "Able to wait calmly",
-      "example": "Be patient while the page loads.",
-      "phonetic": "PA-tient",
-      "syllables": "pa-tient",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "respect",
-      "definition": "To show care and value for others",
-      "example": "We should respect different opinions.",
-      "phonetic": "RE-spect",
-      "syllables": "re-spect",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "sincere",
-      "definition": "Honest and genuine",
-      "example": "He gave a sincere apology.",
-      "phonetic": "SIN-cere",
-      "syllables": "sin-cere",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "thrive",
-      "definition": "To grow or do well",
-      "example": "Plants thrive in warm sunlight.",
-      "phonetic": "THRIVE",
-      "syllables": "thrive",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "venture",
-      "definition": "A new activity that involves risk",
-      "example": "Starting the club was a bold venture.",
-      "phonetic": "VEN-ture",
-      "syllables": "ven-ture",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "analyze",
-      "definition": "To examine carefully",
-      "example": "Scientists analyze data before drawing conclusions.",
-      "phonetic": "AN-a-lyze",
-      "syllables": "an-a-lyze",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "boundary",
-      "definition": "A line that marks a limit",
-      "example": "Please stay inside the boundary lines.",
-      "phonetic": "BOUND-a-ry",
-      "syllables": "bound-a-ry",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "coherent",
-      "definition": "Clear and logically connected",
-      "example": "Her essay presented a coherent argument.",
-      "phonetic": "CO-her-ent",
-      "syllables": "co-her-ent",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "dilemma",
-      "definition": "A difficult choice between options",
-      "example": "He faced a dilemma about which team to join.",
-      "phonetic": "DI-lem-ma",
-      "syllables": "di-lem-ma",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "emphasis",
-      "definition": "Special importance given to something",
-      "example": "The coach placed emphasis on teamwork.",
-      "phonetic": "EM-pha-sis",
-      "syllables": "em-pha-sis",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "fragment",
-      "definition": "A small broken piece of something",
-      "example": "Archaeologists found a fragment of pottery.",
-      "phonetic": "FRAG-ment",
-      "syllables": "frag-ment",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "generate",
-      "definition": "To produce or create",
-      "example": "Wind turbines generate electricity.",
-      "phonetic": "GEN-er-ate",
-      "syllables": "gen-er-ate",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "heritage",
-      "definition": "Traditions passed down through generations",
-      "example": "The festival celebrates local heritage.",
-      "phonetic": "HER-it-age",
-      "syllables": "her-it-age",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "identify",
-      "definition": "To recognize and name",
-      "example": "Can you identify the main idea in this paragraph?",
-      "phonetic": "I-den-ti-fy",
-      "syllables": "i-den-ti-fy",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "justify",
-      "definition": "To show a good reason for",
-      "example": "Please justify your answer with evidence.",
-      "phonetic": "JUS-ti-fy",
-      "syllables": "jus-ti-fy",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "kinetic",
-      "definition": "Relating to motion",
-      "example": "A roller coaster has high kinetic energy.",
-      "phonetic": "KI-net-ic",
-      "syllables": "ki-net-ic",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "landscape",
-      "definition": "All the visible features of an area",
-      "example": "The painting shows a mountain landscape.",
-      "phonetic": "LAND-scape",
-      "syllables": "land-scape",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "moderate",
-      "definition": "Average in amount or level",
-      "example": "We had moderate rain this afternoon.",
-      "phonetic": "MOD-er-ate",
-      "syllables": "mod-er-ate",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "narrative",
-      "definition": "A spoken or written story",
-      "example": "The narrative follows a young inventor.",
-      "phonetic": "NAR-ra-tive",
-      "syllables": "nar-ra-tive",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "optimize",
-      "definition": "To make as effective as possible",
-      "example": "We can optimize the schedule to save time.",
-      "phonetic": "OP-ti-mize",
-      "syllables": "op-ti-mize",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "precise",
-      "definition": "Exact and accurate",
-      "example": "Use precise measurements in the lab.",
-      "phonetic": "PRE-cise",
-      "syllables": "pre-cise",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "quantify",
-      "definition": "To express as an amount",
-      "example": "The graph helps quantify population growth.",
-      "phonetic": "QUAN-ti-fy",
-      "syllables": "quan-ti-fy",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "reliable",
-      "definition": "Dependable and consistent",
-      "example": "This source is reliable for research.",
-      "phonetic": "RE-li-a-ble",
-      "syllables": "re-li-a-ble",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "simulate",
-      "definition": "To imitate real conditions",
-      "example": "The game can simulate weather patterns.",
-      "phonetic": "SIM-u-late",
-      "syllables": "sim-u-late",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "transform",
-      "definition": "To change form or appearance",
-      "example": "Heat can transform ice into water.",
-      "phonetic": "TRANS-form",
-      "syllables": "trans-form",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    }
-  ]
-}
+[
+  {
+    "word": "accommodate",
+    "definition": "To provide lodging or adjust to",
+    "sentence": "The hotel can accommodate 200 guests.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ac-com-mo-date",
+    "phonetic": "AC-com-mo-date"
+  },
+  {
+    "word": "bureaucracy",
+    "definition": "Administrative government system",
+    "sentence": "The bureaucracy slowed the process.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bu-reau-cra-cy",
+    "phonetic": "BU-reau-cra-cy"
+  },
+  {
+    "word": "conscientious",
+    "definition": "Thorough and careful",
+    "sentence": "She is a conscientious worker.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-sci-en-tious",
+    "phonetic": "CON-sci-en-tious"
+  },
+  {
+    "word": "entrepreneur",
+    "definition": "A business founder",
+    "sentence": "The entrepreneur started three companies.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "en-tre-pre-neur",
+    "phonetic": "EN-tre-pre-neur"
+  },
+  {
+    "word": "fluorescent",
+    "definition": "Emitting bright light",
+    "sentence": "The fluorescent lights buzzed overhead.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "flu-o-res-cent",
+    "phonetic": "FLU-o-res-cent"
+  },
+  {
+    "word": "guarantee",
+    "definition": "A formal promise",
+    "sentence": "The product comes with a guarantee.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "guar-an-tee",
+    "phonetic": "GUAR-an-tee"
+  },
+  {
+    "word": "hemorrhage",
+    "definition": "Severe bleeding",
+    "sentence": "The doctor stopped the hemorrhage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "hem-or-rhage",
+    "phonetic": "HEM-or-rhage"
+  },
+  {
+    "word": "inconvenience",
+    "definition": "Trouble or difficulty",
+    "sentence": "Sorry for any inconvenience caused.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "in-con-ven-ience",
+    "phonetic": "IN-con-ven-ience"
+  },
+  {
+    "word": "jeopardize",
+    "definition": "To put at risk",
+    "sentence": "Don't jeopardize your future.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "jeop-ar-dize",
+    "phonetic": "JEOP-ar-dize"
+  },
+  {
+    "word": "knowledgeable",
+    "definition": "Well informed",
+    "sentence": "The guide was very knowledgeable.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "knowl-edge-a-ble",
+    "phonetic": "KNOWL-edge-a-ble"
+  },
+  {
+    "word": "liaison",
+    "definition": "A person who links groups",
+    "sentence": "She serves as liaison between departments.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "li-ai-son",
+    "phonetic": "LI-ai-son"
+  },
+  {
+    "word": "mischievous",
+    "definition": "Playfully troublesome",
+    "sentence": "The mischievous child hid the keys.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "mis-chie-vous",
+    "phonetic": "MIS-chie-vous"
+  },
+  {
+    "word": "onomatopoeia",
+    "definition": "Words that imitate sounds",
+    "sentence": "Buzz is an example of onomatopoeia.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "on-o-mat-o-poe-ia",
+    "phonetic": "ON-o-mat-o-poe-ia"
+  },
+  {
+    "word": "pharmaceutical",
+    "definition": "Related to medicinal drugs",
+    "sentence": "The pharmaceutical company developed a vaccine.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "phar-ma-ceu-ti-cal",
+    "phonetic": "PHAR-ma-ceu-ti-cal"
+  },
+  {
+    "word": "rendezvous",
+    "definition": "A planned meeting",
+    "sentence": "They arranged a secret rendezvous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ren-dez-vous",
+    "phonetic": "REN-dez-vous"
+  },
+  {
+    "word": "surveillance",
+    "definition": "Close observation",
+    "sentence": "The building has surveillance cameras.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "sur-veil-lance",
+    "phonetic": "SUR-veil-lance"
+  },
+  {
+    "word": "tyranny",
+    "definition": "Cruel oppressive rule",
+    "sentence": "The people rose against tyranny.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "tyr-an-ny",
+    "phonetic": "TYR-an-ny"
+  },
+  {
+    "word": "ubiquitous",
+    "definition": "Present everywhere",
+    "sentence": "Smartphones are now ubiquitous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "u-biq-ui-tous",
+    "phonetic": "U-biq-ui-tous"
+  },
+  {
+    "word": "vocabulary",
+    "definition": "Words known or used",
+    "sentence": "Reading expands your vocabulary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "vo-cab-u-lar-y",
+    "phonetic": "VO-cab-u-lar-y"
+  },
+  {
+    "word": "Wednesday",
+    "definition": "The fourth day of the week",
+    "sentence": "The meeting is on Wednesday.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "Wednes-day",
+    "phonetic": "WEDNES-day"
+  },
+  {
+    "word": "achievement",
+    "definition": "Something done successfully",
+    "sentence": "Winning the game was a great achievement.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-chieve-ment",
+    "phonetic": "A-chieve-ment"
+  },
+  {
+    "word": "acoustic",
+    "definition": "Related to sound or hearing",
+    "sentence": "He played an acoustic guitar.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-cous-tic",
+    "phonetic": "A-cous-tic"
+  },
+  {
+    "word": "algorithm",
+    "definition": "A set of rules for solving a problem",
+    "sentence": "The computer uses an algorithm to search.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "al-go-rithm",
+    "phonetic": "AL-go-rithm"
+  },
+  {
+    "word": "amphibian",
+    "definition": "An animal living on land and water",
+    "sentence": "A frog is a type of amphibian.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "am-phib-i-an",
+    "phonetic": "AM-phib-i-an"
+  },
+  {
+    "word": "analysis",
+    "definition": "Detailed examination",
+    "sentence": "The scientist performed an analysis of the data.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-nal-y-sis",
+    "phonetic": "A-nal-y-sis"
+  },
+  {
+    "word": "ancient",
+    "definition": "Belonging to the very distant past",
+    "sentence": "They visited the ancient ruins.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-cient",
+    "phonetic": "AN-cient"
+  },
+  {
+    "word": "anniversary",
+    "definition": "Date on which an event took place",
+    "sentence": "They celebrated their wedding anniversary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-ni-ver-sa-ry",
+    "phonetic": "AN-ni-ver-sa-ry"
+  },
+  {
+    "word": "anonymous",
+    "definition": "Not identified by name",
+    "sentence": "The donor chose to remain anonymous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-non-y-mous",
+    "phonetic": "A-non-y-mous"
+  },
+  {
+    "word": "antique",
+    "definition": "A collectible object having a high value",
+    "sentence": "This chair is a valuable antique.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-tique",
+    "phonetic": "AN-tique"
+  },
+  {
+    "word": "anxiety",
+    "definition": "A feeling of worry or nervousness",
+    "sentence": "He felt anxiety before the test.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "anx-i-e-ty",
+    "phonetic": "ANX-i-e-ty"
+  },
+  {
+    "word": "appreciate",
+    "definition": "To recognize the full worth of",
+    "sentence": "I appreciate your help.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ap-pre-ci-ate",
+    "phonetic": "AP-pre-ci-ate"
+  },
+  {
+    "word": "aquarium",
+    "definition": "A tank of water for fish",
+    "sentence": "We saw sharks at the aquarium.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-quar-i-um",
+    "phonetic": "A-quar-i-um"
+  },
+  {
+    "word": "architecture",
+    "definition": "The art of designing buildings",
+    "sentence": "The city has beautiful architecture.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-chi-tec-ture",
+    "phonetic": "AR-chi-tec-ture"
+  },
+  {
+    "word": "arithmetic",
+    "definition": "The branch of math with numbers",
+    "sentence": "We learned arithmetic in school.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-rith-me-tic",
+    "phonetic": "A-rith-me-tic"
+  },
+  {
+    "word": "artificial",
+    "definition": "Made by humans, not natural",
+    "sentence": "The flowers are artificial.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-ti-fi-cial",
+    "phonetic": "AR-ti-fi-cial"
+  },
+  {
+    "word": "atmosphere",
+    "definition": "Gases surrounding a planet",
+    "sentence": "The atmosphere protects the Earth.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "at-mos-phere",
+    "phonetic": "AT-mos-phere"
+  },
+  {
+    "word": "audience",
+    "definition": "Spectators at an event",
+    "sentence": "The audience clapped loudly.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-di-ence",
+    "phonetic": "AU-di-ence"
+  },
+  {
+    "word": "authentic",
+    "definition": "Of undisputed origin; genuine",
+    "sentence": "This is an authentic painting.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-then-tic",
+    "phonetic": "AU-then-tic"
+  },
+  {
+    "word": "biography",
+    "definition": "An account of someone's life",
+    "sentence": "I read a biography of Lincoln.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-og-ra-phy",
+    "phonetic": "BI-og-ra-phy"
+  },
+  {
+    "word": "bizarre",
+    "definition": "Very strange or unusual",
+    "sentence": "It was a bizarre situation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-zarre",
+    "phonetic": "BI-zarre"
+  },
+  {
+    "word": "camouflage",
+    "definition": "Disguise to blend with surroundings",
+    "sentence": "The soldier wore camouflage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-ou-flage",
+    "phonetic": "CAM-ou-flage"
+  },
+  {
+    "word": "campaign",
+    "definition": "A series of actions for a goal",
+    "sentence": "The election campaign was intense.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-paign",
+    "phonetic": "CAM-paign"
+  },
+  {
+    "word": "capacity",
+    "definition": "The maximum amount something can hold",
+    "sentence": "The stadium was filled to capacity.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-pac-i-ty",
+    "phonetic": "CA-pac-i-ty"
+  },
+  {
+    "word": "catastrophe",
+    "definition": "A sudden great disaster",
+    "sentence": "The earthquake was a catastrophe.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-tas-tro-phe",
+    "phonetic": "CA-tas-tro-phe"
+  },
+  {
+    "word": "cemetery",
+    "definition": "A place for burying the dead",
+    "sentence": "They visited the old cemetery.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cem-e-ter-y",
+    "phonetic": "CEM-e-ter-y"
+  },
+  {
+    "word": "ceremony",
+    "definition": "A formal religious or public occasion",
+    "sentence": "The graduation ceremony is tomorrow.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cer-e-mo-ny",
+    "phonetic": "CER-e-mo-ny"
+  },
+  {
+    "word": "chameleon",
+    "definition": "A lizard that changes color",
+    "sentence": "The chameleon turned green.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cha-me-le-on",
+    "phonetic": "CHA-me-le-on"
+  },
+  {
+    "word": "chandelier",
+    "definition": "A decorative hanging light",
+    "sentence": "A crystal chandelier hung in the hall.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chan-de-lier",
+    "phonetic": "CHAN-de-lier"
+  },
+  {
+    "word": "character",
+    "definition": "A person in a novel or movie",
+    "sentence": "Who is your favorite character?",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "char-ac-ter",
+    "phonetic": "CHAR-ac-ter"
+  },
+  {
+    "word": "chemistry",
+    "definition": "Science of substances and reactions",
+    "sentence": "We did experiments in chemistry class.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chem-is-try",
+    "phonetic": "CHEM-is-try"
+  },
+  {
+    "word": "choreography",
+    "definition": "The sequence of steps in dance",
+    "sentence": "The ballet choreography was complex.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cho-re-og-ra-phy",
+    "phonetic": "CHO-re-og-ra-phy"
+  },
+  {
+    "word": "circumference",
+    "definition": "The distance around a circle",
+    "sentence": "Measure the circumference of the ball.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cir-cum-fer-ence",
+    "phonetic": "CIR-cum-fer-ence"
+  },
+  {
+    "word": "civilization",
+    "definition": "Advanced stage of human social development",
+    "sentence": "Ancient Rome was a great civilization.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "civ-i-li-za-tion",
+    "phonetic": "CIV-i-li-za-tion"
+  },
+  {
+    "word": "coincidence",
+    "definition": "Events happening together by chance",
+    "sentence": "It was a coincidence that we met.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "co-in-ci-dence",
+    "phonetic": "CO-in-ci-dence"
+  },
+  {
+    "word": "collaborate",
+    "definition": "Work jointly on an activity",
+    "sentence": "We will collaborate on the project.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-lab-o-rate",
+    "phonetic": "COL-lab-o-rate"
+  },
+  {
+    "word": "collision",
+    "definition": "An instance of one moving object striking another",
+    "sentence": "The car collision caused a traffic jam.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-li-sion",
+    "phonetic": "COL-li-sion"
+  },
+  {
+    "word": "column",
+    "definition": "An upright pillar",
+    "sentence": "The roof was supported by a stone column.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-umn",
+    "phonetic": "COL-umn"
+  },
+  {
+    "word": "committee",
+    "definition": "A group of people appointed for a function",
+    "sentence": "The committee will vote on the issue.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-mit-tee",
+    "phonetic": "COM-mit-tee"
+  },
+  {
+    "word": "communicate",
+    "definition": "Share or exchange information",
+    "sentence": "We communicate by email.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-mu-ni-cate",
+    "phonetic": "COM-mu-ni-cate"
+  },
+  {
+    "word": "community",
+    "definition": "A group of people living in the same place",
+    "sentence": "We have a friendly community.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-mu-ni-ty",
+    "phonetic": "COM-mu-ni-ty"
+  },
+  {
+    "word": "competition",
+    "definition": "The activity of competing",
+    "sentence": "She won the swimming competition.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-pe-ti-tion",
+    "phonetic": "COM-pe-ti-tion"
+  },
+  {
+    "word": "complicated",
+    "definition": "Consisting of many interconnecting parts",
+    "sentence": "The instructions were very complicated.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-pli-cat-ed",
+    "phonetic": "COM-pli-cat-ed"
+  },
+  {
+    "word": "concentrate",
+    "definition": "Focus one's attention",
+    "sentence": "I need to concentrate on my work.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-cen-trate",
+    "phonetic": "CON-cen-trate"
+  },
+  {
+    "word": "conclusion",
+    "definition": "The end or finish of an event",
+    "sentence": "The conclusion of the story was sad.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-clu-sion",
+    "phonetic": "CON-clu-sion"
+  },
+  {
+    "word": "confident",
+    "definition": "Feeling certain about ability",
+    "sentence": "He is confident he will pass.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-fi-dent",
+    "phonetic": "CON-fi-dent"
+  },
+  {
+    "word": "consequence",
+    "definition": "A result or effect of an action",
+    "sentence": "Every action has a consequence.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-se-quence",
+    "phonetic": "CON-se-quence"
+  },
+  {
+    "word": "constellation",
+    "definition": "A group of stars forming a pattern",
+    "sentence": "Can you find the Big Dipper constellation?",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-stel-la-tion",
+    "phonetic": "CON-stel-la-tion"
+  },
+  {
+    "word": "contagious",
+    "definition": "Spread from one person to another",
+    "sentence": "The flu is very contagious.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-ta-gious",
+    "phonetic": "CON-ta-gious"
+  },
+  {
+    "word": "controversial",
+    "definition": "Giving rise to public disagreement",
+    "sentence": "It was a controversial decision.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-tro-ver-sial",
+    "phonetic": "CON-tro-ver-sial"
+  },
+  {
+    "word": "convenient",
+    "definition": "Fitting in well with needs",
+    "sentence": "It is convenient to live near the store.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-ven-ient",
+    "phonetic": "CON-ven-ient"
+  },
+  {
+    "word": "conversation",
+    "definition": "A talk between two or more people",
+    "sentence": "They had a long conversation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-ver-sa-tion",
+    "phonetic": "CON-ver-sa-tion"
+  },
+  {
+    "word": "cooperation",
+    "definition": "The process of working together",
+    "sentence": "The project requires cooperation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "co-op-er-a-tion",
+    "phonetic": "CO-op-er-a-tion"
+  },
+  {
+    "word": "corporation",
+    "definition": "A large company",
+    "sentence": "She works for a major corporation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cor-po-ra-tion",
+    "phonetic": "COR-po-ra-tion"
+  },
+  {
+    "word": "courageous",
+    "definition": "Not deterred by danger or pain",
+    "sentence": "The firefighter was very courageous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cour-a-geous",
+    "phonetic": "COUR-a-geous"
+  },
+  {
+    "word": "criticism",
+    "definition": "Expression of disapproval",
+    "sentence": "He accepted the criticism gracefully.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "crit-i-cism",
+    "phonetic": "CRIT-i-cism"
+  },
+  {
+    "word": "biodiversity",
+    "definition": "The variety of plant and animal life in an area",
+    "sentence": "Rainforests are known for rich biodiversity.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-o-di-ver-si-ty",
+    "phonetic": "BI-o-di-ver-si-ty"
+  },
+  {
+    "word": "collaboration",
+    "definition": "Working jointly with others",
+    "sentence": "The project succeeded through collaboration.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-lab-o-ra-tion",
+    "phonetic": "COL-lab-o-ra-tion"
+  },
+  {
+    "word": "determination",
+    "definition": "Firmness of purpose",
+    "sentence": "Her determination helped her finish the race.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "de-ter-mi-na-tion",
+    "phonetic": "DE-ter-mi-na-tion"
+  },
+  {
+    "word": "geothermal",
+    "definition": "Relating to heat produced inside the earth",
+    "sentence": "Iceland uses geothermal energy for power.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ge-o-ther-mal",
+    "phonetic": "GE-o-ther-mal"
+  },
+  {
+    "word": "hypothesis",
+    "definition": "A proposed explanation for testing",
+    "sentence": "The class tested each hypothesis in the lab.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "hy-poth-e-sis",
+    "phonetic": "HY-poth-e-sis"
+  },
+  {
+    "word": "metamorphosis",
+    "definition": "A major change in form during development",
+    "sentence": "A butterfly emerges after metamorphosis.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "met-a-mor-pho-sis",
+    "phonetic": "MET-a-mor-pho-sis"
+  },
+  {
+    "word": "resilience",
+    "definition": "The ability to recover from difficulty",
+    "sentence": "Resilience helps people handle setbacks.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "re-sil-ience",
+    "phonetic": "RE-sil-ience"
+  },
+  {
+    "word": "sustainability",
+    "definition": "Using resources in a way that avoids long-term harm",
+    "sentence": "The city adopted sustainability goals.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "sus-tain-a-bil-i-ty",
+    "phonetic": "SUS-tain-a-bil-i-ty"
+  },
+  {
+    "word": "wordsmith",
+    "definition": "A person skilled at using words effectively",
+    "sentence": "The poet was praised as a talented wordsmith.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "word-smith",
+    "phonetic": "WORD-smith"
+  },
+  {
+    "word": "ability",
+    "definition": "The power to do something",
+    "sentence": "Practice improves your ability to solve problems.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "a-bil-i-ty",
+    "phonetic": "A-bil-i-ty"
+  },
+  {
+    "word": "balance",
+    "definition": "A steady position without falling",
+    "sentence": "Yoga helps improve balance and focus.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "bal-ance",
+    "phonetic": "BAL-ance"
+  },
+  {
+    "word": "capture",
+    "definition": "To catch or record something",
+    "sentence": "The camera can capture clear photos at night.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "cap-ture",
+    "phonetic": "CAP-ture"
+  },
+  {
+    "word": "decide",
+    "definition": "To make a choice",
+    "sentence": "You should decide which topic to research.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "de-cide",
+    "phonetic": "DE-cide"
+  },
+  {
+    "word": "effort",
+    "definition": "Hard work toward a goal",
+    "sentence": "Her effort showed in the final project.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "ef-fort",
+    "phonetic": "EF-fort"
+  },
+  {
+    "word": "factual",
+    "definition": "Based on proven information",
+    "sentence": "The report should be factual and clear.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "fac-tu-al",
+    "phonetic": "FAC-tu-al"
+  },
+  {
+    "word": "glacier",
+    "definition": "A slow-moving mass of ice",
+    "sentence": "The glacier carved a deep valley.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "gla-cier",
+    "phonetic": "GLA-cier"
+  },
+  {
+    "word": "harvest",
+    "definition": "The process of gathering crops",
+    "sentence": "Farmers begin harvest in early autumn.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "har-vest",
+    "phonetic": "HAR-vest"
+  },
+  {
+    "word": "imagine",
+    "definition": "To form a picture in your mind",
+    "sentence": "Imagine building a city on the moon.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "im-ag-ine",
+    "phonetic": "IM-ag-ine"
+  },
+  {
+    "word": "journey",
+    "definition": "A trip from one place to another",
+    "sentence": "Our journey to the museum took two hours.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "jour-ney",
+    "phonetic": "JOUR-ney"
+  },
+  {
+    "word": "kingdom",
+    "definition": "A country ruled by a king or queen",
+    "sentence": "The story takes place in a distant kingdom.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "king-dom",
+    "phonetic": "KING-dom"
+  },
+  {
+    "word": "logical",
+    "definition": "Reasonable and based on clear thinking",
+    "sentence": "Use a logical method to solve the puzzle.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "log-i-cal",
+    "phonetic": "LOG-i-cal"
+  },
+  {
+    "word": "miracle",
+    "definition": "An amazing event that seems impossible",
+    "sentence": "Doctors called her recovery a miracle.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "mir-a-cle",
+    "phonetic": "MIR-a-cle"
+  },
+  {
+    "word": "natural",
+    "definition": "Existing in nature and not made by people",
+    "sentence": "Wool is a natural material.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "nat-u-ral",
+    "phonetic": "NAT-u-ral"
+  },
+  {
+    "word": "outcome",
+    "definition": "The final result of an action",
+    "sentence": "The outcome of the experiment surprised us.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "out-come",
+    "phonetic": "OUT-come"
+  },
+  {
+    "word": "patient",
+    "definition": "Able to wait calmly",
+    "sentence": "Be patient while the page loads.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "pa-tient",
+    "phonetic": "PA-tient"
+  },
+  {
+    "word": "respect",
+    "definition": "To show care and value for others",
+    "sentence": "We should respect different opinions.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "re-spect",
+    "phonetic": "RE-spect"
+  },
+  {
+    "word": "sincere",
+    "definition": "Honest and genuine",
+    "sentence": "He gave a sincere apology.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "sin-cere",
+    "phonetic": "SIN-cere"
+  },
+  {
+    "word": "thrive",
+    "definition": "To grow or do well",
+    "sentence": "Plants thrive in warm sunlight.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "thrive",
+    "phonetic": "THRIVE"
+  },
+  {
+    "word": "venture",
+    "definition": "A new activity that involves risk",
+    "sentence": "Starting the club was a bold venture.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "ven-ture",
+    "phonetic": "VEN-ture"
+  },
+  {
+    "word": "analyze",
+    "definition": "To examine carefully",
+    "sentence": "Scientists analyze data before drawing conclusions.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "an-a-lyze",
+    "phonetic": "AN-a-lyze"
+  },
+  {
+    "word": "boundary",
+    "definition": "A line that marks a limit",
+    "sentence": "Please stay inside the boundary lines.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "bound-a-ry",
+    "phonetic": "BOUND-a-ry"
+  },
+  {
+    "word": "coherent",
+    "definition": "Clear and logically connected",
+    "sentence": "Her essay presented a coherent argument.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "co-her-ent",
+    "phonetic": "CO-her-ent"
+  },
+  {
+    "word": "dilemma",
+    "definition": "A difficult choice between options",
+    "sentence": "He faced a dilemma about which team to join.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "di-lem-ma",
+    "phonetic": "DI-lem-ma"
+  },
+  {
+    "word": "emphasis",
+    "definition": "Special importance given to something",
+    "sentence": "The coach placed emphasis on teamwork.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "em-pha-sis",
+    "phonetic": "EM-pha-sis"
+  },
+  {
+    "word": "fragment",
+    "definition": "A small broken piece of something",
+    "sentence": "Archaeologists found a fragment of pottery.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "frag-ment",
+    "phonetic": "FRAG-ment"
+  },
+  {
+    "word": "generate",
+    "definition": "To produce or create",
+    "sentence": "Wind turbines generate electricity.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "gen-er-ate",
+    "phonetic": "GEN-er-ate"
+  },
+  {
+    "word": "heritage",
+    "definition": "Traditions passed down through generations",
+    "sentence": "The festival celebrates local heritage.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "her-it-age",
+    "phonetic": "HER-it-age"
+  },
+  {
+    "word": "identify",
+    "definition": "To recognize and name",
+    "sentence": "Can you identify the main idea in this paragraph?",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "i-den-ti-fy",
+    "phonetic": "I-den-ti-fy"
+  },
+  {
+    "word": "justify",
+    "definition": "To show a good reason for",
+    "sentence": "Please justify your answer with evidence.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "jus-ti-fy",
+    "phonetic": "JUS-ti-fy"
+  },
+  {
+    "word": "kinetic",
+    "definition": "Relating to motion",
+    "sentence": "A roller coaster has high kinetic energy.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "ki-net-ic",
+    "phonetic": "KI-net-ic"
+  },
+  {
+    "word": "landscape",
+    "definition": "All the visible features of an area",
+    "sentence": "The painting shows a mountain landscape.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "land-scape",
+    "phonetic": "LAND-scape"
+  },
+  {
+    "word": "moderate",
+    "definition": "Average in amount or level",
+    "sentence": "We had moderate rain this afternoon.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "mod-er-ate",
+    "phonetic": "MOD-er-ate"
+  },
+  {
+    "word": "narrative",
+    "definition": "A spoken or written story",
+    "sentence": "The narrative follows a young inventor.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "nar-ra-tive",
+    "phonetic": "NAR-ra-tive"
+  },
+  {
+    "word": "optimize",
+    "definition": "To make as effective as possible",
+    "sentence": "We can optimize the schedule to save time.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "op-ti-mize",
+    "phonetic": "OP-ti-mize"
+  },
+  {
+    "word": "precise",
+    "definition": "Exact and accurate",
+    "sentence": "Use precise measurements in the lab.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "pre-cise",
+    "phonetic": "PRE-cise"
+  },
+  {
+    "word": "quantify",
+    "definition": "To express as an amount",
+    "sentence": "The graph helps quantify population growth.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "quan-ti-fy",
+    "phonetic": "QUAN-ti-fy"
+  },
+  {
+    "word": "reliable",
+    "definition": "Dependable and consistent",
+    "sentence": "This source is reliable for research.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "re-li-a-ble",
+    "phonetic": "RE-li-a-ble"
+  },
+  {
+    "word": "simulate",
+    "definition": "To imitate real conditions",
+    "sentence": "The game can simulate weather patterns.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "sim-u-late",
+    "phonetic": "SIM-u-late"
+  },
+  {
+    "word": "transform",
+    "definition": "To change form or appearance",
+    "sentence": "Heat can transform ice into water.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "trans-form",
+    "phonetic": "TRANS-form"
+  }
+]

--- a/public/data/words/grade-7.json
+++ b/public/data/words/grade-7.json
@@ -1,1125 +1,1118 @@
-{
-  "grade": 7,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 124,
-  "words": [
-    {
-      "word": "accommodate",
-      "definition": "To provide lodging or adjust to",
-      "example": "The hotel can accommodate 200 guests.",
-      "phonetic": "AC-com-mo-date",
-      "syllables": "ac-com-mo-date",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bureaucracy",
-      "definition": "Administrative government system",
-      "example": "The bureaucracy slowed the process.",
-      "phonetic": "BU-reau-cra-cy",
-      "syllables": "bu-reau-cra-cy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conscientious",
-      "definition": "Thorough and careful",
-      "example": "She is a conscientious worker.",
-      "phonetic": "CON-sci-en-tious",
-      "syllables": "con-sci-en-tious",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "entrepreneur",
-      "definition": "A business founder",
-      "example": "The entrepreneur started three companies.",
-      "phonetic": "EN-tre-pre-neur",
-      "syllables": "en-tre-pre-neur",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "fluorescent",
-      "definition": "Emitting bright light",
-      "example": "The fluorescent lights buzzed overhead.",
-      "phonetic": "FLU-o-res-cent",
-      "syllables": "flu-o-res-cent",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "guarantee",
-      "definition": "A formal promise",
-      "example": "The product comes with a guarantee.",
-      "phonetic": "GUAR-an-tee",
-      "syllables": "guar-an-tee",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "hemorrhage",
-      "definition": "Severe bleeding",
-      "example": "The doctor stopped the hemorrhage.",
-      "phonetic": "HEM-or-rhage",
-      "syllables": "hem-or-rhage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "inconvenience",
-      "definition": "Trouble or difficulty",
-      "example": "Sorry for any inconvenience caused.",
-      "phonetic": "IN-con-ven-ience",
-      "syllables": "in-con-ven-ience",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "jeopardize",
-      "definition": "To put at risk",
-      "example": "Don't jeopardize your future.",
-      "phonetic": "JEOP-ar-dize",
-      "syllables": "jeop-ar-dize",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "knowledgeable",
-      "definition": "Well informed",
-      "example": "The guide was very knowledgeable.",
-      "phonetic": "KNOWL-edge-a-ble",
-      "syllables": "knowl-edge-a-ble",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "liaison",
-      "definition": "A person who links groups",
-      "example": "She serves as liaison between departments.",
-      "phonetic": "LI-ai-son",
-      "syllables": "li-ai-son",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "mischievous",
-      "definition": "Playfully troublesome",
-      "example": "The mischievous child hid the keys.",
-      "phonetic": "MIS-chie-vous",
-      "syllables": "mis-chie-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "onomatopoeia",
-      "definition": "Words that imitate sounds",
-      "example": "Buzz is an example of onomatopoeia.",
-      "phonetic": "ON-o-mat-o-poe-ia",
-      "syllables": "on-o-mat-o-poe-ia",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "pharmaceutical",
-      "definition": "Related to medicinal drugs",
-      "example": "The pharmaceutical company developed a vaccine.",
-      "phonetic": "PHAR-ma-ceu-ti-cal",
-      "syllables": "phar-ma-ceu-ti-cal",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "rendezvous",
-      "definition": "A planned meeting",
-      "example": "They arranged a secret rendezvous.",
-      "phonetic": "REN-dez-vous",
-      "syllables": "ren-dez-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "surveillance",
-      "definition": "Close observation",
-      "example": "The building has surveillance cameras.",
-      "phonetic": "SUR-veil-lance",
-      "syllables": "sur-veil-lance",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "tyranny",
-      "definition": "Cruel oppressive rule",
-      "example": "The people rose against tyranny.",
-      "phonetic": "TYR-an-ny",
-      "syllables": "tyr-an-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ubiquitous",
-      "definition": "Present everywhere",
-      "example": "Smartphones are now ubiquitous.",
-      "phonetic": "U-biq-ui-tous",
-      "syllables": "u-biq-ui-tous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "vocabulary",
-      "definition": "Words known or used",
-      "example": "Reading expands your vocabulary.",
-      "phonetic": "VO-cab-u-lar-y",
-      "syllables": "vo-cab-u-lar-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "Wednesday",
-      "definition": "The fourth day of the week",
-      "example": "The meeting is on Wednesday.",
-      "phonetic": "WEDNES-day",
-      "syllables": "Wednes-day",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "achievement",
-      "definition": "Something done successfully",
-      "example": "Winning the game was a great achievement.",
-      "phonetic": "A-chieve-ment",
-      "syllables": "a-chieve-ment",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "acoustic",
-      "definition": "Related to sound or hearing",
-      "example": "He played an acoustic guitar.",
-      "phonetic": "A-cous-tic",
-      "syllables": "a-cous-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "algorithm",
-      "definition": "A set of rules for solving a problem",
-      "example": "The computer uses an algorithm to search.",
-      "phonetic": "AL-go-rithm",
-      "syllables": "al-go-rithm",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "amphibian",
-      "definition": "An animal living on land and water",
-      "example": "A frog is a type of amphibian.",
-      "phonetic": "AM-phib-i-an",
-      "syllables": "am-phib-i-an",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "analysis",
-      "definition": "Detailed examination",
-      "example": "The scientist performed an analysis of the data.",
-      "phonetic": "A-nal-y-sis",
-      "syllables": "a-nal-y-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ancient",
-      "definition": "Belonging to the very distant past",
-      "example": "They visited the ancient ruins.",
-      "phonetic": "AN-cient",
-      "syllables": "an-cient",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anniversary",
-      "definition": "Date on which an event took place",
-      "example": "They celebrated their wedding anniversary.",
-      "phonetic": "AN-ni-ver-sa-ry",
-      "syllables": "an-ni-ver-sa-ry",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anonymous",
-      "definition": "Not identified by name",
-      "example": "The donor chose to remain anonymous.",
-      "phonetic": "A-non-y-mous",
-      "syllables": "a-non-y-mous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "antique",
-      "definition": "A collectible object having a high value",
-      "example": "This chair is a valuable antique.",
-      "phonetic": "AN-tique",
-      "syllables": "an-tique",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anxiety",
-      "definition": "A feeling of worry or nervousness",
-      "example": "He felt anxiety before the test.",
-      "phonetic": "ANX-i-e-ty",
-      "syllables": "anx-i-e-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "appreciate",
-      "definition": "To recognize the full worth of",
-      "example": "I appreciate your help.",
-      "phonetic": "AP-pre-ci-ate",
-      "syllables": "ap-pre-ci-ate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "aquarium",
-      "definition": "A tank of water for fish",
-      "example": "We saw sharks at the aquarium.",
-      "phonetic": "A-quar-i-um",
-      "syllables": "a-quar-i-um",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "architecture",
-      "definition": "The art of designing buildings",
-      "example": "The city has beautiful architecture.",
-      "phonetic": "AR-chi-tec-ture",
-      "syllables": "ar-chi-tec-ture",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "arithmetic",
-      "definition": "The branch of math with numbers",
-      "example": "We learned arithmetic in school.",
-      "phonetic": "A-rith-me-tic",
-      "syllables": "a-rith-me-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "artificial",
-      "definition": "Made by humans, not natural",
-      "example": "The flowers are artificial.",
-      "phonetic": "AR-ti-fi-cial",
-      "syllables": "ar-ti-fi-cial",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "atmosphere",
-      "definition": "Gases surrounding a planet",
-      "example": "The atmosphere protects the Earth.",
-      "phonetic": "AT-mos-phere",
-      "syllables": "at-mos-phere",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "audience",
-      "definition": "Spectators at an event",
-      "example": "The audience clapped loudly.",
-      "phonetic": "AU-di-ence",
-      "syllables": "au-di-ence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "authentic",
-      "definition": "Of undisputed origin; genuine",
-      "example": "This is an authentic painting.",
-      "phonetic": "AU-then-tic",
-      "syllables": "au-then-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "biography",
-      "definition": "An account of someone's life",
-      "example": "I read a biography of Lincoln.",
-      "phonetic": "BI-og-ra-phy",
-      "syllables": "bi-og-ra-phy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bizarre",
-      "definition": "Very strange or unusual",
-      "example": "It was a bizarre situation.",
-      "phonetic": "BI-zarre",
-      "syllables": "bi-zarre",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "camouflage",
-      "definition": "Disguise to blend with surroundings",
-      "example": "The soldier wore camouflage.",
-      "phonetic": "CAM-ou-flage",
-      "syllables": "cam-ou-flage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "campaign",
-      "definition": "A series of actions for a goal",
-      "example": "The election campaign was intense.",
-      "phonetic": "CAM-paign",
-      "syllables": "cam-paign",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "capacity",
-      "definition": "The maximum amount something can hold",
-      "example": "The stadium was filled to capacity.",
-      "phonetic": "CA-pac-i-ty",
-      "syllables": "ca-pac-i-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "catastrophe",
-      "definition": "A sudden great disaster",
-      "example": "The earthquake was a catastrophe.",
-      "phonetic": "CA-tas-tro-phe",
-      "syllables": "ca-tas-tro-phe",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "cemetery",
-      "definition": "A place for burying the dead",
-      "example": "They visited the old cemetery.",
-      "phonetic": "CEM-e-ter-y",
-      "syllables": "cem-e-ter-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ceremony",
-      "definition": "A formal religious or public occasion",
-      "example": "The graduation ceremony is tomorrow.",
-      "phonetic": "CER-e-mo-ny",
-      "syllables": "cer-e-mo-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chameleon",
-      "definition": "A lizard that changes color",
-      "example": "The chameleon turned green.",
-      "phonetic": "CHA-me-le-on",
-      "syllables": "cha-me-le-on",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chandelier",
-      "definition": "A decorative hanging light",
-      "example": "A crystal chandelier hung in the hall.",
-      "phonetic": "CHAN-de-lier",
-      "syllables": "chan-de-lier",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "character",
-      "definition": "A person in a novel or movie",
-      "example": "Who is your favorite character?",
-      "phonetic": "CHAR-ac-ter",
-      "syllables": "char-ac-ter",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chemistry",
-      "definition": "Science of substances and reactions",
-      "example": "We did experiments in chemistry class.",
-      "phonetic": "CHEM-is-try",
-      "syllables": "chem-is-try",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "choreography",
-      "definition": "The sequence of steps in dance",
-      "example": "The ballet choreography was complex.",
-      "phonetic": "CHO-re-og-ra-phy",
-      "syllables": "cho-re-og-ra-phy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "circumference",
-      "definition": "The distance around a circle",
-      "example": "Measure the circumference of the ball.",
-      "phonetic": "CIR-cum-fer-ence",
-      "syllables": "cir-cum-fer-ence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "civilization",
-      "definition": "Advanced stage of human social development",
-      "example": "Ancient Rome was a great civilization.",
-      "phonetic": "CIV-i-li-za-tion",
-      "syllables": "civ-i-li-za-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "coincidence",
-      "definition": "Events happening together by chance",
-      "example": "It was a coincidence that we met.",
-      "phonetic": "CO-in-ci-dence",
-      "syllables": "co-in-ci-dence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "collaborate",
-      "definition": "Work jointly on an activity",
-      "example": "We will collaborate on the project.",
-      "phonetic": "COL-lab-o-rate",
-      "syllables": "col-lab-o-rate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "collision",
-      "definition": "An instance of one moving object striking another",
-      "example": "The car collision caused a traffic jam.",
-      "phonetic": "COL-li-sion",
-      "syllables": "col-li-sion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "column",
-      "definition": "An upright pillar",
-      "example": "The roof was supported by a stone column.",
-      "phonetic": "COL-umn",
-      "syllables": "col-umn",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "committee",
-      "definition": "A group of people appointed for a function",
-      "example": "The committee will vote on the issue.",
-      "phonetic": "COM-mit-tee",
-      "syllables": "com-mit-tee",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "communicate",
-      "definition": "Share or exchange information",
-      "example": "We communicate by email.",
-      "phonetic": "COM-mu-ni-cate",
-      "syllables": "com-mu-ni-cate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "community",
-      "definition": "A group of people living in the same place",
-      "example": "We have a friendly community.",
-      "phonetic": "COM-mu-ni-ty",
-      "syllables": "com-mu-ni-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "competition",
-      "definition": "The activity of competing",
-      "example": "She won the swimming competition.",
-      "phonetic": "COM-pe-ti-tion",
-      "syllables": "com-pe-ti-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "complicated",
-      "definition": "Consisting of many interconnecting parts",
-      "example": "The instructions were very complicated.",
-      "phonetic": "COM-pli-cat-ed",
-      "syllables": "com-pli-cat-ed",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "concentrate",
-      "definition": "Focus one's attention",
-      "example": "I need to concentrate on my work.",
-      "phonetic": "CON-cen-trate",
-      "syllables": "con-cen-trate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conclusion",
-      "definition": "The end or finish of an event",
-      "example": "The conclusion of the story was sad.",
-      "phonetic": "CON-clu-sion",
-      "syllables": "con-clu-sion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "confident",
-      "definition": "Feeling certain about ability",
-      "example": "He is confident he will pass.",
-      "phonetic": "CON-fi-dent",
-      "syllables": "con-fi-dent",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "consequence",
-      "definition": "A result or effect of an action",
-      "example": "Every action has a consequence.",
-      "phonetic": "CON-se-quence",
-      "syllables": "con-se-quence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "constellation",
-      "definition": "A group of stars forming a pattern",
-      "example": "Can you find the Big Dipper constellation?",
-      "phonetic": "CON-stel-la-tion",
-      "syllables": "con-stel-la-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "contagious",
-      "definition": "Spread from one person to another",
-      "example": "The flu is very contagious.",
-      "phonetic": "CON-ta-gious",
-      "syllables": "con-ta-gious",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "controversial",
-      "definition": "Giving rise to public disagreement",
-      "example": "It was a controversial decision.",
-      "phonetic": "CON-tro-ver-sial",
-      "syllables": "con-tro-ver-sial",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "convenient",
-      "definition": "Fitting in well with needs",
-      "example": "It is convenient to live near the store.",
-      "phonetic": "CON-ven-ient",
-      "syllables": "con-ven-ient",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conversation",
-      "definition": "A talk between two or more people",
-      "example": "They had a long conversation.",
-      "phonetic": "CON-ver-sa-tion",
-      "syllables": "con-ver-sa-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "cooperation",
-      "definition": "The process of working together",
-      "example": "The project requires cooperation.",
-      "phonetic": "CO-op-er-a-tion",
-      "syllables": "co-op-er-a-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "corporation",
-      "definition": "A large company",
-      "example": "She works for a major corporation.",
-      "phonetic": "COR-po-ra-tion",
-      "syllables": "cor-po-ra-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "courageous",
-      "definition": "Not deterred by danger or pain",
-      "example": "The firefighter was very courageous.",
-      "phonetic": "COUR-a-geous",
-      "syllables": "cour-a-geous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "criticism",
-      "definition": "Expression of disapproval",
-      "example": "He accepted the criticism gracefully.",
-      "phonetic": "CRIT-i-cism",
-      "syllables": "crit-i-cism",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "biodiversity",
-      "definition": "The variety of plant and animal life in an area",
-      "example": "Rainforests are known for rich biodiversity.",
-      "phonetic": "BI-o-di-ver-si-ty",
-      "syllables": "bi-o-di-ver-si-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "collaboration",
-      "definition": "Working jointly with others",
-      "example": "The project succeeded through collaboration.",
-      "phonetic": "COL-lab-o-ra-tion",
-      "syllables": "col-lab-o-ra-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "determination",
-      "definition": "Firmness of purpose",
-      "example": "Her determination helped her finish the race.",
-      "phonetic": "DE-ter-mi-na-tion",
-      "syllables": "de-ter-mi-na-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "geothermal",
-      "definition": "Relating to heat produced inside the earth",
-      "example": "Iceland uses geothermal energy for power.",
-      "phonetic": "GE-o-ther-mal",
-      "syllables": "ge-o-ther-mal",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "hypothesis",
-      "definition": "A proposed explanation for testing",
-      "example": "The class tested each hypothesis in the lab.",
-      "phonetic": "HY-poth-e-sis",
-      "syllables": "hy-poth-e-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "metamorphosis",
-      "definition": "A major change in form during development",
-      "example": "A butterfly emerges after metamorphosis.",
-      "phonetic": "MET-a-mor-pho-sis",
-      "syllables": "met-a-mor-pho-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "resilience",
-      "definition": "The ability to recover from difficulty",
-      "example": "Resilience helps people handle setbacks.",
-      "phonetic": "RE-sil-ience",
-      "syllables": "re-sil-ience",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "sustainability",
-      "definition": "Using resources in a way that avoids long-term harm",
-      "example": "The city adopted sustainability goals.",
-      "phonetic": "SUS-tain-a-bil-i-ty",
-      "syllables": "sus-tain-a-bil-i-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "wordsmith",
-      "definition": "A person skilled at using words effectively",
-      "example": "The poet was praised as a talented wordsmith.",
-      "phonetic": "WORD-smith",
-      "syllables": "word-smith",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ability",
-      "definition": "The power to do something",
-      "example": "Practice improves your ability to solve problems.",
-      "phonetic": "A-bil-i-ty",
-      "syllables": "a-bil-i-ty",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "balance",
-      "definition": "A steady position without falling",
-      "example": "Yoga helps improve balance and focus.",
-      "phonetic": "BAL-ance",
-      "syllables": "bal-ance",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "capture",
-      "definition": "To catch or record something",
-      "example": "The camera can capture clear photos at night.",
-      "phonetic": "CAP-ture",
-      "syllables": "cap-ture",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "decide",
-      "definition": "To make a choice",
-      "example": "You should decide which topic to research.",
-      "phonetic": "DE-cide",
-      "syllables": "de-cide",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "effort",
-      "definition": "Hard work toward a goal",
-      "example": "Her effort showed in the final project.",
-      "phonetic": "EF-fort",
-      "syllables": "ef-fort",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "factual",
-      "definition": "Based on proven information",
-      "example": "The report should be factual and clear.",
-      "phonetic": "FAC-tu-al",
-      "syllables": "fac-tu-al",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "glacier",
-      "definition": "A slow-moving mass of ice",
-      "example": "The glacier carved a deep valley.",
-      "phonetic": "GLA-cier",
-      "syllables": "gla-cier",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "harvest",
-      "definition": "The process of gathering crops",
-      "example": "Farmers begin harvest in early autumn.",
-      "phonetic": "HAR-vest",
-      "syllables": "har-vest",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "imagine",
-      "definition": "To form a picture in your mind",
-      "example": "Imagine building a city on the moon.",
-      "phonetic": "IM-ag-ine",
-      "syllables": "im-ag-ine",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "journey",
-      "definition": "A trip from one place to another",
-      "example": "Our journey to the museum took two hours.",
-      "phonetic": "JOUR-ney",
-      "syllables": "jour-ney",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "kingdom",
-      "definition": "A country ruled by a king or queen",
-      "example": "The story takes place in a distant kingdom.",
-      "phonetic": "KING-dom",
-      "syllables": "king-dom",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "logical",
-      "definition": "Reasonable and based on clear thinking",
-      "example": "Use a logical method to solve the puzzle.",
-      "phonetic": "LOG-i-cal",
-      "syllables": "log-i-cal",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "miracle",
-      "definition": "An amazing event that seems impossible",
-      "example": "Doctors called her recovery a miracle.",
-      "phonetic": "MIR-a-cle",
-      "syllables": "mir-a-cle",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "natural",
-      "definition": "Existing in nature and not made by people",
-      "example": "Wool is a natural material.",
-      "phonetic": "NAT-u-ral",
-      "syllables": "nat-u-ral",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "outcome",
-      "definition": "The final result of an action",
-      "example": "The outcome of the experiment surprised us.",
-      "phonetic": "OUT-come",
-      "syllables": "out-come",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "patient",
-      "definition": "Able to wait calmly",
-      "example": "Be patient while the page loads.",
-      "phonetic": "PA-tient",
-      "syllables": "pa-tient",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "respect",
-      "definition": "To show care and value for others",
-      "example": "We should respect different opinions.",
-      "phonetic": "RE-spect",
-      "syllables": "re-spect",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "sincere",
-      "definition": "Honest and genuine",
-      "example": "He gave a sincere apology.",
-      "phonetic": "SIN-cere",
-      "syllables": "sin-cere",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "thrive",
-      "definition": "To grow or do well",
-      "example": "Plants thrive in warm sunlight.",
-      "phonetic": "THRIVE",
-      "syllables": "thrive",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "venture",
-      "definition": "A new activity that involves risk",
-      "example": "Starting the club was a bold venture.",
-      "phonetic": "VEN-ture",
-      "syllables": "ven-ture",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "analyze",
-      "definition": "To examine carefully",
-      "example": "Scientists analyze data before drawing conclusions.",
-      "phonetic": "AN-a-lyze",
-      "syllables": "an-a-lyze",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "boundary",
-      "definition": "A line that marks a limit",
-      "example": "Please stay inside the boundary lines.",
-      "phonetic": "BOUND-a-ry",
-      "syllables": "bound-a-ry",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "coherent",
-      "definition": "Clear and logically connected",
-      "example": "Her essay presented a coherent argument.",
-      "phonetic": "CO-her-ent",
-      "syllables": "co-her-ent",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "dilemma",
-      "definition": "A difficult choice between options",
-      "example": "He faced a dilemma about which team to join.",
-      "phonetic": "DI-lem-ma",
-      "syllables": "di-lem-ma",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "emphasis",
-      "definition": "Special importance given to something",
-      "example": "The coach placed emphasis on teamwork.",
-      "phonetic": "EM-pha-sis",
-      "syllables": "em-pha-sis",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "fragment",
-      "definition": "A small broken piece of something",
-      "example": "Archaeologists found a fragment of pottery.",
-      "phonetic": "FRAG-ment",
-      "syllables": "frag-ment",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "generate",
-      "definition": "To produce or create",
-      "example": "Wind turbines generate electricity.",
-      "phonetic": "GEN-er-ate",
-      "syllables": "gen-er-ate",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "heritage",
-      "definition": "Traditions passed down through generations",
-      "example": "The festival celebrates local heritage.",
-      "phonetic": "HER-it-age",
-      "syllables": "her-it-age",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "identify",
-      "definition": "To recognize and name",
-      "example": "Can you identify the main idea in this paragraph?",
-      "phonetic": "I-den-ti-fy",
-      "syllables": "i-den-ti-fy",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "justify",
-      "definition": "To show a good reason for",
-      "example": "Please justify your answer with evidence.",
-      "phonetic": "JUS-ti-fy",
-      "syllables": "jus-ti-fy",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "kinetic",
-      "definition": "Relating to motion",
-      "example": "A roller coaster has high kinetic energy.",
-      "phonetic": "KI-net-ic",
-      "syllables": "ki-net-ic",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "landscape",
-      "definition": "All the visible features of an area",
-      "example": "The painting shows a mountain landscape.",
-      "phonetic": "LAND-scape",
-      "syllables": "land-scape",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "moderate",
-      "definition": "Average in amount or level",
-      "example": "We had moderate rain this afternoon.",
-      "phonetic": "MOD-er-ate",
-      "syllables": "mod-er-ate",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "narrative",
-      "definition": "A spoken or written story",
-      "example": "The narrative follows a young inventor.",
-      "phonetic": "NAR-ra-tive",
-      "syllables": "nar-ra-tive",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "optimize",
-      "definition": "To make as effective as possible",
-      "example": "We can optimize the schedule to save time.",
-      "phonetic": "OP-ti-mize",
-      "syllables": "op-ti-mize",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "precise",
-      "definition": "Exact and accurate",
-      "example": "Use precise measurements in the lab.",
-      "phonetic": "PRE-cise",
-      "syllables": "pre-cise",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "quantify",
-      "definition": "To express as an amount",
-      "example": "The graph helps quantify population growth.",
-      "phonetic": "QUAN-ti-fy",
-      "syllables": "quan-ti-fy",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "reliable",
-      "definition": "Dependable and consistent",
-      "example": "This source is reliable for research.",
-      "phonetic": "RE-li-a-ble",
-      "syllables": "re-li-a-ble",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "simulate",
-      "definition": "To imitate real conditions",
-      "example": "The game can simulate weather patterns.",
-      "phonetic": "SIM-u-late",
-      "syllables": "sim-u-late",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "transform",
-      "definition": "To change form or appearance",
-      "example": "Heat can transform ice into water.",
-      "phonetic": "TRANS-form",
-      "syllables": "trans-form",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    }
-  ]
-}
+[
+  {
+    "word": "accommodate",
+    "definition": "To provide lodging or adjust to",
+    "sentence": "The hotel can accommodate 200 guests.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ac-com-mo-date",
+    "phonetic": "AC-com-mo-date"
+  },
+  {
+    "word": "bureaucracy",
+    "definition": "Administrative government system",
+    "sentence": "The bureaucracy slowed the process.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bu-reau-cra-cy",
+    "phonetic": "BU-reau-cra-cy"
+  },
+  {
+    "word": "conscientious",
+    "definition": "Thorough and careful",
+    "sentence": "She is a conscientious worker.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-sci-en-tious",
+    "phonetic": "CON-sci-en-tious"
+  },
+  {
+    "word": "entrepreneur",
+    "definition": "A business founder",
+    "sentence": "The entrepreneur started three companies.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "en-tre-pre-neur",
+    "phonetic": "EN-tre-pre-neur"
+  },
+  {
+    "word": "fluorescent",
+    "definition": "Emitting bright light",
+    "sentence": "The fluorescent lights buzzed overhead.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "flu-o-res-cent",
+    "phonetic": "FLU-o-res-cent"
+  },
+  {
+    "word": "guarantee",
+    "definition": "A formal promise",
+    "sentence": "The product comes with a guarantee.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "guar-an-tee",
+    "phonetic": "GUAR-an-tee"
+  },
+  {
+    "word": "hemorrhage",
+    "definition": "Severe bleeding",
+    "sentence": "The doctor stopped the hemorrhage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "hem-or-rhage",
+    "phonetic": "HEM-or-rhage"
+  },
+  {
+    "word": "inconvenience",
+    "definition": "Trouble or difficulty",
+    "sentence": "Sorry for any inconvenience caused.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "in-con-ven-ience",
+    "phonetic": "IN-con-ven-ience"
+  },
+  {
+    "word": "jeopardize",
+    "definition": "To put at risk",
+    "sentence": "Don't jeopardize your future.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "jeop-ar-dize",
+    "phonetic": "JEOP-ar-dize"
+  },
+  {
+    "word": "knowledgeable",
+    "definition": "Well informed",
+    "sentence": "The guide was very knowledgeable.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "knowl-edge-a-ble",
+    "phonetic": "KNOWL-edge-a-ble"
+  },
+  {
+    "word": "liaison",
+    "definition": "A person who links groups",
+    "sentence": "She serves as liaison between departments.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "li-ai-son",
+    "phonetic": "LI-ai-son"
+  },
+  {
+    "word": "mischievous",
+    "definition": "Playfully troublesome",
+    "sentence": "The mischievous child hid the keys.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "mis-chie-vous",
+    "phonetic": "MIS-chie-vous"
+  },
+  {
+    "word": "onomatopoeia",
+    "definition": "Words that imitate sounds",
+    "sentence": "Buzz is an example of onomatopoeia.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "on-o-mat-o-poe-ia",
+    "phonetic": "ON-o-mat-o-poe-ia"
+  },
+  {
+    "word": "pharmaceutical",
+    "definition": "Related to medicinal drugs",
+    "sentence": "The pharmaceutical company developed a vaccine.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "phar-ma-ceu-ti-cal",
+    "phonetic": "PHAR-ma-ceu-ti-cal"
+  },
+  {
+    "word": "rendezvous",
+    "definition": "A planned meeting",
+    "sentence": "They arranged a secret rendezvous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ren-dez-vous",
+    "phonetic": "REN-dez-vous"
+  },
+  {
+    "word": "surveillance",
+    "definition": "Close observation",
+    "sentence": "The building has surveillance cameras.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "sur-veil-lance",
+    "phonetic": "SUR-veil-lance"
+  },
+  {
+    "word": "tyranny",
+    "definition": "Cruel oppressive rule",
+    "sentence": "The people rose against tyranny.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "tyr-an-ny",
+    "phonetic": "TYR-an-ny"
+  },
+  {
+    "word": "ubiquitous",
+    "definition": "Present everywhere",
+    "sentence": "Smartphones are now ubiquitous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "u-biq-ui-tous",
+    "phonetic": "U-biq-ui-tous"
+  },
+  {
+    "word": "vocabulary",
+    "definition": "Words known or used",
+    "sentence": "Reading expands your vocabulary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "vo-cab-u-lar-y",
+    "phonetic": "VO-cab-u-lar-y"
+  },
+  {
+    "word": "Wednesday",
+    "definition": "The fourth day of the week",
+    "sentence": "The meeting is on Wednesday.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "Wednes-day",
+    "phonetic": "WEDNES-day"
+  },
+  {
+    "word": "achievement",
+    "definition": "Something done successfully",
+    "sentence": "Winning the game was a great achievement.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-chieve-ment",
+    "phonetic": "A-chieve-ment"
+  },
+  {
+    "word": "acoustic",
+    "definition": "Related to sound or hearing",
+    "sentence": "He played an acoustic guitar.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-cous-tic",
+    "phonetic": "A-cous-tic"
+  },
+  {
+    "word": "algorithm",
+    "definition": "A set of rules for solving a problem",
+    "sentence": "The computer uses an algorithm to search.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "al-go-rithm",
+    "phonetic": "AL-go-rithm"
+  },
+  {
+    "word": "amphibian",
+    "definition": "An animal living on land and water",
+    "sentence": "A frog is a type of amphibian.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "am-phib-i-an",
+    "phonetic": "AM-phib-i-an"
+  },
+  {
+    "word": "analysis",
+    "definition": "Detailed examination",
+    "sentence": "The scientist performed an analysis of the data.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-nal-y-sis",
+    "phonetic": "A-nal-y-sis"
+  },
+  {
+    "word": "ancient",
+    "definition": "Belonging to the very distant past",
+    "sentence": "They visited the ancient ruins.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-cient",
+    "phonetic": "AN-cient"
+  },
+  {
+    "word": "anniversary",
+    "definition": "Date on which an event took place",
+    "sentence": "They celebrated their wedding anniversary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-ni-ver-sa-ry",
+    "phonetic": "AN-ni-ver-sa-ry"
+  },
+  {
+    "word": "anonymous",
+    "definition": "Not identified by name",
+    "sentence": "The donor chose to remain anonymous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-non-y-mous",
+    "phonetic": "A-non-y-mous"
+  },
+  {
+    "word": "antique",
+    "definition": "A collectible object having a high value",
+    "sentence": "This chair is a valuable antique.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-tique",
+    "phonetic": "AN-tique"
+  },
+  {
+    "word": "anxiety",
+    "definition": "A feeling of worry or nervousness",
+    "sentence": "He felt anxiety before the test.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "anx-i-e-ty",
+    "phonetic": "ANX-i-e-ty"
+  },
+  {
+    "word": "appreciate",
+    "definition": "To recognize the full worth of",
+    "sentence": "I appreciate your help.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ap-pre-ci-ate",
+    "phonetic": "AP-pre-ci-ate"
+  },
+  {
+    "word": "aquarium",
+    "definition": "A tank of water for fish",
+    "sentence": "We saw sharks at the aquarium.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-quar-i-um",
+    "phonetic": "A-quar-i-um"
+  },
+  {
+    "word": "architecture",
+    "definition": "The art of designing buildings",
+    "sentence": "The city has beautiful architecture.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-chi-tec-ture",
+    "phonetic": "AR-chi-tec-ture"
+  },
+  {
+    "word": "arithmetic",
+    "definition": "The branch of math with numbers",
+    "sentence": "We learned arithmetic in school.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-rith-me-tic",
+    "phonetic": "A-rith-me-tic"
+  },
+  {
+    "word": "artificial",
+    "definition": "Made by humans, not natural",
+    "sentence": "The flowers are artificial.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-ti-fi-cial",
+    "phonetic": "AR-ti-fi-cial"
+  },
+  {
+    "word": "atmosphere",
+    "definition": "Gases surrounding a planet",
+    "sentence": "The atmosphere protects the Earth.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "at-mos-phere",
+    "phonetic": "AT-mos-phere"
+  },
+  {
+    "word": "audience",
+    "definition": "Spectators at an event",
+    "sentence": "The audience clapped loudly.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-di-ence",
+    "phonetic": "AU-di-ence"
+  },
+  {
+    "word": "authentic",
+    "definition": "Of undisputed origin; genuine",
+    "sentence": "This is an authentic painting.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-then-tic",
+    "phonetic": "AU-then-tic"
+  },
+  {
+    "word": "biography",
+    "definition": "An account of someone's life",
+    "sentence": "I read a biography of Lincoln.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-og-ra-phy",
+    "phonetic": "BI-og-ra-phy"
+  },
+  {
+    "word": "bizarre",
+    "definition": "Very strange or unusual",
+    "sentence": "It was a bizarre situation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-zarre",
+    "phonetic": "BI-zarre"
+  },
+  {
+    "word": "camouflage",
+    "definition": "Disguise to blend with surroundings",
+    "sentence": "The soldier wore camouflage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-ou-flage",
+    "phonetic": "CAM-ou-flage"
+  },
+  {
+    "word": "campaign",
+    "definition": "A series of actions for a goal",
+    "sentence": "The election campaign was intense.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-paign",
+    "phonetic": "CAM-paign"
+  },
+  {
+    "word": "capacity",
+    "definition": "The maximum amount something can hold",
+    "sentence": "The stadium was filled to capacity.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-pac-i-ty",
+    "phonetic": "CA-pac-i-ty"
+  },
+  {
+    "word": "catastrophe",
+    "definition": "A sudden great disaster",
+    "sentence": "The earthquake was a catastrophe.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-tas-tro-phe",
+    "phonetic": "CA-tas-tro-phe"
+  },
+  {
+    "word": "cemetery",
+    "definition": "A place for burying the dead",
+    "sentence": "They visited the old cemetery.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cem-e-ter-y",
+    "phonetic": "CEM-e-ter-y"
+  },
+  {
+    "word": "ceremony",
+    "definition": "A formal religious or public occasion",
+    "sentence": "The graduation ceremony is tomorrow.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cer-e-mo-ny",
+    "phonetic": "CER-e-mo-ny"
+  },
+  {
+    "word": "chameleon",
+    "definition": "A lizard that changes color",
+    "sentence": "The chameleon turned green.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cha-me-le-on",
+    "phonetic": "CHA-me-le-on"
+  },
+  {
+    "word": "chandelier",
+    "definition": "A decorative hanging light",
+    "sentence": "A crystal chandelier hung in the hall.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chan-de-lier",
+    "phonetic": "CHAN-de-lier"
+  },
+  {
+    "word": "character",
+    "definition": "A person in a novel or movie",
+    "sentence": "Who is your favorite character?",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "char-ac-ter",
+    "phonetic": "CHAR-ac-ter"
+  },
+  {
+    "word": "chemistry",
+    "definition": "Science of substances and reactions",
+    "sentence": "We did experiments in chemistry class.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chem-is-try",
+    "phonetic": "CHEM-is-try"
+  },
+  {
+    "word": "choreography",
+    "definition": "The sequence of steps in dance",
+    "sentence": "The ballet choreography was complex.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cho-re-og-ra-phy",
+    "phonetic": "CHO-re-og-ra-phy"
+  },
+  {
+    "word": "circumference",
+    "definition": "The distance around a circle",
+    "sentence": "Measure the circumference of the ball.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cir-cum-fer-ence",
+    "phonetic": "CIR-cum-fer-ence"
+  },
+  {
+    "word": "civilization",
+    "definition": "Advanced stage of human social development",
+    "sentence": "Ancient Rome was a great civilization.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "civ-i-li-za-tion",
+    "phonetic": "CIV-i-li-za-tion"
+  },
+  {
+    "word": "coincidence",
+    "definition": "Events happening together by chance",
+    "sentence": "It was a coincidence that we met.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "co-in-ci-dence",
+    "phonetic": "CO-in-ci-dence"
+  },
+  {
+    "word": "collaborate",
+    "definition": "Work jointly on an activity",
+    "sentence": "We will collaborate on the project.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-lab-o-rate",
+    "phonetic": "COL-lab-o-rate"
+  },
+  {
+    "word": "collision",
+    "definition": "An instance of one moving object striking another",
+    "sentence": "The car collision caused a traffic jam.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-li-sion",
+    "phonetic": "COL-li-sion"
+  },
+  {
+    "word": "column",
+    "definition": "An upright pillar",
+    "sentence": "The roof was supported by a stone column.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-umn",
+    "phonetic": "COL-umn"
+  },
+  {
+    "word": "committee",
+    "definition": "A group of people appointed for a function",
+    "sentence": "The committee will vote on the issue.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-mit-tee",
+    "phonetic": "COM-mit-tee"
+  },
+  {
+    "word": "communicate",
+    "definition": "Share or exchange information",
+    "sentence": "We communicate by email.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-mu-ni-cate",
+    "phonetic": "COM-mu-ni-cate"
+  },
+  {
+    "word": "community",
+    "definition": "A group of people living in the same place",
+    "sentence": "We have a friendly community.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-mu-ni-ty",
+    "phonetic": "COM-mu-ni-ty"
+  },
+  {
+    "word": "competition",
+    "definition": "The activity of competing",
+    "sentence": "She won the swimming competition.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-pe-ti-tion",
+    "phonetic": "COM-pe-ti-tion"
+  },
+  {
+    "word": "complicated",
+    "definition": "Consisting of many interconnecting parts",
+    "sentence": "The instructions were very complicated.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-pli-cat-ed",
+    "phonetic": "COM-pli-cat-ed"
+  },
+  {
+    "word": "concentrate",
+    "definition": "Focus one's attention",
+    "sentence": "I need to concentrate on my work.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-cen-trate",
+    "phonetic": "CON-cen-trate"
+  },
+  {
+    "word": "conclusion",
+    "definition": "The end or finish of an event",
+    "sentence": "The conclusion of the story was sad.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-clu-sion",
+    "phonetic": "CON-clu-sion"
+  },
+  {
+    "word": "confident",
+    "definition": "Feeling certain about ability",
+    "sentence": "He is confident he will pass.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-fi-dent",
+    "phonetic": "CON-fi-dent"
+  },
+  {
+    "word": "consequence",
+    "definition": "A result or effect of an action",
+    "sentence": "Every action has a consequence.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-se-quence",
+    "phonetic": "CON-se-quence"
+  },
+  {
+    "word": "constellation",
+    "definition": "A group of stars forming a pattern",
+    "sentence": "Can you find the Big Dipper constellation?",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-stel-la-tion",
+    "phonetic": "CON-stel-la-tion"
+  },
+  {
+    "word": "contagious",
+    "definition": "Spread from one person to another",
+    "sentence": "The flu is very contagious.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-ta-gious",
+    "phonetic": "CON-ta-gious"
+  },
+  {
+    "word": "controversial",
+    "definition": "Giving rise to public disagreement",
+    "sentence": "It was a controversial decision.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-tro-ver-sial",
+    "phonetic": "CON-tro-ver-sial"
+  },
+  {
+    "word": "convenient",
+    "definition": "Fitting in well with needs",
+    "sentence": "It is convenient to live near the store.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-ven-ient",
+    "phonetic": "CON-ven-ient"
+  },
+  {
+    "word": "conversation",
+    "definition": "A talk between two or more people",
+    "sentence": "They had a long conversation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-ver-sa-tion",
+    "phonetic": "CON-ver-sa-tion"
+  },
+  {
+    "word": "cooperation",
+    "definition": "The process of working together",
+    "sentence": "The project requires cooperation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "co-op-er-a-tion",
+    "phonetic": "CO-op-er-a-tion"
+  },
+  {
+    "word": "corporation",
+    "definition": "A large company",
+    "sentence": "She works for a major corporation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cor-po-ra-tion",
+    "phonetic": "COR-po-ra-tion"
+  },
+  {
+    "word": "courageous",
+    "definition": "Not deterred by danger or pain",
+    "sentence": "The firefighter was very courageous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cour-a-geous",
+    "phonetic": "COUR-a-geous"
+  },
+  {
+    "word": "criticism",
+    "definition": "Expression of disapproval",
+    "sentence": "He accepted the criticism gracefully.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "crit-i-cism",
+    "phonetic": "CRIT-i-cism"
+  },
+  {
+    "word": "biodiversity",
+    "definition": "The variety of plant and animal life in an area",
+    "sentence": "Rainforests are known for rich biodiversity.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-o-di-ver-si-ty",
+    "phonetic": "BI-o-di-ver-si-ty"
+  },
+  {
+    "word": "collaboration",
+    "definition": "Working jointly with others",
+    "sentence": "The project succeeded through collaboration.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-lab-o-ra-tion",
+    "phonetic": "COL-lab-o-ra-tion"
+  },
+  {
+    "word": "determination",
+    "definition": "Firmness of purpose",
+    "sentence": "Her determination helped her finish the race.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "de-ter-mi-na-tion",
+    "phonetic": "DE-ter-mi-na-tion"
+  },
+  {
+    "word": "geothermal",
+    "definition": "Relating to heat produced inside the earth",
+    "sentence": "Iceland uses geothermal energy for power.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ge-o-ther-mal",
+    "phonetic": "GE-o-ther-mal"
+  },
+  {
+    "word": "hypothesis",
+    "definition": "A proposed explanation for testing",
+    "sentence": "The class tested each hypothesis in the lab.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "hy-poth-e-sis",
+    "phonetic": "HY-poth-e-sis"
+  },
+  {
+    "word": "metamorphosis",
+    "definition": "A major change in form during development",
+    "sentence": "A butterfly emerges after metamorphosis.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "met-a-mor-pho-sis",
+    "phonetic": "MET-a-mor-pho-sis"
+  },
+  {
+    "word": "resilience",
+    "definition": "The ability to recover from difficulty",
+    "sentence": "Resilience helps people handle setbacks.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "re-sil-ience",
+    "phonetic": "RE-sil-ience"
+  },
+  {
+    "word": "sustainability",
+    "definition": "Using resources in a way that avoids long-term harm",
+    "sentence": "The city adopted sustainability goals.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "sus-tain-a-bil-i-ty",
+    "phonetic": "SUS-tain-a-bil-i-ty"
+  },
+  {
+    "word": "wordsmith",
+    "definition": "A person skilled at using words effectively",
+    "sentence": "The poet was praised as a talented wordsmith.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "word-smith",
+    "phonetic": "WORD-smith"
+  },
+  {
+    "word": "ability",
+    "definition": "The power to do something",
+    "sentence": "Practice improves your ability to solve problems.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "a-bil-i-ty",
+    "phonetic": "A-bil-i-ty"
+  },
+  {
+    "word": "balance",
+    "definition": "A steady position without falling",
+    "sentence": "Yoga helps improve balance and focus.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "bal-ance",
+    "phonetic": "BAL-ance"
+  },
+  {
+    "word": "capture",
+    "definition": "To catch or record something",
+    "sentence": "The camera can capture clear photos at night.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "cap-ture",
+    "phonetic": "CAP-ture"
+  },
+  {
+    "word": "decide",
+    "definition": "To make a choice",
+    "sentence": "You should decide which topic to research.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "de-cide",
+    "phonetic": "DE-cide"
+  },
+  {
+    "word": "effort",
+    "definition": "Hard work toward a goal",
+    "sentence": "Her effort showed in the final project.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "ef-fort",
+    "phonetic": "EF-fort"
+  },
+  {
+    "word": "factual",
+    "definition": "Based on proven information",
+    "sentence": "The report should be factual and clear.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "fac-tu-al",
+    "phonetic": "FAC-tu-al"
+  },
+  {
+    "word": "glacier",
+    "definition": "A slow-moving mass of ice",
+    "sentence": "The glacier carved a deep valley.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "gla-cier",
+    "phonetic": "GLA-cier"
+  },
+  {
+    "word": "harvest",
+    "definition": "The process of gathering crops",
+    "sentence": "Farmers begin harvest in early autumn.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "har-vest",
+    "phonetic": "HAR-vest"
+  },
+  {
+    "word": "imagine",
+    "definition": "To form a picture in your mind",
+    "sentence": "Imagine building a city on the moon.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "im-ag-ine",
+    "phonetic": "IM-ag-ine"
+  },
+  {
+    "word": "journey",
+    "definition": "A trip from one place to another",
+    "sentence": "Our journey to the museum took two hours.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "jour-ney",
+    "phonetic": "JOUR-ney"
+  },
+  {
+    "word": "kingdom",
+    "definition": "A country ruled by a king or queen",
+    "sentence": "The story takes place in a distant kingdom.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "king-dom",
+    "phonetic": "KING-dom"
+  },
+  {
+    "word": "logical",
+    "definition": "Reasonable and based on clear thinking",
+    "sentence": "Use a logical method to solve the puzzle.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "log-i-cal",
+    "phonetic": "LOG-i-cal"
+  },
+  {
+    "word": "miracle",
+    "definition": "An amazing event that seems impossible",
+    "sentence": "Doctors called her recovery a miracle.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "mir-a-cle",
+    "phonetic": "MIR-a-cle"
+  },
+  {
+    "word": "natural",
+    "definition": "Existing in nature and not made by people",
+    "sentence": "Wool is a natural material.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "nat-u-ral",
+    "phonetic": "NAT-u-ral"
+  },
+  {
+    "word": "outcome",
+    "definition": "The final result of an action",
+    "sentence": "The outcome of the experiment surprised us.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "out-come",
+    "phonetic": "OUT-come"
+  },
+  {
+    "word": "patient",
+    "definition": "Able to wait calmly",
+    "sentence": "Be patient while the page loads.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "pa-tient",
+    "phonetic": "PA-tient"
+  },
+  {
+    "word": "respect",
+    "definition": "To show care and value for others",
+    "sentence": "We should respect different opinions.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "re-spect",
+    "phonetic": "RE-spect"
+  },
+  {
+    "word": "sincere",
+    "definition": "Honest and genuine",
+    "sentence": "He gave a sincere apology.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "sin-cere",
+    "phonetic": "SIN-cere"
+  },
+  {
+    "word": "thrive",
+    "definition": "To grow or do well",
+    "sentence": "Plants thrive in warm sunlight.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "thrive",
+    "phonetic": "THRIVE"
+  },
+  {
+    "word": "venture",
+    "definition": "A new activity that involves risk",
+    "sentence": "Starting the club was a bold venture.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "ven-ture",
+    "phonetic": "VEN-ture"
+  },
+  {
+    "word": "analyze",
+    "definition": "To examine carefully",
+    "sentence": "Scientists analyze data before drawing conclusions.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "an-a-lyze",
+    "phonetic": "AN-a-lyze"
+  },
+  {
+    "word": "boundary",
+    "definition": "A line that marks a limit",
+    "sentence": "Please stay inside the boundary lines.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "bound-a-ry",
+    "phonetic": "BOUND-a-ry"
+  },
+  {
+    "word": "coherent",
+    "definition": "Clear and logically connected",
+    "sentence": "Her essay presented a coherent argument.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "co-her-ent",
+    "phonetic": "CO-her-ent"
+  },
+  {
+    "word": "dilemma",
+    "definition": "A difficult choice between options",
+    "sentence": "He faced a dilemma about which team to join.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "di-lem-ma",
+    "phonetic": "DI-lem-ma"
+  },
+  {
+    "word": "emphasis",
+    "definition": "Special importance given to something",
+    "sentence": "The coach placed emphasis on teamwork.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "em-pha-sis",
+    "phonetic": "EM-pha-sis"
+  },
+  {
+    "word": "fragment",
+    "definition": "A small broken piece of something",
+    "sentence": "Archaeologists found a fragment of pottery.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "frag-ment",
+    "phonetic": "FRAG-ment"
+  },
+  {
+    "word": "generate",
+    "definition": "To produce or create",
+    "sentence": "Wind turbines generate electricity.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "gen-er-ate",
+    "phonetic": "GEN-er-ate"
+  },
+  {
+    "word": "heritage",
+    "definition": "Traditions passed down through generations",
+    "sentence": "The festival celebrates local heritage.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "her-it-age",
+    "phonetic": "HER-it-age"
+  },
+  {
+    "word": "identify",
+    "definition": "To recognize and name",
+    "sentence": "Can you identify the main idea in this paragraph?",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "i-den-ti-fy",
+    "phonetic": "I-den-ti-fy"
+  },
+  {
+    "word": "justify",
+    "definition": "To show a good reason for",
+    "sentence": "Please justify your answer with evidence.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "jus-ti-fy",
+    "phonetic": "JUS-ti-fy"
+  },
+  {
+    "word": "kinetic",
+    "definition": "Relating to motion",
+    "sentence": "A roller coaster has high kinetic energy.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "ki-net-ic",
+    "phonetic": "KI-net-ic"
+  },
+  {
+    "word": "landscape",
+    "definition": "All the visible features of an area",
+    "sentence": "The painting shows a mountain landscape.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "land-scape",
+    "phonetic": "LAND-scape"
+  },
+  {
+    "word": "moderate",
+    "definition": "Average in amount or level",
+    "sentence": "We had moderate rain this afternoon.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "mod-er-ate",
+    "phonetic": "MOD-er-ate"
+  },
+  {
+    "word": "narrative",
+    "definition": "A spoken or written story",
+    "sentence": "The narrative follows a young inventor.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "nar-ra-tive",
+    "phonetic": "NAR-ra-tive"
+  },
+  {
+    "word": "optimize",
+    "definition": "To make as effective as possible",
+    "sentence": "We can optimize the schedule to save time.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "op-ti-mize",
+    "phonetic": "OP-ti-mize"
+  },
+  {
+    "word": "precise",
+    "definition": "Exact and accurate",
+    "sentence": "Use precise measurements in the lab.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "pre-cise",
+    "phonetic": "PRE-cise"
+  },
+  {
+    "word": "quantify",
+    "definition": "To express as an amount",
+    "sentence": "The graph helps quantify population growth.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "quan-ti-fy",
+    "phonetic": "QUAN-ti-fy"
+  },
+  {
+    "word": "reliable",
+    "definition": "Dependable and consistent",
+    "sentence": "This source is reliable for research.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "re-li-a-ble",
+    "phonetic": "RE-li-a-ble"
+  },
+  {
+    "word": "simulate",
+    "definition": "To imitate real conditions",
+    "sentence": "The game can simulate weather patterns.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "sim-u-late",
+    "phonetic": "SIM-u-late"
+  },
+  {
+    "word": "transform",
+    "definition": "To change form or appearance",
+    "sentence": "Heat can transform ice into water.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "trans-form",
+    "phonetic": "TRANS-form"
+  }
+]

--- a/public/data/words/grade-8.json
+++ b/public/data/words/grade-8.json
@@ -1,1125 +1,1118 @@
-{
-  "grade": 8,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 124,
-  "words": [
-    {
-      "word": "accommodate",
-      "definition": "To provide lodging or adjust to",
-      "example": "The hotel can accommodate 200 guests.",
-      "phonetic": "AC-com-mo-date",
-      "syllables": "ac-com-mo-date",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bureaucracy",
-      "definition": "Administrative government system",
-      "example": "The bureaucracy slowed the process.",
-      "phonetic": "BU-reau-cra-cy",
-      "syllables": "bu-reau-cra-cy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conscientious",
-      "definition": "Thorough and careful",
-      "example": "She is a conscientious worker.",
-      "phonetic": "CON-sci-en-tious",
-      "syllables": "con-sci-en-tious",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "entrepreneur",
-      "definition": "A business founder",
-      "example": "The entrepreneur started three companies.",
-      "phonetic": "EN-tre-pre-neur",
-      "syllables": "en-tre-pre-neur",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "fluorescent",
-      "definition": "Emitting bright light",
-      "example": "The fluorescent lights buzzed overhead.",
-      "phonetic": "FLU-o-res-cent",
-      "syllables": "flu-o-res-cent",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "guarantee",
-      "definition": "A formal promise",
-      "example": "The product comes with a guarantee.",
-      "phonetic": "GUAR-an-tee",
-      "syllables": "guar-an-tee",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "hemorrhage",
-      "definition": "Severe bleeding",
-      "example": "The doctor stopped the hemorrhage.",
-      "phonetic": "HEM-or-rhage",
-      "syllables": "hem-or-rhage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "inconvenience",
-      "definition": "Trouble or difficulty",
-      "example": "Sorry for any inconvenience caused.",
-      "phonetic": "IN-con-ven-ience",
-      "syllables": "in-con-ven-ience",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "jeopardize",
-      "definition": "To put at risk",
-      "example": "Don't jeopardize your future.",
-      "phonetic": "JEOP-ar-dize",
-      "syllables": "jeop-ar-dize",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "knowledgeable",
-      "definition": "Well informed",
-      "example": "The guide was very knowledgeable.",
-      "phonetic": "KNOWL-edge-a-ble",
-      "syllables": "knowl-edge-a-ble",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "liaison",
-      "definition": "A person who links groups",
-      "example": "She serves as liaison between departments.",
-      "phonetic": "LI-ai-son",
-      "syllables": "li-ai-son",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "mischievous",
-      "definition": "Playfully troublesome",
-      "example": "The mischievous child hid the keys.",
-      "phonetic": "MIS-chie-vous",
-      "syllables": "mis-chie-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "onomatopoeia",
-      "definition": "Words that imitate sounds",
-      "example": "Buzz is an example of onomatopoeia.",
-      "phonetic": "ON-o-mat-o-poe-ia",
-      "syllables": "on-o-mat-o-poe-ia",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "pharmaceutical",
-      "definition": "Related to medicinal drugs",
-      "example": "The pharmaceutical company developed a vaccine.",
-      "phonetic": "PHAR-ma-ceu-ti-cal",
-      "syllables": "phar-ma-ceu-ti-cal",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "rendezvous",
-      "definition": "A planned meeting",
-      "example": "They arranged a secret rendezvous.",
-      "phonetic": "REN-dez-vous",
-      "syllables": "ren-dez-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "surveillance",
-      "definition": "Close observation",
-      "example": "The building has surveillance cameras.",
-      "phonetic": "SUR-veil-lance",
-      "syllables": "sur-veil-lance",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "tyranny",
-      "definition": "Cruel oppressive rule",
-      "example": "The people rose against tyranny.",
-      "phonetic": "TYR-an-ny",
-      "syllables": "tyr-an-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ubiquitous",
-      "definition": "Present everywhere",
-      "example": "Smartphones are now ubiquitous.",
-      "phonetic": "U-biq-ui-tous",
-      "syllables": "u-biq-ui-tous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "vocabulary",
-      "definition": "Words known or used",
-      "example": "Reading expands your vocabulary.",
-      "phonetic": "VO-cab-u-lar-y",
-      "syllables": "vo-cab-u-lar-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "Wednesday",
-      "definition": "The fourth day of the week",
-      "example": "The meeting is on Wednesday.",
-      "phonetic": "WEDNES-day",
-      "syllables": "Wednes-day",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "achievement",
-      "definition": "Something done successfully",
-      "example": "Winning the game was a great achievement.",
-      "phonetic": "A-chieve-ment",
-      "syllables": "a-chieve-ment",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "acoustic",
-      "definition": "Related to sound or hearing",
-      "example": "He played an acoustic guitar.",
-      "phonetic": "A-cous-tic",
-      "syllables": "a-cous-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "algorithm",
-      "definition": "A set of rules for solving a problem",
-      "example": "The computer uses an algorithm to search.",
-      "phonetic": "AL-go-rithm",
-      "syllables": "al-go-rithm",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "amphibian",
-      "definition": "An animal living on land and water",
-      "example": "A frog is a type of amphibian.",
-      "phonetic": "AM-phib-i-an",
-      "syllables": "am-phib-i-an",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "analysis",
-      "definition": "Detailed examination",
-      "example": "The scientist performed an analysis of the data.",
-      "phonetic": "A-nal-y-sis",
-      "syllables": "a-nal-y-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ancient",
-      "definition": "Belonging to the very distant past",
-      "example": "They visited the ancient ruins.",
-      "phonetic": "AN-cient",
-      "syllables": "an-cient",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anniversary",
-      "definition": "Date on which an event took place",
-      "example": "They celebrated their wedding anniversary.",
-      "phonetic": "AN-ni-ver-sa-ry",
-      "syllables": "an-ni-ver-sa-ry",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anonymous",
-      "definition": "Not identified by name",
-      "example": "The donor chose to remain anonymous.",
-      "phonetic": "A-non-y-mous",
-      "syllables": "a-non-y-mous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "antique",
-      "definition": "A collectible object having a high value",
-      "example": "This chair is a valuable antique.",
-      "phonetic": "AN-tique",
-      "syllables": "an-tique",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anxiety",
-      "definition": "A feeling of worry or nervousness",
-      "example": "He felt anxiety before the test.",
-      "phonetic": "ANX-i-e-ty",
-      "syllables": "anx-i-e-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "appreciate",
-      "definition": "To recognize the full worth of",
-      "example": "I appreciate your help.",
-      "phonetic": "AP-pre-ci-ate",
-      "syllables": "ap-pre-ci-ate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "aquarium",
-      "definition": "A tank of water for fish",
-      "example": "We saw sharks at the aquarium.",
-      "phonetic": "A-quar-i-um",
-      "syllables": "a-quar-i-um",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "architecture",
-      "definition": "The art of designing buildings",
-      "example": "The city has beautiful architecture.",
-      "phonetic": "AR-chi-tec-ture",
-      "syllables": "ar-chi-tec-ture",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "arithmetic",
-      "definition": "The branch of math with numbers",
-      "example": "We learned arithmetic in school.",
-      "phonetic": "A-rith-me-tic",
-      "syllables": "a-rith-me-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "artificial",
-      "definition": "Made by humans, not natural",
-      "example": "The flowers are artificial.",
-      "phonetic": "AR-ti-fi-cial",
-      "syllables": "ar-ti-fi-cial",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "atmosphere",
-      "definition": "Gases surrounding a planet",
-      "example": "The atmosphere protects the Earth.",
-      "phonetic": "AT-mos-phere",
-      "syllables": "at-mos-phere",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "audience",
-      "definition": "Spectators at an event",
-      "example": "The audience clapped loudly.",
-      "phonetic": "AU-di-ence",
-      "syllables": "au-di-ence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "authentic",
-      "definition": "Of undisputed origin; genuine",
-      "example": "This is an authentic painting.",
-      "phonetic": "AU-then-tic",
-      "syllables": "au-then-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "biography",
-      "definition": "An account of someone's life",
-      "example": "I read a biography of Lincoln.",
-      "phonetic": "BI-og-ra-phy",
-      "syllables": "bi-og-ra-phy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bizarre",
-      "definition": "Very strange or unusual",
-      "example": "It was a bizarre situation.",
-      "phonetic": "BI-zarre",
-      "syllables": "bi-zarre",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "camouflage",
-      "definition": "Disguise to blend with surroundings",
-      "example": "The soldier wore camouflage.",
-      "phonetic": "CAM-ou-flage",
-      "syllables": "cam-ou-flage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "campaign",
-      "definition": "A series of actions for a goal",
-      "example": "The election campaign was intense.",
-      "phonetic": "CAM-paign",
-      "syllables": "cam-paign",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "capacity",
-      "definition": "The maximum amount something can hold",
-      "example": "The stadium was filled to capacity.",
-      "phonetic": "CA-pac-i-ty",
-      "syllables": "ca-pac-i-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "catastrophe",
-      "definition": "A sudden great disaster",
-      "example": "The earthquake was a catastrophe.",
-      "phonetic": "CA-tas-tro-phe",
-      "syllables": "ca-tas-tro-phe",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "cemetery",
-      "definition": "A place for burying the dead",
-      "example": "They visited the old cemetery.",
-      "phonetic": "CEM-e-ter-y",
-      "syllables": "cem-e-ter-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ceremony",
-      "definition": "A formal religious or public occasion",
-      "example": "The graduation ceremony is tomorrow.",
-      "phonetic": "CER-e-mo-ny",
-      "syllables": "cer-e-mo-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chameleon",
-      "definition": "A lizard that changes color",
-      "example": "The chameleon turned green.",
-      "phonetic": "CHA-me-le-on",
-      "syllables": "cha-me-le-on",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chandelier",
-      "definition": "A decorative hanging light",
-      "example": "A crystal chandelier hung in the hall.",
-      "phonetic": "CHAN-de-lier",
-      "syllables": "chan-de-lier",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "character",
-      "definition": "A person in a novel or movie",
-      "example": "Who is your favorite character?",
-      "phonetic": "CHAR-ac-ter",
-      "syllables": "char-ac-ter",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chemistry",
-      "definition": "Science of substances and reactions",
-      "example": "We did experiments in chemistry class.",
-      "phonetic": "CHEM-is-try",
-      "syllables": "chem-is-try",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "choreography",
-      "definition": "The sequence of steps in dance",
-      "example": "The ballet choreography was complex.",
-      "phonetic": "CHO-re-og-ra-phy",
-      "syllables": "cho-re-og-ra-phy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "circumference",
-      "definition": "The distance around a circle",
-      "example": "Measure the circumference of the ball.",
-      "phonetic": "CIR-cum-fer-ence",
-      "syllables": "cir-cum-fer-ence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "civilization",
-      "definition": "Advanced stage of human social development",
-      "example": "Ancient Rome was a great civilization.",
-      "phonetic": "CIV-i-li-za-tion",
-      "syllables": "civ-i-li-za-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "coincidence",
-      "definition": "Events happening together by chance",
-      "example": "It was a coincidence that we met.",
-      "phonetic": "CO-in-ci-dence",
-      "syllables": "co-in-ci-dence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "collaborate",
-      "definition": "Work jointly on an activity",
-      "example": "We will collaborate on the project.",
-      "phonetic": "COL-lab-o-rate",
-      "syllables": "col-lab-o-rate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "collision",
-      "definition": "An instance of one moving object striking another",
-      "example": "The car collision caused a traffic jam.",
-      "phonetic": "COL-li-sion",
-      "syllables": "col-li-sion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "column",
-      "definition": "An upright pillar",
-      "example": "The roof was supported by a stone column.",
-      "phonetic": "COL-umn",
-      "syllables": "col-umn",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "committee",
-      "definition": "A group of people appointed for a function",
-      "example": "The committee will vote on the issue.",
-      "phonetic": "COM-mit-tee",
-      "syllables": "com-mit-tee",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "communicate",
-      "definition": "Share or exchange information",
-      "example": "We communicate by email.",
-      "phonetic": "COM-mu-ni-cate",
-      "syllables": "com-mu-ni-cate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "community",
-      "definition": "A group of people living in the same place",
-      "example": "We have a friendly community.",
-      "phonetic": "COM-mu-ni-ty",
-      "syllables": "com-mu-ni-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "competition",
-      "definition": "The activity of competing",
-      "example": "She won the swimming competition.",
-      "phonetic": "COM-pe-ti-tion",
-      "syllables": "com-pe-ti-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "complicated",
-      "definition": "Consisting of many interconnecting parts",
-      "example": "The instructions were very complicated.",
-      "phonetic": "COM-pli-cat-ed",
-      "syllables": "com-pli-cat-ed",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "concentrate",
-      "definition": "Focus one's attention",
-      "example": "I need to concentrate on my work.",
-      "phonetic": "CON-cen-trate",
-      "syllables": "con-cen-trate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conclusion",
-      "definition": "The end or finish of an event",
-      "example": "The conclusion of the story was sad.",
-      "phonetic": "CON-clu-sion",
-      "syllables": "con-clu-sion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "confident",
-      "definition": "Feeling certain about ability",
-      "example": "He is confident he will pass.",
-      "phonetic": "CON-fi-dent",
-      "syllables": "con-fi-dent",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "consequence",
-      "definition": "A result or effect of an action",
-      "example": "Every action has a consequence.",
-      "phonetic": "CON-se-quence",
-      "syllables": "con-se-quence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "constellation",
-      "definition": "A group of stars forming a pattern",
-      "example": "Can you find the Big Dipper constellation?",
-      "phonetic": "CON-stel-la-tion",
-      "syllables": "con-stel-la-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "contagious",
-      "definition": "Spread from one person to another",
-      "example": "The flu is very contagious.",
-      "phonetic": "CON-ta-gious",
-      "syllables": "con-ta-gious",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "controversial",
-      "definition": "Giving rise to public disagreement",
-      "example": "It was a controversial decision.",
-      "phonetic": "CON-tro-ver-sial",
-      "syllables": "con-tro-ver-sial",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "convenient",
-      "definition": "Fitting in well with needs",
-      "example": "It is convenient to live near the store.",
-      "phonetic": "CON-ven-ient",
-      "syllables": "con-ven-ient",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conversation",
-      "definition": "A talk between two or more people",
-      "example": "They had a long conversation.",
-      "phonetic": "CON-ver-sa-tion",
-      "syllables": "con-ver-sa-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "cooperation",
-      "definition": "The process of working together",
-      "example": "The project requires cooperation.",
-      "phonetic": "CO-op-er-a-tion",
-      "syllables": "co-op-er-a-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "corporation",
-      "definition": "A large company",
-      "example": "She works for a major corporation.",
-      "phonetic": "COR-po-ra-tion",
-      "syllables": "cor-po-ra-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "courageous",
-      "definition": "Not deterred by danger or pain",
-      "example": "The firefighter was very courageous.",
-      "phonetic": "COUR-a-geous",
-      "syllables": "cour-a-geous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "criticism",
-      "definition": "Expression of disapproval",
-      "example": "He accepted the criticism gracefully.",
-      "phonetic": "CRIT-i-cism",
-      "syllables": "crit-i-cism",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "biodiversity",
-      "definition": "The variety of plant and animal life in an area",
-      "example": "Rainforests are known for rich biodiversity.",
-      "phonetic": "BI-o-di-ver-si-ty",
-      "syllables": "bi-o-di-ver-si-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "collaboration",
-      "definition": "Working jointly with others",
-      "example": "The project succeeded through collaboration.",
-      "phonetic": "COL-lab-o-ra-tion",
-      "syllables": "col-lab-o-ra-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "determination",
-      "definition": "Firmness of purpose",
-      "example": "Her determination helped her finish the race.",
-      "phonetic": "DE-ter-mi-na-tion",
-      "syllables": "de-ter-mi-na-tion",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "geothermal",
-      "definition": "Relating to heat produced inside the earth",
-      "example": "Iceland uses geothermal energy for power.",
-      "phonetic": "GE-o-ther-mal",
-      "syllables": "ge-o-ther-mal",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "hypothesis",
-      "definition": "A proposed explanation for testing",
-      "example": "The class tested each hypothesis in the lab.",
-      "phonetic": "HY-poth-e-sis",
-      "syllables": "hy-poth-e-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "metamorphosis",
-      "definition": "A major change in form during development",
-      "example": "A butterfly emerges after metamorphosis.",
-      "phonetic": "MET-a-mor-pho-sis",
-      "syllables": "met-a-mor-pho-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "resilience",
-      "definition": "The ability to recover from difficulty",
-      "example": "Resilience helps people handle setbacks.",
-      "phonetic": "RE-sil-ience",
-      "syllables": "re-sil-ience",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "sustainability",
-      "definition": "Using resources in a way that avoids long-term harm",
-      "example": "The city adopted sustainability goals.",
-      "phonetic": "SUS-tain-a-bil-i-ty",
-      "syllables": "sus-tain-a-bil-i-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "wordsmith",
-      "definition": "A person skilled at using words effectively",
-      "example": "The poet was praised as a talented wordsmith.",
-      "phonetic": "WORD-smith",
-      "syllables": "word-smith",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ability",
-      "definition": "The power to do something",
-      "example": "Practice improves your ability to solve problems.",
-      "phonetic": "A-bil-i-ty",
-      "syllables": "a-bil-i-ty",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "balance",
-      "definition": "A steady position without falling",
-      "example": "Yoga helps improve balance and focus.",
-      "phonetic": "BAL-ance",
-      "syllables": "bal-ance",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "capture",
-      "definition": "To catch or record something",
-      "example": "The camera can capture clear photos at night.",
-      "phonetic": "CAP-ture",
-      "syllables": "cap-ture",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "decide",
-      "definition": "To make a choice",
-      "example": "You should decide which topic to research.",
-      "phonetic": "DE-cide",
-      "syllables": "de-cide",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "effort",
-      "definition": "Hard work toward a goal",
-      "example": "Her effort showed in the final project.",
-      "phonetic": "EF-fort",
-      "syllables": "ef-fort",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "factual",
-      "definition": "Based on proven information",
-      "example": "The report should be factual and clear.",
-      "phonetic": "FAC-tu-al",
-      "syllables": "fac-tu-al",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "glacier",
-      "definition": "A slow-moving mass of ice",
-      "example": "The glacier carved a deep valley.",
-      "phonetic": "GLA-cier",
-      "syllables": "gla-cier",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "harvest",
-      "definition": "The process of gathering crops",
-      "example": "Farmers begin harvest in early autumn.",
-      "phonetic": "HAR-vest",
-      "syllables": "har-vest",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "imagine",
-      "definition": "To form a picture in your mind",
-      "example": "Imagine building a city on the moon.",
-      "phonetic": "IM-ag-ine",
-      "syllables": "im-ag-ine",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "journey",
-      "definition": "A trip from one place to another",
-      "example": "Our journey to the museum took two hours.",
-      "phonetic": "JOUR-ney",
-      "syllables": "jour-ney",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "kingdom",
-      "definition": "A country ruled by a king or queen",
-      "example": "The story takes place in a distant kingdom.",
-      "phonetic": "KING-dom",
-      "syllables": "king-dom",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "logical",
-      "definition": "Reasonable and based on clear thinking",
-      "example": "Use a logical method to solve the puzzle.",
-      "phonetic": "LOG-i-cal",
-      "syllables": "log-i-cal",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "miracle",
-      "definition": "An amazing event that seems impossible",
-      "example": "Doctors called her recovery a miracle.",
-      "phonetic": "MIR-a-cle",
-      "syllables": "mir-a-cle",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "natural",
-      "definition": "Existing in nature and not made by people",
-      "example": "Wool is a natural material.",
-      "phonetic": "NAT-u-ral",
-      "syllables": "nat-u-ral",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "outcome",
-      "definition": "The final result of an action",
-      "example": "The outcome of the experiment surprised us.",
-      "phonetic": "OUT-come",
-      "syllables": "out-come",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "patient",
-      "definition": "Able to wait calmly",
-      "example": "Be patient while the page loads.",
-      "phonetic": "PA-tient",
-      "syllables": "pa-tient",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "respect",
-      "definition": "To show care and value for others",
-      "example": "We should respect different opinions.",
-      "phonetic": "RE-spect",
-      "syllables": "re-spect",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "sincere",
-      "definition": "Honest and genuine",
-      "example": "He gave a sincere apology.",
-      "phonetic": "SIN-cere",
-      "syllables": "sin-cere",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "thrive",
-      "definition": "To grow or do well",
-      "example": "Plants thrive in warm sunlight.",
-      "phonetic": "THRIVE",
-      "syllables": "thrive",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "venture",
-      "definition": "A new activity that involves risk",
-      "example": "Starting the club was a bold venture.",
-      "phonetic": "VEN-ture",
-      "syllables": "ven-ture",
-      "difficulty": "easy",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "analyze",
-      "definition": "To examine carefully",
-      "example": "Scientists analyze data before drawing conclusions.",
-      "phonetic": "AN-a-lyze",
-      "syllables": "an-a-lyze",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "boundary",
-      "definition": "A line that marks a limit",
-      "example": "Please stay inside the boundary lines.",
-      "phonetic": "BOUND-a-ry",
-      "syllables": "bound-a-ry",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "coherent",
-      "definition": "Clear and logically connected",
-      "example": "Her essay presented a coherent argument.",
-      "phonetic": "CO-her-ent",
-      "syllables": "co-her-ent",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "dilemma",
-      "definition": "A difficult choice between options",
-      "example": "He faced a dilemma about which team to join.",
-      "phonetic": "DI-lem-ma",
-      "syllables": "di-lem-ma",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "emphasis",
-      "definition": "Special importance given to something",
-      "example": "The coach placed emphasis on teamwork.",
-      "phonetic": "EM-pha-sis",
-      "syllables": "em-pha-sis",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "fragment",
-      "definition": "A small broken piece of something",
-      "example": "Archaeologists found a fragment of pottery.",
-      "phonetic": "FRAG-ment",
-      "syllables": "frag-ment",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "generate",
-      "definition": "To produce or create",
-      "example": "Wind turbines generate electricity.",
-      "phonetic": "GEN-er-ate",
-      "syllables": "gen-er-ate",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "heritage",
-      "definition": "Traditions passed down through generations",
-      "example": "The festival celebrates local heritage.",
-      "phonetic": "HER-it-age",
-      "syllables": "her-it-age",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "identify",
-      "definition": "To recognize and name",
-      "example": "Can you identify the main idea in this paragraph?",
-      "phonetic": "I-den-ti-fy",
-      "syllables": "i-den-ti-fy",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "justify",
-      "definition": "To show a good reason for",
-      "example": "Please justify your answer with evidence.",
-      "phonetic": "JUS-ti-fy",
-      "syllables": "jus-ti-fy",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "kinetic",
-      "definition": "Relating to motion",
-      "example": "A roller coaster has high kinetic energy.",
-      "phonetic": "KI-net-ic",
-      "syllables": "ki-net-ic",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "landscape",
-      "definition": "All the visible features of an area",
-      "example": "The painting shows a mountain landscape.",
-      "phonetic": "LAND-scape",
-      "syllables": "land-scape",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "moderate",
-      "definition": "Average in amount or level",
-      "example": "We had moderate rain this afternoon.",
-      "phonetic": "MOD-er-ate",
-      "syllables": "mod-er-ate",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "narrative",
-      "definition": "A spoken or written story",
-      "example": "The narrative follows a young inventor.",
-      "phonetic": "NAR-ra-tive",
-      "syllables": "nar-ra-tive",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "optimize",
-      "definition": "To make as effective as possible",
-      "example": "We can optimize the schedule to save time.",
-      "phonetic": "OP-ti-mize",
-      "syllables": "op-ti-mize",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "precise",
-      "definition": "Exact and accurate",
-      "example": "Use precise measurements in the lab.",
-      "phonetic": "PRE-cise",
-      "syllables": "pre-cise",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "quantify",
-      "definition": "To express as an amount",
-      "example": "The graph helps quantify population growth.",
-      "phonetic": "QUAN-ti-fy",
-      "syllables": "quan-ti-fy",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "reliable",
-      "definition": "Dependable and consistent",
-      "example": "This source is reliable for research.",
-      "phonetic": "RE-li-a-ble",
-      "syllables": "re-li-a-ble",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "simulate",
-      "definition": "To imitate real conditions",
-      "example": "The game can simulate weather patterns.",
-      "phonetic": "SIM-u-late",
-      "syllables": "sim-u-late",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "transform",
-      "definition": "To change form or appearance",
-      "example": "Heat can transform ice into water.",
-      "phonetic": "TRANS-form",
-      "syllables": "trans-form",
-      "difficulty": "medium",
-      "gradeLevel": "6-8"
-    }
-  ]
-}
+[
+  {
+    "word": "accommodate",
+    "definition": "To provide lodging or adjust to",
+    "sentence": "The hotel can accommodate 200 guests.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ac-com-mo-date",
+    "phonetic": "AC-com-mo-date"
+  },
+  {
+    "word": "bureaucracy",
+    "definition": "Administrative government system",
+    "sentence": "The bureaucracy slowed the process.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bu-reau-cra-cy",
+    "phonetic": "BU-reau-cra-cy"
+  },
+  {
+    "word": "conscientious",
+    "definition": "Thorough and careful",
+    "sentence": "She is a conscientious worker.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-sci-en-tious",
+    "phonetic": "CON-sci-en-tious"
+  },
+  {
+    "word": "entrepreneur",
+    "definition": "A business founder",
+    "sentence": "The entrepreneur started three companies.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "en-tre-pre-neur",
+    "phonetic": "EN-tre-pre-neur"
+  },
+  {
+    "word": "fluorescent",
+    "definition": "Emitting bright light",
+    "sentence": "The fluorescent lights buzzed overhead.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "flu-o-res-cent",
+    "phonetic": "FLU-o-res-cent"
+  },
+  {
+    "word": "guarantee",
+    "definition": "A formal promise",
+    "sentence": "The product comes with a guarantee.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "guar-an-tee",
+    "phonetic": "GUAR-an-tee"
+  },
+  {
+    "word": "hemorrhage",
+    "definition": "Severe bleeding",
+    "sentence": "The doctor stopped the hemorrhage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "hem-or-rhage",
+    "phonetic": "HEM-or-rhage"
+  },
+  {
+    "word": "inconvenience",
+    "definition": "Trouble or difficulty",
+    "sentence": "Sorry for any inconvenience caused.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "in-con-ven-ience",
+    "phonetic": "IN-con-ven-ience"
+  },
+  {
+    "word": "jeopardize",
+    "definition": "To put at risk",
+    "sentence": "Don't jeopardize your future.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "jeop-ar-dize",
+    "phonetic": "JEOP-ar-dize"
+  },
+  {
+    "word": "knowledgeable",
+    "definition": "Well informed",
+    "sentence": "The guide was very knowledgeable.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "knowl-edge-a-ble",
+    "phonetic": "KNOWL-edge-a-ble"
+  },
+  {
+    "word": "liaison",
+    "definition": "A person who links groups",
+    "sentence": "She serves as liaison between departments.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "li-ai-son",
+    "phonetic": "LI-ai-son"
+  },
+  {
+    "word": "mischievous",
+    "definition": "Playfully troublesome",
+    "sentence": "The mischievous child hid the keys.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "mis-chie-vous",
+    "phonetic": "MIS-chie-vous"
+  },
+  {
+    "word": "onomatopoeia",
+    "definition": "Words that imitate sounds",
+    "sentence": "Buzz is an example of onomatopoeia.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "on-o-mat-o-poe-ia",
+    "phonetic": "ON-o-mat-o-poe-ia"
+  },
+  {
+    "word": "pharmaceutical",
+    "definition": "Related to medicinal drugs",
+    "sentence": "The pharmaceutical company developed a vaccine.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "phar-ma-ceu-ti-cal",
+    "phonetic": "PHAR-ma-ceu-ti-cal"
+  },
+  {
+    "word": "rendezvous",
+    "definition": "A planned meeting",
+    "sentence": "They arranged a secret rendezvous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ren-dez-vous",
+    "phonetic": "REN-dez-vous"
+  },
+  {
+    "word": "surveillance",
+    "definition": "Close observation",
+    "sentence": "The building has surveillance cameras.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "sur-veil-lance",
+    "phonetic": "SUR-veil-lance"
+  },
+  {
+    "word": "tyranny",
+    "definition": "Cruel oppressive rule",
+    "sentence": "The people rose against tyranny.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "tyr-an-ny",
+    "phonetic": "TYR-an-ny"
+  },
+  {
+    "word": "ubiquitous",
+    "definition": "Present everywhere",
+    "sentence": "Smartphones are now ubiquitous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "u-biq-ui-tous",
+    "phonetic": "U-biq-ui-tous"
+  },
+  {
+    "word": "vocabulary",
+    "definition": "Words known or used",
+    "sentence": "Reading expands your vocabulary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "vo-cab-u-lar-y",
+    "phonetic": "VO-cab-u-lar-y"
+  },
+  {
+    "word": "Wednesday",
+    "definition": "The fourth day of the week",
+    "sentence": "The meeting is on Wednesday.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "Wednes-day",
+    "phonetic": "WEDNES-day"
+  },
+  {
+    "word": "achievement",
+    "definition": "Something done successfully",
+    "sentence": "Winning the game was a great achievement.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-chieve-ment",
+    "phonetic": "A-chieve-ment"
+  },
+  {
+    "word": "acoustic",
+    "definition": "Related to sound or hearing",
+    "sentence": "He played an acoustic guitar.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-cous-tic",
+    "phonetic": "A-cous-tic"
+  },
+  {
+    "word": "algorithm",
+    "definition": "A set of rules for solving a problem",
+    "sentence": "The computer uses an algorithm to search.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "al-go-rithm",
+    "phonetic": "AL-go-rithm"
+  },
+  {
+    "word": "amphibian",
+    "definition": "An animal living on land and water",
+    "sentence": "A frog is a type of amphibian.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "am-phib-i-an",
+    "phonetic": "AM-phib-i-an"
+  },
+  {
+    "word": "analysis",
+    "definition": "Detailed examination",
+    "sentence": "The scientist performed an analysis of the data.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-nal-y-sis",
+    "phonetic": "A-nal-y-sis"
+  },
+  {
+    "word": "ancient",
+    "definition": "Belonging to the very distant past",
+    "sentence": "They visited the ancient ruins.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-cient",
+    "phonetic": "AN-cient"
+  },
+  {
+    "word": "anniversary",
+    "definition": "Date on which an event took place",
+    "sentence": "They celebrated their wedding anniversary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-ni-ver-sa-ry",
+    "phonetic": "AN-ni-ver-sa-ry"
+  },
+  {
+    "word": "anonymous",
+    "definition": "Not identified by name",
+    "sentence": "The donor chose to remain anonymous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-non-y-mous",
+    "phonetic": "A-non-y-mous"
+  },
+  {
+    "word": "antique",
+    "definition": "A collectible object having a high value",
+    "sentence": "This chair is a valuable antique.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-tique",
+    "phonetic": "AN-tique"
+  },
+  {
+    "word": "anxiety",
+    "definition": "A feeling of worry or nervousness",
+    "sentence": "He felt anxiety before the test.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "anx-i-e-ty",
+    "phonetic": "ANX-i-e-ty"
+  },
+  {
+    "word": "appreciate",
+    "definition": "To recognize the full worth of",
+    "sentence": "I appreciate your help.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ap-pre-ci-ate",
+    "phonetic": "AP-pre-ci-ate"
+  },
+  {
+    "word": "aquarium",
+    "definition": "A tank of water for fish",
+    "sentence": "We saw sharks at the aquarium.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-quar-i-um",
+    "phonetic": "A-quar-i-um"
+  },
+  {
+    "word": "architecture",
+    "definition": "The art of designing buildings",
+    "sentence": "The city has beautiful architecture.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-chi-tec-ture",
+    "phonetic": "AR-chi-tec-ture"
+  },
+  {
+    "word": "arithmetic",
+    "definition": "The branch of math with numbers",
+    "sentence": "We learned arithmetic in school.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-rith-me-tic",
+    "phonetic": "A-rith-me-tic"
+  },
+  {
+    "word": "artificial",
+    "definition": "Made by humans, not natural",
+    "sentence": "The flowers are artificial.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-ti-fi-cial",
+    "phonetic": "AR-ti-fi-cial"
+  },
+  {
+    "word": "atmosphere",
+    "definition": "Gases surrounding a planet",
+    "sentence": "The atmosphere protects the Earth.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "at-mos-phere",
+    "phonetic": "AT-mos-phere"
+  },
+  {
+    "word": "audience",
+    "definition": "Spectators at an event",
+    "sentence": "The audience clapped loudly.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-di-ence",
+    "phonetic": "AU-di-ence"
+  },
+  {
+    "word": "authentic",
+    "definition": "Of undisputed origin; genuine",
+    "sentence": "This is an authentic painting.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-then-tic",
+    "phonetic": "AU-then-tic"
+  },
+  {
+    "word": "biography",
+    "definition": "An account of someone's life",
+    "sentence": "I read a biography of Lincoln.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-og-ra-phy",
+    "phonetic": "BI-og-ra-phy"
+  },
+  {
+    "word": "bizarre",
+    "definition": "Very strange or unusual",
+    "sentence": "It was a bizarre situation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-zarre",
+    "phonetic": "BI-zarre"
+  },
+  {
+    "word": "camouflage",
+    "definition": "Disguise to blend with surroundings",
+    "sentence": "The soldier wore camouflage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-ou-flage",
+    "phonetic": "CAM-ou-flage"
+  },
+  {
+    "word": "campaign",
+    "definition": "A series of actions for a goal",
+    "sentence": "The election campaign was intense.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-paign",
+    "phonetic": "CAM-paign"
+  },
+  {
+    "word": "capacity",
+    "definition": "The maximum amount something can hold",
+    "sentence": "The stadium was filled to capacity.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-pac-i-ty",
+    "phonetic": "CA-pac-i-ty"
+  },
+  {
+    "word": "catastrophe",
+    "definition": "A sudden great disaster",
+    "sentence": "The earthquake was a catastrophe.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-tas-tro-phe",
+    "phonetic": "CA-tas-tro-phe"
+  },
+  {
+    "word": "cemetery",
+    "definition": "A place for burying the dead",
+    "sentence": "They visited the old cemetery.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cem-e-ter-y",
+    "phonetic": "CEM-e-ter-y"
+  },
+  {
+    "word": "ceremony",
+    "definition": "A formal religious or public occasion",
+    "sentence": "The graduation ceremony is tomorrow.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cer-e-mo-ny",
+    "phonetic": "CER-e-mo-ny"
+  },
+  {
+    "word": "chameleon",
+    "definition": "A lizard that changes color",
+    "sentence": "The chameleon turned green.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cha-me-le-on",
+    "phonetic": "CHA-me-le-on"
+  },
+  {
+    "word": "chandelier",
+    "definition": "A decorative hanging light",
+    "sentence": "A crystal chandelier hung in the hall.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chan-de-lier",
+    "phonetic": "CHAN-de-lier"
+  },
+  {
+    "word": "character",
+    "definition": "A person in a novel or movie",
+    "sentence": "Who is your favorite character?",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "char-ac-ter",
+    "phonetic": "CHAR-ac-ter"
+  },
+  {
+    "word": "chemistry",
+    "definition": "Science of substances and reactions",
+    "sentence": "We did experiments in chemistry class.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chem-is-try",
+    "phonetic": "CHEM-is-try"
+  },
+  {
+    "word": "choreography",
+    "definition": "The sequence of steps in dance",
+    "sentence": "The ballet choreography was complex.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cho-re-og-ra-phy",
+    "phonetic": "CHO-re-og-ra-phy"
+  },
+  {
+    "word": "circumference",
+    "definition": "The distance around a circle",
+    "sentence": "Measure the circumference of the ball.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cir-cum-fer-ence",
+    "phonetic": "CIR-cum-fer-ence"
+  },
+  {
+    "word": "civilization",
+    "definition": "Advanced stage of human social development",
+    "sentence": "Ancient Rome was a great civilization.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "civ-i-li-za-tion",
+    "phonetic": "CIV-i-li-za-tion"
+  },
+  {
+    "word": "coincidence",
+    "definition": "Events happening together by chance",
+    "sentence": "It was a coincidence that we met.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "co-in-ci-dence",
+    "phonetic": "CO-in-ci-dence"
+  },
+  {
+    "word": "collaborate",
+    "definition": "Work jointly on an activity",
+    "sentence": "We will collaborate on the project.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-lab-o-rate",
+    "phonetic": "COL-lab-o-rate"
+  },
+  {
+    "word": "collision",
+    "definition": "An instance of one moving object striking another",
+    "sentence": "The car collision caused a traffic jam.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-li-sion",
+    "phonetic": "COL-li-sion"
+  },
+  {
+    "word": "column",
+    "definition": "An upright pillar",
+    "sentence": "The roof was supported by a stone column.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-umn",
+    "phonetic": "COL-umn"
+  },
+  {
+    "word": "committee",
+    "definition": "A group of people appointed for a function",
+    "sentence": "The committee will vote on the issue.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-mit-tee",
+    "phonetic": "COM-mit-tee"
+  },
+  {
+    "word": "communicate",
+    "definition": "Share or exchange information",
+    "sentence": "We communicate by email.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-mu-ni-cate",
+    "phonetic": "COM-mu-ni-cate"
+  },
+  {
+    "word": "community",
+    "definition": "A group of people living in the same place",
+    "sentence": "We have a friendly community.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-mu-ni-ty",
+    "phonetic": "COM-mu-ni-ty"
+  },
+  {
+    "word": "competition",
+    "definition": "The activity of competing",
+    "sentence": "She won the swimming competition.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-pe-ti-tion",
+    "phonetic": "COM-pe-ti-tion"
+  },
+  {
+    "word": "complicated",
+    "definition": "Consisting of many interconnecting parts",
+    "sentence": "The instructions were very complicated.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "com-pli-cat-ed",
+    "phonetic": "COM-pli-cat-ed"
+  },
+  {
+    "word": "concentrate",
+    "definition": "Focus one's attention",
+    "sentence": "I need to concentrate on my work.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-cen-trate",
+    "phonetic": "CON-cen-trate"
+  },
+  {
+    "word": "conclusion",
+    "definition": "The end or finish of an event",
+    "sentence": "The conclusion of the story was sad.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-clu-sion",
+    "phonetic": "CON-clu-sion"
+  },
+  {
+    "word": "confident",
+    "definition": "Feeling certain about ability",
+    "sentence": "He is confident he will pass.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-fi-dent",
+    "phonetic": "CON-fi-dent"
+  },
+  {
+    "word": "consequence",
+    "definition": "A result or effect of an action",
+    "sentence": "Every action has a consequence.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-se-quence",
+    "phonetic": "CON-se-quence"
+  },
+  {
+    "word": "constellation",
+    "definition": "A group of stars forming a pattern",
+    "sentence": "Can you find the Big Dipper constellation?",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-stel-la-tion",
+    "phonetic": "CON-stel-la-tion"
+  },
+  {
+    "word": "contagious",
+    "definition": "Spread from one person to another",
+    "sentence": "The flu is very contagious.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-ta-gious",
+    "phonetic": "CON-ta-gious"
+  },
+  {
+    "word": "controversial",
+    "definition": "Giving rise to public disagreement",
+    "sentence": "It was a controversial decision.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-tro-ver-sial",
+    "phonetic": "CON-tro-ver-sial"
+  },
+  {
+    "word": "convenient",
+    "definition": "Fitting in well with needs",
+    "sentence": "It is convenient to live near the store.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-ven-ient",
+    "phonetic": "CON-ven-ient"
+  },
+  {
+    "word": "conversation",
+    "definition": "A talk between two or more people",
+    "sentence": "They had a long conversation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-ver-sa-tion",
+    "phonetic": "CON-ver-sa-tion"
+  },
+  {
+    "word": "cooperation",
+    "definition": "The process of working together",
+    "sentence": "The project requires cooperation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "co-op-er-a-tion",
+    "phonetic": "CO-op-er-a-tion"
+  },
+  {
+    "word": "corporation",
+    "definition": "A large company",
+    "sentence": "She works for a major corporation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cor-po-ra-tion",
+    "phonetic": "COR-po-ra-tion"
+  },
+  {
+    "word": "courageous",
+    "definition": "Not deterred by danger or pain",
+    "sentence": "The firefighter was very courageous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cour-a-geous",
+    "phonetic": "COUR-a-geous"
+  },
+  {
+    "word": "criticism",
+    "definition": "Expression of disapproval",
+    "sentence": "He accepted the criticism gracefully.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "crit-i-cism",
+    "phonetic": "CRIT-i-cism"
+  },
+  {
+    "word": "biodiversity",
+    "definition": "The variety of plant and animal life in an area",
+    "sentence": "Rainforests are known for rich biodiversity.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-o-di-ver-si-ty",
+    "phonetic": "BI-o-di-ver-si-ty"
+  },
+  {
+    "word": "collaboration",
+    "definition": "Working jointly with others",
+    "sentence": "The project succeeded through collaboration.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "col-lab-o-ra-tion",
+    "phonetic": "COL-lab-o-ra-tion"
+  },
+  {
+    "word": "determination",
+    "definition": "Firmness of purpose",
+    "sentence": "Her determination helped her finish the race.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "de-ter-mi-na-tion",
+    "phonetic": "DE-ter-mi-na-tion"
+  },
+  {
+    "word": "geothermal",
+    "definition": "Relating to heat produced inside the earth",
+    "sentence": "Iceland uses geothermal energy for power.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ge-o-ther-mal",
+    "phonetic": "GE-o-ther-mal"
+  },
+  {
+    "word": "hypothesis",
+    "definition": "A proposed explanation for testing",
+    "sentence": "The class tested each hypothesis in the lab.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "hy-poth-e-sis",
+    "phonetic": "HY-poth-e-sis"
+  },
+  {
+    "word": "metamorphosis",
+    "definition": "A major change in form during development",
+    "sentence": "A butterfly emerges after metamorphosis.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "met-a-mor-pho-sis",
+    "phonetic": "MET-a-mor-pho-sis"
+  },
+  {
+    "word": "resilience",
+    "definition": "The ability to recover from difficulty",
+    "sentence": "Resilience helps people handle setbacks.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "re-sil-ience",
+    "phonetic": "RE-sil-ience"
+  },
+  {
+    "word": "sustainability",
+    "definition": "Using resources in a way that avoids long-term harm",
+    "sentence": "The city adopted sustainability goals.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "sus-tain-a-bil-i-ty",
+    "phonetic": "SUS-tain-a-bil-i-ty"
+  },
+  {
+    "word": "wordsmith",
+    "definition": "A person skilled at using words effectively",
+    "sentence": "The poet was praised as a talented wordsmith.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "word-smith",
+    "phonetic": "WORD-smith"
+  },
+  {
+    "word": "ability",
+    "definition": "The power to do something",
+    "sentence": "Practice improves your ability to solve problems.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "a-bil-i-ty",
+    "phonetic": "A-bil-i-ty"
+  },
+  {
+    "word": "balance",
+    "definition": "A steady position without falling",
+    "sentence": "Yoga helps improve balance and focus.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "bal-ance",
+    "phonetic": "BAL-ance"
+  },
+  {
+    "word": "capture",
+    "definition": "To catch or record something",
+    "sentence": "The camera can capture clear photos at night.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "cap-ture",
+    "phonetic": "CAP-ture"
+  },
+  {
+    "word": "decide",
+    "definition": "To make a choice",
+    "sentence": "You should decide which topic to research.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "de-cide",
+    "phonetic": "DE-cide"
+  },
+  {
+    "word": "effort",
+    "definition": "Hard work toward a goal",
+    "sentence": "Her effort showed in the final project.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "ef-fort",
+    "phonetic": "EF-fort"
+  },
+  {
+    "word": "factual",
+    "definition": "Based on proven information",
+    "sentence": "The report should be factual and clear.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "fac-tu-al",
+    "phonetic": "FAC-tu-al"
+  },
+  {
+    "word": "glacier",
+    "definition": "A slow-moving mass of ice",
+    "sentence": "The glacier carved a deep valley.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "gla-cier",
+    "phonetic": "GLA-cier"
+  },
+  {
+    "word": "harvest",
+    "definition": "The process of gathering crops",
+    "sentence": "Farmers begin harvest in early autumn.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "har-vest",
+    "phonetic": "HAR-vest"
+  },
+  {
+    "word": "imagine",
+    "definition": "To form a picture in your mind",
+    "sentence": "Imagine building a city on the moon.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "im-ag-ine",
+    "phonetic": "IM-ag-ine"
+  },
+  {
+    "word": "journey",
+    "definition": "A trip from one place to another",
+    "sentence": "Our journey to the museum took two hours.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "jour-ney",
+    "phonetic": "JOUR-ney"
+  },
+  {
+    "word": "kingdom",
+    "definition": "A country ruled by a king or queen",
+    "sentence": "The story takes place in a distant kingdom.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "king-dom",
+    "phonetic": "KING-dom"
+  },
+  {
+    "word": "logical",
+    "definition": "Reasonable and based on clear thinking",
+    "sentence": "Use a logical method to solve the puzzle.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "log-i-cal",
+    "phonetic": "LOG-i-cal"
+  },
+  {
+    "word": "miracle",
+    "definition": "An amazing event that seems impossible",
+    "sentence": "Doctors called her recovery a miracle.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "mir-a-cle",
+    "phonetic": "MIR-a-cle"
+  },
+  {
+    "word": "natural",
+    "definition": "Existing in nature and not made by people",
+    "sentence": "Wool is a natural material.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "nat-u-ral",
+    "phonetic": "NAT-u-ral"
+  },
+  {
+    "word": "outcome",
+    "definition": "The final result of an action",
+    "sentence": "The outcome of the experiment surprised us.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "out-come",
+    "phonetic": "OUT-come"
+  },
+  {
+    "word": "patient",
+    "definition": "Able to wait calmly",
+    "sentence": "Be patient while the page loads.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "pa-tient",
+    "phonetic": "PA-tient"
+  },
+  {
+    "word": "respect",
+    "definition": "To show care and value for others",
+    "sentence": "We should respect different opinions.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "re-spect",
+    "phonetic": "RE-spect"
+  },
+  {
+    "word": "sincere",
+    "definition": "Honest and genuine",
+    "sentence": "He gave a sincere apology.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "sin-cere",
+    "phonetic": "SIN-cere"
+  },
+  {
+    "word": "thrive",
+    "definition": "To grow or do well",
+    "sentence": "Plants thrive in warm sunlight.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "thrive",
+    "phonetic": "THRIVE"
+  },
+  {
+    "word": "venture",
+    "definition": "A new activity that involves risk",
+    "sentence": "Starting the club was a bold venture.",
+    "grade": 6,
+    "difficulty": "easy",
+    "syllables": "ven-ture",
+    "phonetic": "VEN-ture"
+  },
+  {
+    "word": "analyze",
+    "definition": "To examine carefully",
+    "sentence": "Scientists analyze data before drawing conclusions.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "an-a-lyze",
+    "phonetic": "AN-a-lyze"
+  },
+  {
+    "word": "boundary",
+    "definition": "A line that marks a limit",
+    "sentence": "Please stay inside the boundary lines.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "bound-a-ry",
+    "phonetic": "BOUND-a-ry"
+  },
+  {
+    "word": "coherent",
+    "definition": "Clear and logically connected",
+    "sentence": "Her essay presented a coherent argument.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "co-her-ent",
+    "phonetic": "CO-her-ent"
+  },
+  {
+    "word": "dilemma",
+    "definition": "A difficult choice between options",
+    "sentence": "He faced a dilemma about which team to join.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "di-lem-ma",
+    "phonetic": "DI-lem-ma"
+  },
+  {
+    "word": "emphasis",
+    "definition": "Special importance given to something",
+    "sentence": "The coach placed emphasis on teamwork.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "em-pha-sis",
+    "phonetic": "EM-pha-sis"
+  },
+  {
+    "word": "fragment",
+    "definition": "A small broken piece of something",
+    "sentence": "Archaeologists found a fragment of pottery.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "frag-ment",
+    "phonetic": "FRAG-ment"
+  },
+  {
+    "word": "generate",
+    "definition": "To produce or create",
+    "sentence": "Wind turbines generate electricity.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "gen-er-ate",
+    "phonetic": "GEN-er-ate"
+  },
+  {
+    "word": "heritage",
+    "definition": "Traditions passed down through generations",
+    "sentence": "The festival celebrates local heritage.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "her-it-age",
+    "phonetic": "HER-it-age"
+  },
+  {
+    "word": "identify",
+    "definition": "To recognize and name",
+    "sentence": "Can you identify the main idea in this paragraph?",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "i-den-ti-fy",
+    "phonetic": "I-den-ti-fy"
+  },
+  {
+    "word": "justify",
+    "definition": "To show a good reason for",
+    "sentence": "Please justify your answer with evidence.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "jus-ti-fy",
+    "phonetic": "JUS-ti-fy"
+  },
+  {
+    "word": "kinetic",
+    "definition": "Relating to motion",
+    "sentence": "A roller coaster has high kinetic energy.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "ki-net-ic",
+    "phonetic": "KI-net-ic"
+  },
+  {
+    "word": "landscape",
+    "definition": "All the visible features of an area",
+    "sentence": "The painting shows a mountain landscape.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "land-scape",
+    "phonetic": "LAND-scape"
+  },
+  {
+    "word": "moderate",
+    "definition": "Average in amount or level",
+    "sentence": "We had moderate rain this afternoon.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "mod-er-ate",
+    "phonetic": "MOD-er-ate"
+  },
+  {
+    "word": "narrative",
+    "definition": "A spoken or written story",
+    "sentence": "The narrative follows a young inventor.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "nar-ra-tive",
+    "phonetic": "NAR-ra-tive"
+  },
+  {
+    "word": "optimize",
+    "definition": "To make as effective as possible",
+    "sentence": "We can optimize the schedule to save time.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "op-ti-mize",
+    "phonetic": "OP-ti-mize"
+  },
+  {
+    "word": "precise",
+    "definition": "Exact and accurate",
+    "sentence": "Use precise measurements in the lab.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "pre-cise",
+    "phonetic": "PRE-cise"
+  },
+  {
+    "word": "quantify",
+    "definition": "To express as an amount",
+    "sentence": "The graph helps quantify population growth.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "quan-ti-fy",
+    "phonetic": "QUAN-ti-fy"
+  },
+  {
+    "word": "reliable",
+    "definition": "Dependable and consistent",
+    "sentence": "This source is reliable for research.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "re-li-a-ble",
+    "phonetic": "RE-li-a-ble"
+  },
+  {
+    "word": "simulate",
+    "definition": "To imitate real conditions",
+    "sentence": "The game can simulate weather patterns.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "sim-u-late",
+    "phonetic": "SIM-u-late"
+  },
+  {
+    "word": "transform",
+    "definition": "To change form or appearance",
+    "sentence": "Heat can transform ice into water.",
+    "grade": 6,
+    "difficulty": "medium",
+    "syllables": "trans-form",
+    "phonetic": "TRANS-form"
+  }
+]

--- a/public/data/words/grade-9.json
+++ b/public/data/words/grade-9.json
@@ -1,459 +1,452 @@
-{
-  "grade": 9,
-  "language": "en-US",
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-03T22:00:53.309Z",
-  "wordCount": 50,
-  "words": [
-    {
-      "word": "accommodate",
-      "definition": "To provide lodging or adjust to",
-      "example": "The hotel can accommodate 200 guests.",
-      "phonetic": "AC-com-mo-date",
-      "syllables": "ac-com-mo-date",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bureaucracy",
-      "definition": "Administrative government system",
-      "example": "The bureaucracy slowed the process.",
-      "phonetic": "BU-reau-cra-cy",
-      "syllables": "bu-reau-cra-cy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "conscientious",
-      "definition": "Thorough and careful",
-      "example": "She is a conscientious worker.",
-      "phonetic": "CON-sci-en-tious",
-      "syllables": "con-sci-en-tious",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "entrepreneur",
-      "definition": "A business founder",
-      "example": "The entrepreneur started three companies.",
-      "phonetic": "EN-tre-pre-neur",
-      "syllables": "en-tre-pre-neur",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "fluorescent",
-      "definition": "Emitting bright light",
-      "example": "The fluorescent lights buzzed overhead.",
-      "phonetic": "FLU-o-res-cent",
-      "syllables": "flu-o-res-cent",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "guarantee",
-      "definition": "A formal promise",
-      "example": "The product comes with a guarantee.",
-      "phonetic": "GUAR-an-tee",
-      "syllables": "guar-an-tee",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "hemorrhage",
-      "definition": "Severe bleeding",
-      "example": "The doctor stopped the hemorrhage.",
-      "phonetic": "HEM-or-rhage",
-      "syllables": "hem-or-rhage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "inconvenience",
-      "definition": "Trouble or difficulty",
-      "example": "Sorry for any inconvenience caused.",
-      "phonetic": "IN-con-ven-ience",
-      "syllables": "in-con-ven-ience",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "jeopardize",
-      "definition": "To put at risk",
-      "example": "Don't jeopardize your future.",
-      "phonetic": "JEOP-ar-dize",
-      "syllables": "jeop-ar-dize",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "knowledgeable",
-      "definition": "Well informed",
-      "example": "The guide was very knowledgeable.",
-      "phonetic": "KNOWL-edge-a-ble",
-      "syllables": "knowl-edge-a-ble",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "liaison",
-      "definition": "A person who links groups",
-      "example": "She serves as liaison between departments.",
-      "phonetic": "LI-ai-son",
-      "syllables": "li-ai-son",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "mischievous",
-      "definition": "Playfully troublesome",
-      "example": "The mischievous child hid the keys.",
-      "phonetic": "MIS-chie-vous",
-      "syllables": "mis-chie-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "onomatopoeia",
-      "definition": "Words that imitate sounds",
-      "example": "Buzz is an example of onomatopoeia.",
-      "phonetic": "ON-o-mat-o-poe-ia",
-      "syllables": "on-o-mat-o-poe-ia",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "pharmaceutical",
-      "definition": "Related to medicinal drugs",
-      "example": "The pharmaceutical company developed a vaccine.",
-      "phonetic": "PHAR-ma-ceu-ti-cal",
-      "syllables": "phar-ma-ceu-ti-cal",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "rendezvous",
-      "definition": "A planned meeting",
-      "example": "They arranged a secret rendezvous.",
-      "phonetic": "REN-dez-vous",
-      "syllables": "ren-dez-vous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "surveillance",
-      "definition": "Close observation",
-      "example": "The building has surveillance cameras.",
-      "phonetic": "SUR-veil-lance",
-      "syllables": "sur-veil-lance",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "tyranny",
-      "definition": "Cruel oppressive rule",
-      "example": "The people rose against tyranny.",
-      "phonetic": "TYR-an-ny",
-      "syllables": "tyr-an-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ubiquitous",
-      "definition": "Present everywhere",
-      "example": "Smartphones are now ubiquitous.",
-      "phonetic": "U-biq-ui-tous",
-      "syllables": "u-biq-ui-tous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "vocabulary",
-      "definition": "Words known or used",
-      "example": "Reading expands your vocabulary.",
-      "phonetic": "VO-cab-u-lar-y",
-      "syllables": "vo-cab-u-lar-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "Wednesday",
-      "definition": "The fourth day of the week",
-      "example": "The meeting is on Wednesday.",
-      "phonetic": "WEDNES-day",
-      "syllables": "Wednes-day",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "achievement",
-      "definition": "Something done successfully",
-      "example": "Winning the game was a great achievement.",
-      "phonetic": "A-chieve-ment",
-      "syllables": "a-chieve-ment",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "acoustic",
-      "definition": "Related to sound or hearing",
-      "example": "He played an acoustic guitar.",
-      "phonetic": "A-cous-tic",
-      "syllables": "a-cous-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "algorithm",
-      "definition": "A set of rules for solving a problem",
-      "example": "The computer uses an algorithm to search.",
-      "phonetic": "AL-go-rithm",
-      "syllables": "al-go-rithm",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "amphibian",
-      "definition": "An animal living on land and water",
-      "example": "A frog is a type of amphibian.",
-      "phonetic": "AM-phib-i-an",
-      "syllables": "am-phib-i-an",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "analysis",
-      "definition": "Detailed examination",
-      "example": "The scientist performed an analysis of the data.",
-      "phonetic": "A-nal-y-sis",
-      "syllables": "a-nal-y-sis",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ancient",
-      "definition": "Belonging to the very distant past",
-      "example": "They visited the ancient ruins.",
-      "phonetic": "AN-cient",
-      "syllables": "an-cient",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anniversary",
-      "definition": "Date on which an event took place",
-      "example": "They celebrated their wedding anniversary.",
-      "phonetic": "AN-ni-ver-sa-ry",
-      "syllables": "an-ni-ver-sa-ry",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anonymous",
-      "definition": "Not identified by name",
-      "example": "The donor chose to remain anonymous.",
-      "phonetic": "A-non-y-mous",
-      "syllables": "a-non-y-mous",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "antique",
-      "definition": "A collectible object having a high value",
-      "example": "This chair is a valuable antique.",
-      "phonetic": "AN-tique",
-      "syllables": "an-tique",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "anxiety",
-      "definition": "A feeling of worry or nervousness",
-      "example": "He felt anxiety before the test.",
-      "phonetic": "ANX-i-e-ty",
-      "syllables": "anx-i-e-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "appreciate",
-      "definition": "To recognize the full worth of",
-      "example": "I appreciate your help.",
-      "phonetic": "AP-pre-ci-ate",
-      "syllables": "ap-pre-ci-ate",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "aquarium",
-      "definition": "A tank of water for fish",
-      "example": "We saw sharks at the aquarium.",
-      "phonetic": "A-quar-i-um",
-      "syllables": "a-quar-i-um",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "architecture",
-      "definition": "The art of designing buildings",
-      "example": "The city has beautiful architecture.",
-      "phonetic": "AR-chi-tec-ture",
-      "syllables": "ar-chi-tec-ture",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "arithmetic",
-      "definition": "The branch of math with numbers",
-      "example": "We learned arithmetic in school.",
-      "phonetic": "A-rith-me-tic",
-      "syllables": "a-rith-me-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "artificial",
-      "definition": "Made by humans, not natural",
-      "example": "The flowers are artificial.",
-      "phonetic": "AR-ti-fi-cial",
-      "syllables": "ar-ti-fi-cial",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "atmosphere",
-      "definition": "Gases surrounding a planet",
-      "example": "The atmosphere protects the Earth.",
-      "phonetic": "AT-mos-phere",
-      "syllables": "at-mos-phere",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "audience",
-      "definition": "Spectators at an event",
-      "example": "The audience clapped loudly.",
-      "phonetic": "AU-di-ence",
-      "syllables": "au-di-ence",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "authentic",
-      "definition": "Of undisputed origin; genuine",
-      "example": "This is an authentic painting.",
-      "phonetic": "AU-then-tic",
-      "syllables": "au-then-tic",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "biography",
-      "definition": "An account of someone's life",
-      "example": "I read a biography of Lincoln.",
-      "phonetic": "BI-og-ra-phy",
-      "syllables": "bi-og-ra-phy",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "bizarre",
-      "definition": "Very strange or unusual",
-      "example": "It was a bizarre situation.",
-      "phonetic": "BI-zarre",
-      "syllables": "bi-zarre",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "camouflage",
-      "definition": "Disguise to blend with surroundings",
-      "example": "The soldier wore camouflage.",
-      "phonetic": "CAM-ou-flage",
-      "syllables": "cam-ou-flage",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "campaign",
-      "definition": "A series of actions for a goal",
-      "example": "The election campaign was intense.",
-      "phonetic": "CAM-paign",
-      "syllables": "cam-paign",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "capacity",
-      "definition": "The maximum amount something can hold",
-      "example": "The stadium was filled to capacity.",
-      "phonetic": "CA-pac-i-ty",
-      "syllables": "ca-pac-i-ty",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "catastrophe",
-      "definition": "A sudden great disaster",
-      "example": "The earthquake was a catastrophe.",
-      "phonetic": "CA-tas-tro-phe",
-      "syllables": "ca-tas-tro-phe",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "cemetery",
-      "definition": "A place for burying the dead",
-      "example": "They visited the old cemetery.",
-      "phonetic": "CEM-e-ter-y",
-      "syllables": "cem-e-ter-y",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "ceremony",
-      "definition": "A formal religious or public occasion",
-      "example": "The graduation ceremony is tomorrow.",
-      "phonetic": "CER-e-mo-ny",
-      "syllables": "cer-e-mo-ny",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chameleon",
-      "definition": "A lizard that changes color",
-      "example": "The chameleon turned green.",
-      "phonetic": "CHA-me-le-on",
-      "syllables": "cha-me-le-on",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chandelier",
-      "definition": "A decorative hanging light",
-      "example": "A crystal chandelier hung in the hall.",
-      "phonetic": "CHAN-de-lier",
-      "syllables": "chan-de-lier",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "character",
-      "definition": "A person in a novel or movie",
-      "example": "Who is your favorite character?",
-      "phonetic": "CHAR-ac-ter",
-      "syllables": "char-ac-ter",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    },
-    {
-      "word": "chemistry",
-      "definition": "Science of substances and reactions",
-      "example": "We did experiments in chemistry class.",
-      "phonetic": "CHEM-is-try",
-      "syllables": "chem-is-try",
-      "difficulty": "hard",
-      "gradeLevel": "6-8"
-    }
-  ]
-}
+[
+  {
+    "word": "accommodate",
+    "definition": "To provide lodging or adjust to",
+    "sentence": "The hotel can accommodate 200 guests.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ac-com-mo-date",
+    "phonetic": "AC-com-mo-date"
+  },
+  {
+    "word": "bureaucracy",
+    "definition": "Administrative government system",
+    "sentence": "The bureaucracy slowed the process.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bu-reau-cra-cy",
+    "phonetic": "BU-reau-cra-cy"
+  },
+  {
+    "word": "conscientious",
+    "definition": "Thorough and careful",
+    "sentence": "She is a conscientious worker.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "con-sci-en-tious",
+    "phonetic": "CON-sci-en-tious"
+  },
+  {
+    "word": "entrepreneur",
+    "definition": "A business founder",
+    "sentence": "The entrepreneur started three companies.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "en-tre-pre-neur",
+    "phonetic": "EN-tre-pre-neur"
+  },
+  {
+    "word": "fluorescent",
+    "definition": "Emitting bright light",
+    "sentence": "The fluorescent lights buzzed overhead.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "flu-o-res-cent",
+    "phonetic": "FLU-o-res-cent"
+  },
+  {
+    "word": "guarantee",
+    "definition": "A formal promise",
+    "sentence": "The product comes with a guarantee.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "guar-an-tee",
+    "phonetic": "GUAR-an-tee"
+  },
+  {
+    "word": "hemorrhage",
+    "definition": "Severe bleeding",
+    "sentence": "The doctor stopped the hemorrhage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "hem-or-rhage",
+    "phonetic": "HEM-or-rhage"
+  },
+  {
+    "word": "inconvenience",
+    "definition": "Trouble or difficulty",
+    "sentence": "Sorry for any inconvenience caused.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "in-con-ven-ience",
+    "phonetic": "IN-con-ven-ience"
+  },
+  {
+    "word": "jeopardize",
+    "definition": "To put at risk",
+    "sentence": "Don't jeopardize your future.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "jeop-ar-dize",
+    "phonetic": "JEOP-ar-dize"
+  },
+  {
+    "word": "knowledgeable",
+    "definition": "Well informed",
+    "sentence": "The guide was very knowledgeable.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "knowl-edge-a-ble",
+    "phonetic": "KNOWL-edge-a-ble"
+  },
+  {
+    "word": "liaison",
+    "definition": "A person who links groups",
+    "sentence": "She serves as liaison between departments.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "li-ai-son",
+    "phonetic": "LI-ai-son"
+  },
+  {
+    "word": "mischievous",
+    "definition": "Playfully troublesome",
+    "sentence": "The mischievous child hid the keys.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "mis-chie-vous",
+    "phonetic": "MIS-chie-vous"
+  },
+  {
+    "word": "onomatopoeia",
+    "definition": "Words that imitate sounds",
+    "sentence": "Buzz is an example of onomatopoeia.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "on-o-mat-o-poe-ia",
+    "phonetic": "ON-o-mat-o-poe-ia"
+  },
+  {
+    "word": "pharmaceutical",
+    "definition": "Related to medicinal drugs",
+    "sentence": "The pharmaceutical company developed a vaccine.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "phar-ma-ceu-ti-cal",
+    "phonetic": "PHAR-ma-ceu-ti-cal"
+  },
+  {
+    "word": "rendezvous",
+    "definition": "A planned meeting",
+    "sentence": "They arranged a secret rendezvous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ren-dez-vous",
+    "phonetic": "REN-dez-vous"
+  },
+  {
+    "word": "surveillance",
+    "definition": "Close observation",
+    "sentence": "The building has surveillance cameras.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "sur-veil-lance",
+    "phonetic": "SUR-veil-lance"
+  },
+  {
+    "word": "tyranny",
+    "definition": "Cruel oppressive rule",
+    "sentence": "The people rose against tyranny.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "tyr-an-ny",
+    "phonetic": "TYR-an-ny"
+  },
+  {
+    "word": "ubiquitous",
+    "definition": "Present everywhere",
+    "sentence": "Smartphones are now ubiquitous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "u-biq-ui-tous",
+    "phonetic": "U-biq-ui-tous"
+  },
+  {
+    "word": "vocabulary",
+    "definition": "Words known or used",
+    "sentence": "Reading expands your vocabulary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "vo-cab-u-lar-y",
+    "phonetic": "VO-cab-u-lar-y"
+  },
+  {
+    "word": "Wednesday",
+    "definition": "The fourth day of the week",
+    "sentence": "The meeting is on Wednesday.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "Wednes-day",
+    "phonetic": "WEDNES-day"
+  },
+  {
+    "word": "achievement",
+    "definition": "Something done successfully",
+    "sentence": "Winning the game was a great achievement.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-chieve-ment",
+    "phonetic": "A-chieve-ment"
+  },
+  {
+    "word": "acoustic",
+    "definition": "Related to sound or hearing",
+    "sentence": "He played an acoustic guitar.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-cous-tic",
+    "phonetic": "A-cous-tic"
+  },
+  {
+    "word": "algorithm",
+    "definition": "A set of rules for solving a problem",
+    "sentence": "The computer uses an algorithm to search.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "al-go-rithm",
+    "phonetic": "AL-go-rithm"
+  },
+  {
+    "word": "amphibian",
+    "definition": "An animal living on land and water",
+    "sentence": "A frog is a type of amphibian.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "am-phib-i-an",
+    "phonetic": "AM-phib-i-an"
+  },
+  {
+    "word": "analysis",
+    "definition": "Detailed examination",
+    "sentence": "The scientist performed an analysis of the data.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-nal-y-sis",
+    "phonetic": "A-nal-y-sis"
+  },
+  {
+    "word": "ancient",
+    "definition": "Belonging to the very distant past",
+    "sentence": "They visited the ancient ruins.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-cient",
+    "phonetic": "AN-cient"
+  },
+  {
+    "word": "anniversary",
+    "definition": "Date on which an event took place",
+    "sentence": "They celebrated their wedding anniversary.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-ni-ver-sa-ry",
+    "phonetic": "AN-ni-ver-sa-ry"
+  },
+  {
+    "word": "anonymous",
+    "definition": "Not identified by name",
+    "sentence": "The donor chose to remain anonymous.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-non-y-mous",
+    "phonetic": "A-non-y-mous"
+  },
+  {
+    "word": "antique",
+    "definition": "A collectible object having a high value",
+    "sentence": "This chair is a valuable antique.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "an-tique",
+    "phonetic": "AN-tique"
+  },
+  {
+    "word": "anxiety",
+    "definition": "A feeling of worry or nervousness",
+    "sentence": "He felt anxiety before the test.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "anx-i-e-ty",
+    "phonetic": "ANX-i-e-ty"
+  },
+  {
+    "word": "appreciate",
+    "definition": "To recognize the full worth of",
+    "sentence": "I appreciate your help.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ap-pre-ci-ate",
+    "phonetic": "AP-pre-ci-ate"
+  },
+  {
+    "word": "aquarium",
+    "definition": "A tank of water for fish",
+    "sentence": "We saw sharks at the aquarium.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-quar-i-um",
+    "phonetic": "A-quar-i-um"
+  },
+  {
+    "word": "architecture",
+    "definition": "The art of designing buildings",
+    "sentence": "The city has beautiful architecture.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-chi-tec-ture",
+    "phonetic": "AR-chi-tec-ture"
+  },
+  {
+    "word": "arithmetic",
+    "definition": "The branch of math with numbers",
+    "sentence": "We learned arithmetic in school.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "a-rith-me-tic",
+    "phonetic": "A-rith-me-tic"
+  },
+  {
+    "word": "artificial",
+    "definition": "Made by humans, not natural",
+    "sentence": "The flowers are artificial.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ar-ti-fi-cial",
+    "phonetic": "AR-ti-fi-cial"
+  },
+  {
+    "word": "atmosphere",
+    "definition": "Gases surrounding a planet",
+    "sentence": "The atmosphere protects the Earth.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "at-mos-phere",
+    "phonetic": "AT-mos-phere"
+  },
+  {
+    "word": "audience",
+    "definition": "Spectators at an event",
+    "sentence": "The audience clapped loudly.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-di-ence",
+    "phonetic": "AU-di-ence"
+  },
+  {
+    "word": "authentic",
+    "definition": "Of undisputed origin; genuine",
+    "sentence": "This is an authentic painting.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "au-then-tic",
+    "phonetic": "AU-then-tic"
+  },
+  {
+    "word": "biography",
+    "definition": "An account of someone's life",
+    "sentence": "I read a biography of Lincoln.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-og-ra-phy",
+    "phonetic": "BI-og-ra-phy"
+  },
+  {
+    "word": "bizarre",
+    "definition": "Very strange or unusual",
+    "sentence": "It was a bizarre situation.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "bi-zarre",
+    "phonetic": "BI-zarre"
+  },
+  {
+    "word": "camouflage",
+    "definition": "Disguise to blend with surroundings",
+    "sentence": "The soldier wore camouflage.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-ou-flage",
+    "phonetic": "CAM-ou-flage"
+  },
+  {
+    "word": "campaign",
+    "definition": "A series of actions for a goal",
+    "sentence": "The election campaign was intense.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cam-paign",
+    "phonetic": "CAM-paign"
+  },
+  {
+    "word": "capacity",
+    "definition": "The maximum amount something can hold",
+    "sentence": "The stadium was filled to capacity.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-pac-i-ty",
+    "phonetic": "CA-pac-i-ty"
+  },
+  {
+    "word": "catastrophe",
+    "definition": "A sudden great disaster",
+    "sentence": "The earthquake was a catastrophe.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "ca-tas-tro-phe",
+    "phonetic": "CA-tas-tro-phe"
+  },
+  {
+    "word": "cemetery",
+    "definition": "A place for burying the dead",
+    "sentence": "They visited the old cemetery.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cem-e-ter-y",
+    "phonetic": "CEM-e-ter-y"
+  },
+  {
+    "word": "ceremony",
+    "definition": "A formal religious or public occasion",
+    "sentence": "The graduation ceremony is tomorrow.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cer-e-mo-ny",
+    "phonetic": "CER-e-mo-ny"
+  },
+  {
+    "word": "chameleon",
+    "definition": "A lizard that changes color",
+    "sentence": "The chameleon turned green.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "cha-me-le-on",
+    "phonetic": "CHA-me-le-on"
+  },
+  {
+    "word": "chandelier",
+    "definition": "A decorative hanging light",
+    "sentence": "A crystal chandelier hung in the hall.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chan-de-lier",
+    "phonetic": "CHAN-de-lier"
+  },
+  {
+    "word": "character",
+    "definition": "A person in a novel or movie",
+    "sentence": "Who is your favorite character?",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "char-ac-ter",
+    "phonetic": "CHAR-ac-ter"
+  },
+  {
+    "word": "chemistry",
+    "definition": "Science of substances and reactions",
+    "sentence": "We did experiments in chemistry class.",
+    "grade": 6,
+    "difficulty": "hard",
+    "syllables": "chem-is-try",
+    "phonetic": "CHEM-is-try"
+  }
+]

--- a/scripts/transform-grade-json.cjs
+++ b/scripts/transform-grade-json.cjs
@@ -1,0 +1,81 @@
+/**
+ * Transform grade JSON files from metadata wrapper format to flat Word[] array.
+ *
+ * Before: { grade, language, version, lastUpdated, wordCount, words: [...] }
+ * After:  [ { word, definition, sentence, grade, difficulty, ... }, ... ]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const wordsDir = path.join(__dirname, '..', 'public', 'data', 'words');
+
+// Map gradeLevel strings to numeric grade
+function parseGrade(gradeLevel) {
+  const normalized = gradeLevel.trim().toLowerCase();
+  if (normalized === 'all' || normalized === 'k-12') return 0;
+  if (normalized === 'k-2' || normalized === 'k-3') return 1;
+  if (normalized.startsWith('3') || normalized.startsWith('4') || normalized.startsWith('5')) return 3;
+  if (normalized.startsWith('6') || normalized.startsWith('7') || normalized.startsWith('8')) return 6;
+  if (normalized.startsWith('9') || normalized.startsWith('10') || normalized.startsWith('11') || normalized.startsWith('12')) return 9;
+
+  const match = normalized.match(/^(\d+)/);
+  if (match) {
+    const num = parseInt(match[1], 10);
+    if (num >= 1 && num <= 2) return 1;
+    if (num >= 3 && num <= 5) return 3;
+    if (num >= 6 && num <= 8) return 6;
+    if (num >= 9) return 9;
+  }
+  return 0;
+}
+
+function normalizeDifficulty(diff) {
+  const normalized = diff.toLowerCase().trim();
+  if (['easy', 'medium', 'hard', 'all'].includes(normalized)) {
+    return normalized;
+  }
+  return 'medium';
+}
+
+// Process all grade files
+const files = fs.readdirSync(wordsDir).filter(f => f.startsWith('grade-') && f.endsWith('.json'));
+
+for (const file of files) {
+  const filePath = path.join(wordsDir, file);
+  const content = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+  // Check if it's the wrapped format
+  if (content.words && Array.isArray(content.words)) {
+    console.log(`Transforming ${file}: ${content.words.length} words`);
+
+    // Transform to Word[] format
+    const transformed = content.words.map(raw => ({
+      word: raw.word,
+      definition: raw.definition,
+      sentence: raw.example,
+      grade: parseGrade(raw.gradeLevel),
+      difficulty: normalizeDifficulty(raw.difficulty),
+      ...(raw.syllables ? { syllables: raw.syllables } : {}),
+      ...(raw.phonetic ? { phonetic: raw.phonetic } : {}),
+    }));
+
+    // Remove duplicates based on 'word' field
+    const seen = new Set();
+    const unique = transformed.filter(w => {
+      if (seen.has(w.word)) {
+        console.log(`  Removing duplicate: ${w.word}`);
+        return false;
+      }
+      seen.add(w.word);
+      return true;
+    });
+
+    fs.writeFileSync(filePath, JSON.stringify(unique, null, 2) + '\n', 'utf8');
+    console.log(`  → ${unique.length} unique words written`);
+  } else {
+    console.log(`Skipping ${file}: already in Word[] format or empty`);
+  }
+}
+
+console.log('\nDone! All grade files transformed to Word[] format.');

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -97,6 +97,7 @@ export function createGameSession(uid: string): GameSession {
     score: 0,
     bestStreak: 0,
     synced: false,
+    rounds: [],
   };
 }
 

--- a/src/hooks/__tests__/useGameState.test.ts
+++ b/src/hooks/__tests__/useGameState.test.ts
@@ -114,14 +114,15 @@ vi.mock("../../lib/wordList", () => ({
   WORD_LIST: MOCK_WORDS,
 }));
 
-vi.mock("../../game-engine/difficulty", async (importOriginal) => {
-  const mod =
-    await importOriginal<typeof import("../../game-engine/difficulty")>();
-  return {
-    ...mod,
-    selectRandomWord: (words: any[]) => (words.length > 0 ? words[0] : null),
-  };
-});
+vi.mock("../../game-engine/difficulty", () => ({
+  getAvailableWords: vi.fn((pool) => ({
+    availableWords: pool || [],
+    shouldResetUsed: false,
+    fallbackReason: null,
+  })),
+  selectRandomWord: vi.fn((words) => (words.length > 0 ? words[0] : null)),
+  getAdjustedDifficulty: vi.fn(),
+}));
 
 vi.mock("sonner", () => ({
   toast: {

--- a/src/hooks/__tests__/useGameState.test.ts
+++ b/src/hooks/__tests__/useGameState.test.ts
@@ -132,9 +132,12 @@ async function getStore() {
 describe("useGameState", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Mock Math.random for deterministic word selection in tests
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 

--- a/src/hooks/__tests__/useGameState.test.ts
+++ b/src/hooks/__tests__/useGameState.test.ts
@@ -13,8 +13,31 @@
  *  - session completion (word pool exhausted → idle)
  *  - streak-5: store streak reaches 5, triggerMessage yields celebratory tone
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from "vitest";
 import { renderHook, act } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Deterministic Math.random for consistent test behavior
+// ---------------------------------------------------------------------------
+
+const originalRandom = Math.random;
+
+beforeAll(() => {
+  Math.random = () => 0.5;
+});
+
+afterAll(() => {
+  Math.random = originalRandom;
+});
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -157,9 +180,8 @@ async function getStore() {
 
 describe("useGameState", () => {
   beforeEach(async () => {
-    vi.resetModules();
     vi.clearAllMocks();
-    // Reset the debounce guard so tests don't interfere with each other
+    // Reset the store state without resetting modules (which breaks mocks)
     const { useGameStore } = await import("../useGameStore");
     useGameStore.getState().restartGame();
   });

--- a/src/hooks/__tests__/useGameState.test.ts
+++ b/src/hooks/__tests__/useGameState.test.ts
@@ -114,6 +114,15 @@ vi.mock("../../lib/wordList", () => ({
   WORD_LIST: MOCK_WORDS,
 }));
 
+vi.mock("../../game-engine/difficulty", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("../../game-engine/difficulty")>();
+  return {
+    ...mod,
+    selectRandomWord: (words: any[]) => (words.length > 0 ? words[0] : null),
+  };
+});
+
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
@@ -149,15 +158,12 @@ describe("useGameState", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
-    // Mock Math.random for deterministic word selection in tests
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
     // Reset the debounce guard so tests don't interfere with each other
     const { useGameStore } = await import("../useGameStore");
     useGameStore.getState().restartGame();
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 

--- a/src/lib/__tests__/wordLoader.test.ts
+++ b/src/lib/__tests__/wordLoader.test.ts
@@ -1,47 +1,35 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
-  mapRawWord,
-  parseGrade,
-  normalizeDifficulty,
   clearWordCache,
   isGradeLoaded,
   getCachedGrades,
   loadWordsForGrade,
   VALID_GRADES,
-} from '../wordLoader';
-import type { GradeWordFile } from '../wordLoader';
+  WordLoaderError,
+} from "../wordLoader";
+import type { Word } from "@/types";
 
 // ---------------------------------------------------------------------------
-// Shared fixture
+// Shared fixture - now in Word[] format (flat array, not wrapped)
 // ---------------------------------------------------------------------------
 
-const GRADE_1_FIXTURE: GradeWordFile = {
-  grade: 1,
-  language: 'en-US',
-  version: '1.0.0',
-  lastUpdated: '2026-01-01T00:00:00.000Z',
-  wordCount: 2,
-  words: [
-    {
-      word: 'apple',
-      definition: 'A round fruit.',
-      example: 'She ate an apple.',
-      phonetic: 'AP-ple',
-      syllables: 'ap-ple',
-      difficulty: 'easy',
-      gradeLevel: 'K-2',
-    },
-    {
-      word: 'book',
-      definition: 'A written work.',
-      example: 'He read a book.',
-      phonetic: 'BOOK',
-      syllables: 'book',
-      difficulty: 'easy',
-      gradeLevel: 'K-2',
-    },
-  ],
-};
+const GRADE_1_WORDS: Word[] = [
+  {
+    word: "apple",
+    definition: "A round fruit.",
+    sentence: "She ate an apple.",
+    grade: 1,
+    difficulty: "easy",
+    syllables: "ap-ple",
+  },
+  {
+    word: "book",
+    definition: "A written work.",
+    sentence: "He read a book.",
+    grade: 1,
+    difficulty: "easy",
+  },
+];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -49,7 +37,7 @@ const GRADE_1_FIXTURE: GradeWordFile = {
 
 function mockFetchOk(payload: unknown): void {
   vi.stubGlobal(
-    'fetch',
+    "fetch",
     vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(payload),
@@ -59,11 +47,11 @@ function mockFetchOk(payload: unknown): void {
 
 function mockFetchFail(status = 404): void {
   vi.stubGlobal(
-    'fetch',
+    "fetch",
     vi.fn().mockResolvedValue({
       ok: false,
       status,
-      json: () => Promise.reject(new Error('not json')),
+      json: () => Promise.reject(new Error("not json")),
     } as unknown as Response),
   );
 }
@@ -72,7 +60,7 @@ function mockFetchFail(status = 404): void {
 // Suite
 // ---------------------------------------------------------------------------
 
-describe('wordLoader', () => {
+describe("wordLoader", () => {
   beforeEach(() => {
     clearWordCache();
   });
@@ -83,133 +71,55 @@ describe('wordLoader', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Synchronous helpers (pre-existing)
+  // VALID_GRADES
   // -------------------------------------------------------------------------
 
-  describe('VALID_GRADES', () => {
-    it('contains exactly the four range-based grade buckets', () => {
-      expect([...VALID_GRADES]).toEqual([1, 3, 6, 9]);
+  describe("VALID_GRADES", () => {
+    it("contains exactly all twelve grade buckets", () => {
+      expect([...VALID_GRADES]).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+      ]);
     });
   });
 
-  describe('mapRawWord', () => {
-    it('maps raw JSON word to Word type', () => {
-      const raw = {
-        word: 'elephant',
-        definition: 'A large animal.',
-        example: 'The elephant walked.',
-        phonetic: 'EL-e-phant',
-        syllables: 'el-e-phant',
-        difficulty: 'medium',
-        gradeLevel: '3-5',
-      };
+  // -------------------------------------------------------------------------
+  // Cache utilities
+  // -------------------------------------------------------------------------
 
-      const result = mapRawWord(raw);
-
-      expect(result.word).toBe('elephant');
-      expect(result.definition).toBe('A large animal.');
-      expect(result.sentence).toBe('The elephant walked.');
-      expect(result.syllables).toBe('el-e-phant');
-      expect(result.grade).toBe(3);
-      expect(result.difficulty).toBe('medium');
-    });
-  });
-
-  describe('parseGrade', () => {
-    it('maps K-2 to grade 1', () => {
-      expect(parseGrade('K-2')).toBe(1);
-    });
-
-    it('maps 3-5 to grade 3', () => {
-      expect(parseGrade('3-5')).toBe(3);
-    });
-
-    it('maps 6-8 to grade 6', () => {
-      expect(parseGrade('6-8')).toBe(6);
-    });
-
-    it('maps 9-12 to grade 9', () => {
-      expect(parseGrade('9-12')).toBe(9);
-    });
-
-    it('maps all to grade 0', () => {
-      expect(parseGrade('all')).toBe(0);
-    });
-
-    it('maps single grade numbers to their range bucket', () => {
-      expect(parseGrade('1')).toBe(1);
-      expect(parseGrade('2')).toBe(1);
-      expect(parseGrade('4')).toBe(3);
-      expect(parseGrade('5')).toBe(3);
-      expect(parseGrade('7')).toBe(6);
-      expect(parseGrade('8')).toBe(6);
-      expect(parseGrade('9')).toBe(9);
-      expect(parseGrade('10')).toBe(9);
-      expect(parseGrade('11')).toBe(9);
-      expect(parseGrade('12')).toBe(9);
-    });
-  });
-
-  describe('normalizeDifficulty', () => {
-    it('returns easy for easy', () => {
-      expect(normalizeDifficulty('easy')).toBe('easy');
-    });
-
-    it('returns medium for medium', () => {
-      expect(normalizeDifficulty('medium')).toBe('medium');
-    });
-
-    it('returns hard for hard', () => {
-      expect(normalizeDifficulty('hard')).toBe('hard');
-    });
-
-    it('returns all for all', () => {
-      expect(normalizeDifficulty('all')).toBe('all');
-    });
-
-    it('defaults to medium for unknown values', () => {
-      expect(normalizeDifficulty('unknown')).toBe('medium');
-    });
-
-    it('handles case insensitivity', () => {
-      expect(normalizeDifficulty('EASY')).toBe('easy');
-    });
-  });
-
-  describe('cache utilities', () => {
-    it('clearWordCache resets cache', () => {
+  describe("cache utilities", () => {
+    it("clearWordCache resets cache", () => {
       clearWordCache();
       expect(isGradeLoaded(1)).toBe(false);
       expect(isGradeLoaded(0)).toBe(false);
     });
 
-    it('getCachedGrades returns empty array on cold cache', () => {
+    it("getCachedGrades returns empty array on cold cache", () => {
       expect(getCachedGrades()).toEqual([]);
     });
   });
 
   // -------------------------------------------------------------------------
-  // Async: loadWordsForGrade — SUB-03 AC tests
+  // loadWordsForGrade
   // -------------------------------------------------------------------------
 
-  describe('loadWordsForGrade', () => {
-    it('successful load: returns mapped Word[] from fetch', async () => {
-      mockFetchOk(GRADE_1_FIXTURE);
+  describe("loadWordsForGrade", () => {
+    it("successful load: returns Word[] from fetch", async () => {
+      mockFetchOk(GRADE_1_WORDS);
 
       const words = await loadWordsForGrade(1);
 
       expect(words).toHaveLength(2);
-      expect(words[0].word).toBe('apple');
+      expect(words[0].word).toBe("apple");
       expect(words[0].grade).toBe(1);
-      expect(words[1].word).toBe('book');
+      expect(words[1].word).toBe("book");
     });
 
-    it('cache hit: second call for same grade does not re-fetch', async () => {
+    it("cache hit: second call for same grade does not re-fetch", async () => {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(GRADE_1_FIXTURE),
+        json: () => Promise.resolve(GRADE_1_WORDS),
       } as Response);
-      vi.stubGlobal('fetch', fetchMock);
+      vi.stubGlobal("fetch", fetchMock);
 
       await loadWordsForGrade(1);
       await loadWordsForGrade(1); // second call — must hit cache
@@ -219,30 +129,56 @@ describe('wordLoader', () => {
       expect(getCachedGrades()).toContain(1);
     });
 
-    it('getCachedGrades reflects loaded grades after successful fetch', async () => {
-      mockFetchOk(GRADE_1_FIXTURE);
+    it("getCachedGrades reflects loaded grades after successful fetch", async () => {
+      mockFetchOk(GRADE_1_WORDS);
 
       await loadWordsForGrade(1);
 
       expect(getCachedGrades()).toEqual([1]);
     });
 
-    it('fetch failure: rejects with an Error describing the file and status', async () => {
+    it("fetch failure: rejects with WordLoaderError describing the file and status", async () => {
       mockFetchFail(503);
 
-      await expect(loadWordsForGrade(3)).rejects.toThrow(
-        /grade-3\.json.*503/,
-      );
+      await expect(loadWordsForGrade(3)).rejects.toThrow(WordLoaderError);
+      await expect(loadWordsForGrade(3)).rejects.toThrow(/grade-3\.json.*503/);
     });
 
-    it('invalid grade: throws when no file is configured for the grade', async () => {
+    it("invalid grade: throws WordLoaderError when no file is configured", async () => {
       // Grade 99 has no entry in GRADE_FILE_MAP
       // Stub fetch so it would succeed if reached — the guard must fire first
-      mockFetchOk(GRADE_1_FIXTURE);
+      mockFetchOk(GRADE_1_WORDS);
 
+      await expect(loadWordsForGrade(99)).rejects.toThrow(WordLoaderError);
       await expect(loadWordsForGrade(99)).rejects.toThrow(
         /No word file configured for grade 99/,
       );
+    });
+
+    it("cache-clear refetch: after clearWordCache, reload re-fetches data", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(GRADE_1_WORDS),
+      } as Response);
+      vi.stubGlobal("fetch", fetchMock);
+
+      // First load
+      const words1 = await loadWordsForGrade(1);
+      expect(words1).toHaveLength(2);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Clear cache
+      clearWordCache();
+      expect(isGradeLoaded(1)).toBe(false);
+
+      // Second load should re-fetch
+      const words2 = await loadWordsForGrade(1);
+      expect(words2).toHaveLength(2);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      // Verify data is the same
+      expect(words2[0].word).toBe(words1[0].word);
+      expect(words2[1].word).toBe(words1[1].word);
     });
   });
 });

--- a/src/lib/__tests__/wordLoader.test.ts
+++ b/src/lib/__tests__/wordLoader.test.ts
@@ -1,117 +1,248 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   mapRawWord,
   parseGrade,
   normalizeDifficulty,
   clearWordCache,
   isGradeLoaded,
+  getCachedGrades,
+  loadWordsForGrade,
   VALID_GRADES,
-} from "../wordLoader";
+} from '../wordLoader';
+import type { GradeWordFile } from '../wordLoader';
 
-describe("wordLoader", () => {
+// ---------------------------------------------------------------------------
+// Shared fixture
+// ---------------------------------------------------------------------------
+
+const GRADE_1_FIXTURE: GradeWordFile = {
+  grade: 1,
+  language: 'en-US',
+  version: '1.0.0',
+  lastUpdated: '2026-01-01T00:00:00.000Z',
+  wordCount: 2,
+  words: [
+    {
+      word: 'apple',
+      definition: 'A round fruit.',
+      example: 'She ate an apple.',
+      phonetic: 'AP-ple',
+      syllables: 'ap-ple',
+      difficulty: 'easy',
+      gradeLevel: 'K-2',
+    },
+    {
+      word: 'book',
+      definition: 'A written work.',
+      example: 'He read a book.',
+      phonetic: 'BOOK',
+      syllables: 'book',
+      difficulty: 'easy',
+      gradeLevel: 'K-2',
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetchOk(payload: unknown): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    } as Response),
+  );
+}
+
+function mockFetchFail(status = 404): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status,
+      json: () => Promise.reject(new Error('not json')),
+    } as unknown as Response),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('wordLoader', () => {
   beforeEach(() => {
     clearWordCache();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
-  describe("VALID_GRADES", () => {
-    it("contains exactly the four range-based grade buckets", () => {
+  // -------------------------------------------------------------------------
+  // Synchronous helpers (pre-existing)
+  // -------------------------------------------------------------------------
+
+  describe('VALID_GRADES', () => {
+    it('contains exactly the four range-based grade buckets', () => {
       expect([...VALID_GRADES]).toEqual([1, 3, 6, 9]);
     });
   });
 
-  describe("mapRawWord", () => {
-    it("maps raw JSON word to Word type", () => {
+  describe('mapRawWord', () => {
+    it('maps raw JSON word to Word type', () => {
       const raw = {
-        word: "elephant",
-        definition: "A large animal.",
-        example: "The elephant walked.",
-        phonetic: "EL-e-phant",
-        syllables: "el-e-phant",
-        difficulty: "medium",
-        gradeLevel: "3-5",
+        word: 'elephant',
+        definition: 'A large animal.',
+        example: 'The elephant walked.',
+        phonetic: 'EL-e-phant',
+        syllables: 'el-e-phant',
+        difficulty: 'medium',
+        gradeLevel: '3-5',
       };
 
       const result = mapRawWord(raw);
 
-      expect(result.word).toBe("elephant");
-      expect(result.definition).toBe("A large animal.");
-      expect(result.sentence).toBe("The elephant walked.");
-      expect(result.syllables).toBe("el-e-phant");
+      expect(result.word).toBe('elephant');
+      expect(result.definition).toBe('A large animal.');
+      expect(result.sentence).toBe('The elephant walked.');
+      expect(result.syllables).toBe('el-e-phant');
       expect(result.grade).toBe(3);
-      expect(result.difficulty).toBe("medium");
+      expect(result.difficulty).toBe('medium');
     });
   });
 
-  describe("parseGrade", () => {
-    it("maps K-2 to grade 1", () => {
-      expect(parseGrade("K-2")).toBe(1);
+  describe('parseGrade', () => {
+    it('maps K-2 to grade 1', () => {
+      expect(parseGrade('K-2')).toBe(1);
     });
 
-    it("maps 3-5 to grade 3", () => {
-      expect(parseGrade("3-5")).toBe(3);
+    it('maps 3-5 to grade 3', () => {
+      expect(parseGrade('3-5')).toBe(3);
     });
 
-    it("maps 6-8 to grade 6", () => {
-      expect(parseGrade("6-8")).toBe(6);
+    it('maps 6-8 to grade 6', () => {
+      expect(parseGrade('6-8')).toBe(6);
     });
 
-    it("maps 9-12 to grade 9", () => {
-      expect(parseGrade("9-12")).toBe(9);
+    it('maps 9-12 to grade 9', () => {
+      expect(parseGrade('9-12')).toBe(9);
     });
 
-    it("maps all to grade 0", () => {
-      expect(parseGrade("all")).toBe(0);
+    it('maps all to grade 0', () => {
+      expect(parseGrade('all')).toBe(0);
     });
 
-    it("maps single grade numbers to their range bucket", () => {
-      expect(parseGrade("1")).toBe(1);
-      expect(parseGrade("2")).toBe(1);
-      expect(parseGrade("4")).toBe(3);
-      expect(parseGrade("5")).toBe(3);
-      expect(parseGrade("7")).toBe(6);
-      expect(parseGrade("8")).toBe(6);
-      expect(parseGrade("9")).toBe(9);
-      expect(parseGrade("10")).toBe(9);
-      expect(parseGrade("11")).toBe(9);
-      expect(parseGrade("12")).toBe(9);
-    });
-  });
-
-  describe("normalizeDifficulty", () => {
-    it("returns easy for easy", () => {
-      expect(normalizeDifficulty("easy")).toBe("easy");
-    });
-
-    it("returns medium for medium", () => {
-      expect(normalizeDifficulty("medium")).toBe("medium");
-    });
-
-    it("returns hard for hard", () => {
-      expect(normalizeDifficulty("hard")).toBe("hard");
-    });
-
-    it("returns all for all", () => {
-      expect(normalizeDifficulty("all")).toBe("all");
-    });
-
-    it("defaults to medium for unknown values", () => {
-      expect(normalizeDifficulty("unknown")).toBe("medium");
-    });
-
-    it("handles case insensitivity", () => {
-      expect(normalizeDifficulty("EASY")).toBe("easy");
+    it('maps single grade numbers to their range bucket', () => {
+      expect(parseGrade('1')).toBe(1);
+      expect(parseGrade('2')).toBe(1);
+      expect(parseGrade('4')).toBe(3);
+      expect(parseGrade('5')).toBe(3);
+      expect(parseGrade('7')).toBe(6);
+      expect(parseGrade('8')).toBe(6);
+      expect(parseGrade('9')).toBe(9);
+      expect(parseGrade('10')).toBe(9);
+      expect(parseGrade('11')).toBe(9);
+      expect(parseGrade('12')).toBe(9);
     });
   });
 
-  describe("cache", () => {
-    it("clearWordCache resets cache", () => {
+  describe('normalizeDifficulty', () => {
+    it('returns easy for easy', () => {
+      expect(normalizeDifficulty('easy')).toBe('easy');
+    });
+
+    it('returns medium for medium', () => {
+      expect(normalizeDifficulty('medium')).toBe('medium');
+    });
+
+    it('returns hard for hard', () => {
+      expect(normalizeDifficulty('hard')).toBe('hard');
+    });
+
+    it('returns all for all', () => {
+      expect(normalizeDifficulty('all')).toBe('all');
+    });
+
+    it('defaults to medium for unknown values', () => {
+      expect(normalizeDifficulty('unknown')).toBe('medium');
+    });
+
+    it('handles case insensitivity', () => {
+      expect(normalizeDifficulty('EASY')).toBe('easy');
+    });
+  });
+
+  describe('cache utilities', () => {
+    it('clearWordCache resets cache', () => {
       clearWordCache();
       expect(isGradeLoaded(1)).toBe(false);
       expect(isGradeLoaded(0)).toBe(false);
+    });
+
+    it('getCachedGrades returns empty array on cold cache', () => {
+      expect(getCachedGrades()).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Async: loadWordsForGrade — SUB-03 AC tests
+  // -------------------------------------------------------------------------
+
+  describe('loadWordsForGrade', () => {
+    it('successful load: returns mapped Word[] from fetch', async () => {
+      mockFetchOk(GRADE_1_FIXTURE);
+
+      const words = await loadWordsForGrade(1);
+
+      expect(words).toHaveLength(2);
+      expect(words[0].word).toBe('apple');
+      expect(words[0].grade).toBe(1);
+      expect(words[1].word).toBe('book');
+    });
+
+    it('cache hit: second call for same grade does not re-fetch', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(GRADE_1_FIXTURE),
+      } as Response);
+      vi.stubGlobal('fetch', fetchMock);
+
+      await loadWordsForGrade(1);
+      await loadWordsForGrade(1); // second call — must hit cache
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(isGradeLoaded(1)).toBe(true);
+      expect(getCachedGrades()).toContain(1);
+    });
+
+    it('getCachedGrades reflects loaded grades after successful fetch', async () => {
+      mockFetchOk(GRADE_1_FIXTURE);
+
+      await loadWordsForGrade(1);
+
+      expect(getCachedGrades()).toEqual([1]);
+    });
+
+    it('fetch failure: rejects with an Error describing the file and status', async () => {
+      mockFetchFail(503);
+
+      await expect(loadWordsForGrade(3)).rejects.toThrow(
+        /grade-3\.json.*503/,
+      );
+    });
+
+    it('invalid grade: throws when no file is configured for the grade', async () => {
+      // Grade 99 has no entry in GRADE_FILE_MAP
+      // Stub fetch so it would succeed if reached — the guard must fire first
+      mockFetchOk(GRADE_1_FIXTURE);
+
+      await expect(loadWordsForGrade(99)).rejects.toThrow(
+        /No word file configured for grade 99/,
+      );
     });
   });
 });

--- a/src/lib/wordLoader.ts
+++ b/src/lib/wordLoader.ts
@@ -12,50 +12,33 @@
  *   grade 0  → all four files combined
  */
 
-import type { Word, GameDifficulty, Grade } from '../types';
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-/** Raw word record as stored in the grade JSON files. */
-export interface RawWordRecord {
-  word: string;
-  definition: string;
-  example: string;
-  phonetic: string;
-  syllables: string;
-  difficulty: string;
-  gradeLevel: string;
-}
-
-/** Grade word file structure. */
-export interface GradeWordFile {
-  grade: number;
-  language: string;
-  version: string;
-  lastUpdated: string;
-  wordCount: number;
-  words: RawWordRecord[];
-}
+import type { Word, GameDifficulty, Grade } from "@/types";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 /**
- * The four grade buckets that the generator emits and the loader fetches.
+ * All grade buckets that the generator emits and the loader fetches.
  * Must stay in sync with generate-word-databases.js GRADE_LEVEL_MAP values.
  */
-export const VALID_GRADES = [1, 3, 6, 9] as const;
+export const VALID_GRADES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
 
 /** Grade-to-file mapping. Grade 0 = "all grades" (loads every file). */
 export const GRADE_FILE_MAP: Record<number, string> = {
-  0: 'all', // special: loads all files
-  1: 'grade-1',
-  3: 'grade-3',
-  6: 'grade-6',
-  9: 'grade-9',
+  0: "all", // special: loads all files
+  1: "grade-1",
+  2: "grade-2",
+  3: "grade-3",
+  4: "grade-4",
+  5: "grade-5",
+  6: "grade-6",
+  7: "grade-7",
+  8: "grade-8",
+  9: "grade-9",
+  10: "grade-10",
+  11: "grade-11",
+  12: "grade-12",
 };
 
 // ---------------------------------------------------------------------------
@@ -69,91 +52,43 @@ const wordCache = new Map<number, Word[]>();
 let allGradesLoaded = false;
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Error Types
 // ---------------------------------------------------------------------------
 
-/**
- * Map a raw word record from the JSON file to the application Word type.
- */
-export function mapRawWord(raw: RawWordRecord): Word {
-  return {
-    word: raw.word,
-    definition: raw.definition,
-    sentence: raw.example,
-    syllables: raw.syllables,
-    grade: parseGrade(raw.gradeLevel),
-    difficulty: normalizeDifficulty(raw.difficulty),
-  };
-}
-
-/**
- * Parse grade level string (e.g., "K-2", "3-5", "6-8", "9-12") to the
- * numeric grade filter used by the game (1, 3, 6, 9, or 0 for all).
- *
- * The returned values mirror the keys in GRADE_FILE_MAP so that any word's
- * grade field matches the file it was loaded from.
- */
-export function parseGrade(gradeLevel: string): number {
-  const normalized = gradeLevel.trim().toLowerCase();
-  if (normalized === 'all' || normalized === 'k-12') return 0;
-  if (normalized === 'k-2' || normalized === 'k-3') return 1;
-  if (
-    normalized.startsWith('3') ||
-    normalized.startsWith('4') ||
-    normalized.startsWith('5')
-  )
-    return 3;
-  if (
-    normalized.startsWith('6') ||
-    normalized.startsWith('7') ||
-    normalized.startsWith('8')
-  )
-    return 6;
-  if (
-    normalized.startsWith('9') ||
-    normalized.startsWith('10') ||
-    normalized.startsWith('11') ||
-    normalized.startsWith('12')
-  )
-    return 9;
-  // Fallback: map numeric strings to the nearest range bucket
-  const match = normalized.match(/^(\d+)/);
-  if (match) {
-    const num = parseInt(match[1], 10);
-    if (num >= 1 && num <= 2) return 1;
-    if (num >= 3 && num <= 5) return 3;
-    if (num >= 6 && num <= 8) return 6;
-    if (num >= 9) return 9;
-  }
-  return 0;
-}
-
-/** Normalize difficulty string to GameDifficulty type. */
-export function normalizeDifficulty(diff: string): GameDifficulty {
-  const normalized = diff.toLowerCase().trim();
-  if (
-    normalized === 'easy' ||
-    normalized === 'medium' ||
-    normalized === 'hard' ||
-    normalized === 'all'
+/** Dedicated error class for word loading failures. */
+export class WordLoaderError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
   ) {
-    return normalized;
+    super(message);
+    this.name = "WordLoaderError";
   }
-  return 'medium'; // safe default
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 /** Fetch and parse a single grade JSON file. */
 async function fetchGradeWords(
   fileName: string,
   signal?: AbortSignal,
-): Promise<GradeWordFile> {
-  const response = await fetch(`/data/words/${fileName}.json`, { signal });
-  if (!response.ok) {
-    throw new Error(
-      `Failed to load word file: /data/words/${fileName}.json (${response.status})`,
-    );
+): Promise<Word[]> {
+  try {
+    const response = await fetch(`/data/words/${fileName}.json`, { signal });
+    if (!response.ok) {
+      throw new WordLoaderError(
+        `Failed to load word file: /data/words/${fileName}.json (${response.status})`,
+      );
+    }
+    return response.json() as Promise<Word[]>;
+  } catch (error) {
+    if (error instanceof WordLoaderError) {
+      throw error;
+    }
+    throw new WordLoaderError(`Failed to fetch word file: ${fileName}`, error);
   }
-  return response.json() as Promise<GradeWordFile>;
 }
 
 // ---------------------------------------------------------------------------
@@ -163,12 +98,12 @@ async function fetchGradeWords(
 /**
  * Load words for a specific grade level. Results are cached.
  *
- * @param grade - Grade bucket (1, 3, 6, or 9) or 0 for all grades
+ * @param grade - Grade bucket (1-12) or 0 for all grades
  * @param signal - Optional AbortSignal to cancel in-flight requests
  * @returns Promise resolving to the filtered word list
  */
 export async function loadWordsForGrade(
-  grade: Grade,
+  grade: number,
   signal?: AbortSignal,
 ): Promise<Word[]> {
   // Return cached if available
@@ -183,8 +118,7 @@ export async function loadWordsForGrade(
     const allPromises = VALID_GRADES.map(async (g) => {
       if (wordCache.has(g)) return wordCache.get(g)!;
       const fileName = GRADE_FILE_MAP[g];
-      const data = await fetchGradeWords(fileName, signal);
-      const gradeWords = data.words.map(mapRawWord);
+      const gradeWords = await fetchGradeWords(fileName, signal);
       wordCache.set(g, gradeWords);
       return gradeWords;
     });
@@ -195,10 +129,9 @@ export async function loadWordsForGrade(
   } else {
     const fileName = GRADE_FILE_MAP[grade];
     if (!fileName) {
-      throw new Error(`No word file configured for grade ${grade}`);
+      throw new WordLoaderError(`No word file configured for grade ${grade}`);
     }
-    const data = await fetchGradeWords(fileName, signal);
-    words = data.words.map(mapRawWord);
+    words = await fetchGradeWords(fileName, signal);
   }
 
   wordCache.set(grade, words);
@@ -216,7 +149,7 @@ export async function getWordsForConfigAsync(
   const words = await loadWordsForGrade(grade);
 
   return words.filter((w) => {
-    const diffMatch = difficulty === 'all' || w.difficulty === difficulty;
+    const diffMatch = difficulty === "all" || w.difficulty === difficulty;
     return diffMatch;
   });
 }
@@ -240,6 +173,6 @@ export function isGradeLoaded(grade: number): boolean {
  * Return the list of grade numbers currently held in the cache.
  * Useful for debugging and for inspecting warm-cache state in tests.
  */
-export function getCachedGrades(): Grade[] {
+export function getCachedGrades(): number[] {
   return Array.from(wordCache.keys());
 }

--- a/src/lib/wordLoader.ts
+++ b/src/lib/wordLoader.ts
@@ -12,7 +12,7 @@
  *   grade 0  → all four files combined
  */
 
-import type { Word, GameDifficulty } from "../types";
+import type { Word, GameDifficulty, Grade } from '../types';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -51,11 +51,11 @@ export const VALID_GRADES = [1, 3, 6, 9] as const;
 
 /** Grade-to-file mapping. Grade 0 = "all grades" (loads every file). */
 export const GRADE_FILE_MAP: Record<number, string> = {
-  0: "all", // special: loads all files
-  1: "grade-1",
-  3: "grade-3",
-  6: "grade-6",
-  9: "grade-9",
+  0: 'all', // special: loads all files
+  1: 'grade-1',
+  3: 'grade-3',
+  6: 'grade-6',
+  9: 'grade-9',
 };
 
 // ---------------------------------------------------------------------------
@@ -95,25 +95,25 @@ export function mapRawWord(raw: RawWordRecord): Word {
  */
 export function parseGrade(gradeLevel: string): number {
   const normalized = gradeLevel.trim().toLowerCase();
-  if (normalized === "all" || normalized === "k-12") return 0;
-  if (normalized === "k-2" || normalized === "k-3") return 1;
+  if (normalized === 'all' || normalized === 'k-12') return 0;
+  if (normalized === 'k-2' || normalized === 'k-3') return 1;
   if (
-    normalized.startsWith("3") ||
-    normalized.startsWith("4") ||
-    normalized.startsWith("5")
+    normalized.startsWith('3') ||
+    normalized.startsWith('4') ||
+    normalized.startsWith('5')
   )
     return 3;
   if (
-    normalized.startsWith("6") ||
-    normalized.startsWith("7") ||
-    normalized.startsWith("8")
+    normalized.startsWith('6') ||
+    normalized.startsWith('7') ||
+    normalized.startsWith('8')
   )
     return 6;
   if (
-    normalized.startsWith("9") ||
-    normalized.startsWith("10") ||
-    normalized.startsWith("11") ||
-    normalized.startsWith("12")
+    normalized.startsWith('9') ||
+    normalized.startsWith('10') ||
+    normalized.startsWith('11') ||
+    normalized.startsWith('12')
   )
     return 9;
   // Fallback: map numeric strings to the nearest range bucket
@@ -132,19 +132,22 @@ export function parseGrade(gradeLevel: string): number {
 export function normalizeDifficulty(diff: string): GameDifficulty {
   const normalized = diff.toLowerCase().trim();
   if (
-    normalized === "easy" ||
-    normalized === "medium" ||
-    normalized === "hard" ||
-    normalized === "all"
+    normalized === 'easy' ||
+    normalized === 'medium' ||
+    normalized === 'hard' ||
+    normalized === 'all'
   ) {
     return normalized;
   }
-  return "medium"; // safe default
+  return 'medium'; // safe default
 }
 
 /** Fetch and parse a single grade JSON file. */
-async function fetchGradeWords(fileName: string): Promise<GradeWordFile> {
-  const response = await fetch(`/data/words/${fileName}.json`);
+async function fetchGradeWords(
+  fileName: string,
+  signal?: AbortSignal,
+): Promise<GradeWordFile> {
+  const response = await fetch(`/data/words/${fileName}.json`, { signal });
   if (!response.ok) {
     throw new Error(
       `Failed to load word file: /data/words/${fileName}.json (${response.status})`,
@@ -161,9 +164,13 @@ async function fetchGradeWords(fileName: string): Promise<GradeWordFile> {
  * Load words for a specific grade level. Results are cached.
  *
  * @param grade - Grade bucket (1, 3, 6, or 9) or 0 for all grades
+ * @param signal - Optional AbortSignal to cancel in-flight requests
  * @returns Promise resolving to the filtered word list
  */
-export async function loadWordsForGrade(grade: number): Promise<Word[]> {
+export async function loadWordsForGrade(
+  grade: Grade,
+  signal?: AbortSignal,
+): Promise<Word[]> {
   // Return cached if available
   if (wordCache.has(grade)) {
     return wordCache.get(grade)!;
@@ -176,7 +183,7 @@ export async function loadWordsForGrade(grade: number): Promise<Word[]> {
     const allPromises = VALID_GRADES.map(async (g) => {
       if (wordCache.has(g)) return wordCache.get(g)!;
       const fileName = GRADE_FILE_MAP[g];
-      const data = await fetchGradeWords(fileName);
+      const data = await fetchGradeWords(fileName, signal);
       const gradeWords = data.words.map(mapRawWord);
       wordCache.set(g, gradeWords);
       return gradeWords;
@@ -190,7 +197,7 @@ export async function loadWordsForGrade(grade: number): Promise<Word[]> {
     if (!fileName) {
       throw new Error(`No word file configured for grade ${grade}`);
     }
-    const data = await fetchGradeWords(fileName);
+    const data = await fetchGradeWords(fileName, signal);
     words = data.words.map(mapRawWord);
   }
 
@@ -209,7 +216,7 @@ export async function getWordsForConfigAsync(
   const words = await loadWordsForGrade(grade);
 
   return words.filter((w) => {
-    const diffMatch = difficulty === "all" || w.difficulty === difficulty;
+    const diffMatch = difficulty === 'all' || w.difficulty === difficulty;
     return diffMatch;
   });
 }
@@ -227,4 +234,12 @@ export function clearWordCache(): void {
  */
 export function isGradeLoaded(grade: number): boolean {
   return wordCache.has(grade) || (grade === 0 && allGradesLoaded);
+}
+
+/**
+ * Return the list of grade numbers currently held in the cache.
+ * Useful for debugging and for inspecting warm-cache state in tests.
+ */
+export function getCachedGrades(): Grade[] {
+  return Array.from(wordCache.keys());
 }

--- a/src/types/__tests__/types.test.ts
+++ b/src/types/__tests__/types.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { Word, WordProgress, GameSession, Grade } from '../index';
+
+/**
+ * SUB-01 AC: Unit tests that construct valid objects and assert they satisfy
+ * each interface using the `satisfies` operator (compile-time) plus runtime
+ * field checks via expectTypeOf.
+ */
+describe('Core domain types', () => {
+  describe('Word', () => {
+    it('accepts a minimal valid Word object', () => {
+      const w = {
+        word: 'elephant',
+        definition: 'A large animal with a trunk.',
+        sentence: 'The elephant walked to the watering hole.',
+        grade: 3,
+        difficulty: 'medium',
+      } satisfies Word;
+
+      expectTypeOf(w).toMatchTypeOf<Word>();
+    });
+
+    it('accepts a full Word object including optional fields', () => {
+      const w = {
+        word: 'acrobat',
+        definition: 'A person who performs gymnastic feats.',
+        sentence: 'The acrobat flipped through the air.',
+        grade: 6,
+        difficulty: 'hard',
+        partOfSpeech: 'noun',
+        usageExample: 'She trained as an acrobat.',
+        syllables: 'ac-ro-bat',
+      } satisfies Word;
+
+      expectTypeOf(w).toMatchTypeOf<Word>();
+    });
+
+    it('Grade alias resolves to the same type as Word["grade"]', () => {
+      expectTypeOf<Grade>().toEqualTypeOf<Word['grade']>();
+    });
+  });
+
+  describe('WordProgress', () => {
+    it('accepts a valid WordProgress object', () => {
+      const wp = {
+        word: 'elephant',
+        correctCount: 5,
+        attemptCount: 7,
+        skipCount: 1,
+        mastered: false,
+        lastDifficulty: 'medium',
+        lastAttemptedAt: '2026-04-10T14:00:00.000Z',
+      } satisfies WordProgress;
+
+      expectTypeOf(wp).toMatchTypeOf<WordProgress>();
+    });
+
+    it('mastered flag is a boolean', () => {
+      const wp: WordProgress = {
+        word: 'quiz',
+        correctCount: 10,
+        attemptCount: 10,
+        skipCount: 0,
+        mastered: true,
+        lastDifficulty: 'easy',
+        lastAttemptedAt: '2026-04-10T14:00:00.000Z',
+      };
+
+      expectTypeOf(wp.mastered).toBeBoolean();
+    });
+  });
+
+  describe('GameSession', () => {
+    it('accepts a valid GameSession object', () => {
+      const gs = {
+        id: 'sess-abc-123',
+        uid: 'user-xyz-456',
+        startTime: '2026-04-10T13:00:00.000Z',
+        wordsSpelled: 10,
+        correctCount: 8,
+        difficultyEvolution: [1, 1, -1, 1, 1],
+        score: 840,
+        bestStreak: 5,
+        synced: false,
+      } satisfies GameSession;
+
+      expectTypeOf(gs).toMatchTypeOf<GameSession>();
+    });
+
+    it('accepts a GameSession with optional endTime', () => {
+      const gs = {
+        id: 'sess-def-789',
+        uid: 'user-abc-001',
+        startTime: '2026-04-10T12:00:00.000Z',
+        endTime: '2026-04-10T12:15:00.000Z',
+        wordsSpelled: 20,
+        correctCount: 18,
+        difficultyEvolution: [],
+        score: 1800,
+        bestStreak: 12,
+        synced: true,
+      } satisfies GameSession;
+
+      expectTypeOf(gs.endTime).toEqualTypeOf<string | undefined>();
+    });
+
+    it('difficultyEvolution is an array of numbers', () => {
+      const gs: GameSession = {
+        id: 'sess-ghi-000',
+        uid: 'offline',
+        startTime: '2026-04-10T11:00:00.000Z',
+        wordsSpelled: 5,
+        correctCount: 3,
+        difficultyEvolution: [1, -1, 1],
+        score: 300,
+        bestStreak: 2,
+        synced: false,
+      };
+
+      expectTypeOf(gs.difficultyEvolution).toEqualTypeOf<number[]>();
+    });
+  });
+});

--- a/src/types/__tests__/types.test.ts
+++ b/src/types/__tests__/types.test.ts
@@ -1,123 +1,190 @@
-import { describe, it, expectTypeOf } from 'vitest';
-import type { Word, WordProgress, GameSession, Grade } from '../index';
+import { describe, it, expectTypeOf } from "vitest";
+import type {
+  Word,
+  WordProgress,
+  GameSession,
+  GameRound,
+  Grade,
+} from "../index";
 
 /**
  * SUB-01 AC: Unit tests that construct valid objects and assert they satisfy
  * each interface using the `satisfies` operator (compile-time) plus runtime
  * field checks via expectTypeOf.
  */
-describe('Core domain types', () => {
-  describe('Word', () => {
-    it('accepts a minimal valid Word object', () => {
+describe("Core domain types", () => {
+  describe("Word", () => {
+    it("accepts a minimal valid Word object", () => {
       const w = {
-        word: 'elephant',
-        definition: 'A large animal with a trunk.',
-        sentence: 'The elephant walked to the watering hole.',
+        word: "elephant",
+        definition: "A large animal with a trunk.",
+        sentence: "The elephant walked to the watering hole.",
         grade: 3,
-        difficulty: 'medium',
+        difficulty: "medium",
       } satisfies Word;
 
       expectTypeOf(w).toMatchTypeOf<Word>();
     });
 
-    it('accepts a full Word object including optional fields', () => {
+    it("accepts a full Word object including optional fields", () => {
       const w = {
-        word: 'acrobat',
-        definition: 'A person who performs gymnastic feats.',
-        sentence: 'The acrobat flipped through the air.',
+        word: "acrobat",
+        definition: "A person who performs gymnastic feats.",
+        sentence: "The acrobat flipped through the air.",
         grade: 6,
-        difficulty: 'hard',
-        partOfSpeech: 'noun',
-        usageExample: 'She trained as an acrobat.',
-        syllables: 'ac-ro-bat',
+        difficulty: "hard",
+        partOfSpeech: "noun",
+        usageExample: "She trained as an acrobat.",
+        syllables: "ac-ro-bat",
       } satisfies Word;
 
       expectTypeOf(w).toMatchTypeOf<Word>();
     });
 
     it('Grade alias resolves to the same type as Word["grade"]', () => {
-      expectTypeOf<Grade>().toEqualTypeOf<Word['grade']>();
+      expectTypeOf<Grade>().toEqualTypeOf<Word["grade"]>();
     });
   });
 
-  describe('WordProgress', () => {
-    it('accepts a valid WordProgress object', () => {
+  describe("WordProgress", () => {
+    it("accepts a valid WordProgress object", () => {
       const wp = {
-        word: 'elephant',
+        word: "elephant",
         correctCount: 5,
         attemptCount: 7,
         skipCount: 1,
         mastered: false,
-        lastDifficulty: 'medium',
-        lastAttemptedAt: '2026-04-10T14:00:00.000Z',
+        lastDifficulty: "medium",
+        lastAttemptedAt: "2026-04-10T14:00:00.000Z",
       } satisfies WordProgress;
 
       expectTypeOf(wp).toMatchTypeOf<WordProgress>();
     });
 
-    it('mastered flag is a boolean', () => {
+    it("mastered flag is a boolean", () => {
       const wp: WordProgress = {
-        word: 'quiz',
+        word: "quiz",
         correctCount: 10,
         attemptCount: 10,
         skipCount: 0,
         mastered: true,
-        lastDifficulty: 'easy',
-        lastAttemptedAt: '2026-04-10T14:00:00.000Z',
+        lastDifficulty: "easy",
+        lastAttemptedAt: "2026-04-10T14:00:00.000Z",
       };
 
       expectTypeOf(wp.mastered).toBeBoolean();
     });
   });
 
-  describe('GameSession', () => {
-    it('accepts a valid GameSession object', () => {
+  describe("GameSession", () => {
+    it("accepts a valid GameSession object", () => {
       const gs = {
-        id: 'sess-abc-123',
-        uid: 'user-xyz-456',
-        startTime: '2026-04-10T13:00:00.000Z',
+        id: "sess-abc-123",
+        uid: "user-xyz-456",
+        startTime: "2026-04-10T13:00:00.000Z",
         wordsSpelled: 10,
         correctCount: 8,
         difficultyEvolution: [1, 1, -1, 1, 1],
         score: 840,
         bestStreak: 5,
         synced: false,
+        rounds: [],
       } satisfies GameSession;
 
       expectTypeOf(gs).toMatchTypeOf<GameSession>();
     });
 
-    it('accepts a GameSession with optional endTime', () => {
+    it("accepts a GameSession with optional endTime", () => {
       const gs = {
-        id: 'sess-def-789',
-        uid: 'user-abc-001',
-        startTime: '2026-04-10T12:00:00.000Z',
-        endTime: '2026-04-10T12:15:00.000Z',
+        id: "sess-def-789",
+        uid: "user-abc-001",
+        startTime: "2026-04-10T12:00:00.000Z",
+        endTime: "2026-04-10T12:15:00.000Z",
         wordsSpelled: 20,
         correctCount: 18,
         difficultyEvolution: [],
         score: 1800,
         bestStreak: 12,
         synced: true,
+        rounds: [],
       } satisfies GameSession;
 
-      expectTypeOf(gs.endTime).toEqualTypeOf<string | undefined>();
+      expectTypeOf(gs.endTime).toBeString();
     });
 
-    it('difficultyEvolution is an array of numbers', () => {
+    it("difficultyEvolution is an array of numbers", () => {
       const gs: GameSession = {
-        id: 'sess-ghi-000',
-        uid: 'offline',
-        startTime: '2026-04-10T11:00:00.000Z',
+        id: "sess-ghi-000",
+        uid: "offline",
+        startTime: "2026-04-10T11:00:00.000Z",
         wordsSpelled: 5,
         correctCount: 3,
         difficultyEvolution: [1, -1, 1],
         score: 300,
         bestStreak: 2,
         synced: false,
+        rounds: [],
       };
 
       expectTypeOf(gs.difficultyEvolution).toEqualTypeOf<number[]>();
+    });
+
+    it("accepts GameRound objects in rounds array", () => {
+      const round: GameRound = {
+        word: "elephant",
+        isCorrect: true,
+        points: 100,
+        streak: 3,
+        timeTaken: 5200,
+      };
+
+      expectTypeOf(round).toMatchTypeOf<GameRound>();
+      expectTypeOf(round.word).toBeString();
+      expectTypeOf(round.isCorrect).toBeBoolean();
+      expectTypeOf(round.points).toBeNumber();
+      expectTypeOf(round.streak).toBeNumber();
+      expectTypeOf(round.timeTaken).toEqualTypeOf<number | undefined>();
+    });
+
+    it("GameSession with populated rounds array", () => {
+      const gs: GameSession = {
+        id: "sess-rounds-001",
+        uid: "user-test",
+        startTime: "2026-04-10T10:00:00.000Z",
+        endTime: "2026-04-10T10:10:00.000Z",
+        wordsSpelled: 3,
+        correctCount: 2,
+        difficultyEvolution: [1, 1, -1],
+        score: 250,
+        bestStreak: 2,
+        synced: false,
+        rounds: [
+          {
+            word: "cat",
+            isCorrect: true,
+            points: 100,
+            streak: 1,
+            timeTaken: 3000,
+          },
+          {
+            word: "dog",
+            isCorrect: true,
+            points: 150,
+            streak: 2,
+            timeTaken: 4500,
+          },
+          {
+            word: "elephant",
+            isCorrect: false,
+            points: 0,
+            streak: 0,
+            timeTaken: 12000,
+          },
+        ],
+      };
+
+      expectTypeOf(gs.rounds).toEqualTypeOf<GameRound[]>();
+      expectTypeOf(gs.rounds[0].word).toBeString();
     });
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@
 /**
  * Difficulty levels for words and game configuration.
  */
-export type GameDifficulty = 'easy' | 'medium' | 'hard' | 'all';
+export type GameDifficulty = "easy" | "medium" | "hard" | "all";
 
 /**
  * A single word in the spelling bee word bank.
@@ -22,8 +22,8 @@ export interface Word {
   definition: string;
   /** A sentence using the word (target word replaced with _____ for hints) */
   sentence: string;
-  /** Grade level: 1 (K-2), 3 (3-5), 6 (6-8), 9 (9-12), 0 (all grades) */
-  grade: number;
+  /** Grade level: 1 (K-2), 2 (K-2), 3 (3-5), 4 (3-5), 5 (3-5), 6 (6-8), 7 (6-8), 8 (6-8), 9 (9-12), 10 (9-12), 11 (9-12), 12 (9-12), 0 (all grades) */
+  grade: Grade;
   /** Word difficulty tier */
   difficulty: GameDifficulty;
   /** Part of speech (e.g., "noun", "verb") */
@@ -35,10 +35,10 @@ export interface Word {
 }
 
 /**
- * Convenience alias for the grade field of a Word.
- * Exported so hooks and stores can reference it without re-deriving it.
+ * Valid grade values as a literal union for compile-time enforcement.
+ * Mirrors the grade levels used in the word database (grades 1-12, plus 0 for all).
  */
-export type Grade = Word['grade'];
+export type Grade = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 0;
 
 /**
  * Tracking data for a single word's mastery progress.
@@ -67,7 +67,7 @@ export interface WordProgress {
 /**
  * Phase of the game finite state machine.
  */
-export type GamePhase = 'idle' | 'playing' | 'round_end';
+export type GamePhase = "idle" | "playing" | "round_end";
 
 /**
  * Result of a single spelling submission.
@@ -93,6 +93,22 @@ export interface GameResult {
   normalizedInput: string;
   /** Whether the answer was submitted via voice recognition */
   isVoice: boolean;
+}
+
+/**
+ * Result of a single game round.
+ */
+export interface GameRound {
+  /** The word for this round */
+  word: string;
+  /** Whether the answer was correct */
+  isCorrect: boolean;
+  /** Points awarded */
+  points: number;
+  /** Streak after this round */
+  streak: number;
+  /** Time taken to answer (ms) */
+  timeTaken?: number;
 }
 
 /**
@@ -129,6 +145,8 @@ export interface GameSession {
   bestStreak: number;
   /** Whether this session has been synced to the cloud */
   synced: boolean;
+  /** Individual round results */
+  rounds: GameRound[];
 }
 
 // ---------------------------------------------------------------------------
@@ -138,7 +156,7 @@ export interface GameSession {
 /**
  * Difficulty selector for user-facing settings UI.
  */
-export type PreferenceDifficulty = 'easy' | 'medium' | 'hard' | 'all';
+export type PreferenceDifficulty = "easy" | "medium" | "hard" | "all";
 
 /**
  * Grade level selector for user-facing settings UI.
@@ -146,14 +164,14 @@ export type PreferenceDifficulty = 'easy' | 'medium' | 'hard' | 'all';
  *   'K-2'  → grade 1, '3-5' → grade 3, '6-8' → grade 6,
  *   '9-12' → grade 9, 'all' → grade 0
  */
-export type GradeLevel = 'K-2' | '3-5' | '6-8' | '9-12' | 'all';
+export type GradeLevel = "K-2" | "3-5" | "6-8" | "9-12" | "all";
 
 /**
  * Voice synthesis quality option.
  */
-export type VoiceQuality = 'natural' | 'standard';
+export type VoiceQuality = "natural" | "standard";
 
 /**
  * Listening timeout duration option.
  */
-export type ListeningTimeout = 'normal' | 'longer' | 'off';
+export type ListeningTimeout = "normal" | "longer" | "off";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,12 @@ export interface Word {
 }
 
 /**
+ * Convenience alias for the grade field of a Word.
+ * Exported so hooks and stores can reference it without re-deriving it.
+ */
+export type Grade = Word['grade'];
+
+/**
  * Tracking data for a single word's mastery progress.
  */
 export interface WordProgress {
@@ -67,15 +73,25 @@ export type GamePhase = 'idle' | 'playing' | 'round_end';
  * Result of a single spelling submission.
  */
 export interface GameResult {
+  /** Whether the submitted spelling was correct */
   isCorrect: boolean;
+  /** Points awarded for this submission */
   points: number;
+  /** Running total score after this submission */
   newScore: number;
+  /** Current streak count after this submission */
   newStreak: number;
+  /** Best streak achieved so far in the session */
   newBestStreak: number;
+  /** Human-readable feedback message */
   feedback: string;
+  /** The word that was being spelled */
   targetWord: string;
+  /** Raw text/voice input as received */
   rawInput: string;
+  /** Normalized (trimmed, lowercased) input used for comparison */
   normalizedInput: string;
+  /** Whether the answer was submitted via voice recognition */
   isVoice: boolean;
 }
 
@@ -83,7 +99,9 @@ export interface GameResult {
  * Displayable session statistic.
  */
 export interface SessionStat {
+  /** Human-readable label (e.g., "Words Correct") */
   label: string;
+  /** Formatted or raw value to display */
   value: string | number;
 }
 


### PR DESCRIPTION
…riteria

SUB-01 (#23):
- Add `Grade` standalone type alias (`export type Grade = Word['grade']`) to src/types/index.ts so hooks can import it without re-deriving it
- Add src/types/__tests__/types.test.ts with `satisfies`-based Vitest tests for Word, WordProgress, and GameSession construction

SUB-03 (#25):
- Replace stub public/data/words/grade-1.json (15 words, 729 B) with the full 108-word file ported from buzzy-game (27 kB)
- Export `getCachedGrades()` from src/lib/wordLoader.ts — required by issue AC and the Grade[] return type contract
- Expand src/lib/__tests__/wordLoader.test.ts with four async scenarios: successful load (vi.stubGlobal fetch), cache hit (fetch called once), fetch failure (rejects with typed error), invalid grade (throws)

Closes #23 (remaining ACs)
Closes #25 (remaining ACs)