### PR TITLE
feat: Add PWA install prompt component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Onboarding from "./components/Onboarding";
 import GameBoard from "./components/GameBoard";
 import MetricsBar from "./components/MetricsBar";
 import Settings from "./components/Settings";
+import PwaInstallPrompt from "./components/PwaInstallPrompt";
 import AdminFeedback from "./pages/admin/Feedback";
 
 export default function App() {
@@ -148,6 +149,9 @@ export default function App() {
           ⚠️ You&apos;re offline — game features may be limited
         </div>
       )}
+
+      {/* PWA Install Prompt */}
+      <PwaInstallPrompt />
 
       {view === "game" && (
         <MetricsBar onOpenSettings={() => setIsSettingsOpen(true)} />

--- a/src/components/PwaInstallPrompt.tsx
+++ b/src/components/PwaInstallPrompt.tsx
@@ -1,0 +1,82 @@
+/**
+ * PwaInstallPrompt — dismissible banner prompting the user to install the PWA.
+ *
+ * Renders a compact, animated install banner when the browser fires
+ * `beforeinstallprompt`. Uses the `usePwaInstall` hook to trigger the
+ * native install dialog.
+ */
+
+import { useState, useCallback } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Download, X } from "lucide-react";
+import { usePwaInstall } from "../hooks/usePwaInstall";
+import { Button } from "./ui/button";
+import { cn } from "@/lib/utils";
+
+export default function PwaInstallPrompt() {
+  const { isInstallable, isInstalled, promptInstall } = usePwaInstall();
+  const [dismissed, setDismissed] = useState(false);
+
+  const handleInstall = useCallback(() => {
+    promptInstall();
+  }, [promptInstall]);
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(true);
+  }, []);
+
+  // Don't render if not installable, already installed, or user dismissed
+  if (!isInstallable || isInstalled || dismissed) {
+    return null;
+  }
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -20 }}
+        transition={{ duration: 0.3 }}
+        className={cn(
+          "fixed top-4 left-1/2 z-50 max-w-sm w-[calc(100%-2rem)] -translate-x-1/2",
+          "bg-white dark:bg-gray-800 shadow-lg rounded-xl border border-orange-200",
+          "p-4 flex items-center gap-3",
+        )}
+        role="alert"
+        aria-label="Install Real Bee as an app"
+      >
+        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-orange-100 flex items-center justify-center">
+          <Download className="w-5 h-5 text-orange-600" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Install Real Bee
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+            Add to your home screen for quick access and offline use.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <Button
+            size="sm"
+            variant="default"
+            className="bg-orange-500 hover:bg-orange-600 text-white text-xs px-3 py-1.5 h-auto"
+            onClick={handleInstall}
+          >
+            Install
+          </Button>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            className="p-1 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            aria-label="Dismiss install prompt"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/__tests__/PwaInstallPrompt.test.tsx
+++ b/src/components/__tests__/PwaInstallPrompt.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Tests for src/components/PwaInstallPrompt.tsx
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PwaInstallPrompt from "../PwaInstallPrompt";
+import type { UsePwaInstallResult } from "../../hooks/usePwaInstall";
+
+// ---------------------------------------------------------------------------
+// Mock the usePwaInstall hook
+// ---------------------------------------------------------------------------
+
+vi.mock("../../hooks/usePwaInstall", () => ({
+  usePwaInstall: vi.fn(),
+}));
+
+const mockUsePwaInstall = vi.mocked(
+  await import("../../hooks/usePwaInstall"),
+).usePwaInstall;
+
+function mockPwaInstallState(
+  opts: Pick<UsePwaInstallResult, "isInstallable" | "isInstalled"> & {
+    promptInstall?: () => void;
+  },
+) {
+  mockUsePwaInstall.mockReturnValue({
+    isInstallable: opts.isInstallable,
+    isInstalled: opts.isInstalled,
+    promptInstall: opts.promptInstall ?? vi.fn(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("PwaInstallPrompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders when installable and not installed", () => {
+    mockPwaInstallState({ isInstallable: true, isInstalled: false });
+
+    render(<PwaInstallPrompt />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Install Real Bee")).toBeInTheDocument();
+  });
+
+  it("does not render when not installable", () => {
+    mockPwaInstallState({ isInstallable: false, isInstalled: false });
+
+    const { container } = render(<PwaInstallPrompt />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not render when already installed", () => {
+    mockPwaInstallState({ isInstallable: true, isInstalled: true });
+
+    const { container } = render(<PwaInstallPrompt />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("dismiss button hides the banner", () => {
+    mockPwaInstallState({ isInstallable: true, isInstalled: false });
+
+    render(<PwaInstallPrompt />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    const dismissButton = screen.getByRole("button", { name: /dismiss/i });
+    fireEvent.click(dismissButton);
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("install button calls promptInstall", () => {
+    const promptInstall = vi.fn();
+    mockPwaInstallState({
+      isInstallable: true,
+      isInstalled: false,
+      promptInstall,
+    });
+
+    render(<PwaInstallPrompt />);
+
+    // There are two buttons (Install + dismiss X), find the Install one
+    const buttons = screen.getAllByRole("button");
+    const installButton = buttons.find((btn) => btn.textContent === "Install")!;
+    fireEvent.click(installButton);
+
+    expect(promptInstall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/usePwaInstall.test.ts
+++ b/src/hooks/__tests__/usePwaInstall.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for src/hooks/usePwaInstall.ts
+ *
+ * Verifies:
+ *  - isInstallable becomes true when beforeinstallprompt fires
+ *  - isInstalled detects standalone display mode
+ *  - promptInstall calls prompt() on the deferred event
+ *  - promptInstall is a no-op when no deferred event is available
+ *  - User choice updates isInstalled state
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePwaInstall } from "../usePwaInstall";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockBeforeInstallPromptEvent() {
+  const promptFn = vi.fn().mockResolvedValue(undefined);
+  const userChoicePromise = Promise.resolve({
+    outcome: "accepted" as const,
+    platform: "web",
+  });
+
+  const event = new Event("beforeinstallprompt", { cancelable: true });
+  (event as any).prompt = promptFn;
+  (event as any).userChoice = userChoicePromise;
+
+  return { event, promptFn, userChoicePromise };
+}
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(), // deprecated
+      removeListener: vi.fn(), // deprecated
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("usePwaInstall", () => {
+  let eventListeners: Record<string, Array<(e: any) => void>>;
+
+  beforeEach(() => {
+    eventListeners = {};
+    vi.useFakeTimers();
+
+    // Mock addEventListener/removeEventListener on window
+    vi.spyOn(window, "addEventListener").mockImplementation(
+      (event: string, handler: any) => {
+        if (!eventListeners[event]) eventListeners[event] = [];
+        eventListeners[event].push(handler);
+      },
+    );
+    vi.spyOn(window, "removeEventListener").mockImplementation(
+      (event: string) => {
+        delete eventListeners[event];
+      },
+    );
+
+    // Default: not installed
+    mockMatchMedia(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // isInstallable
+  // -------------------------------------------------------------------------
+
+  describe("isInstallable", () => {
+    it("starts as false", () => {
+      const { result } = renderHook(() => usePwaInstall());
+      expect(result.current.isInstallable).toBe(false);
+    });
+
+    it("becomes true when beforeinstallprompt fires", () => {
+      const { result } = renderHook(() => usePwaInstall());
+
+      // Simulate beforeinstallprompt
+      const { event } = createMockBeforeInstallPromptEvent();
+      act(() => {
+        const handlers = eventListeners["beforeinstallprompt"] ?? [];
+        handlers.forEach((handler) => handler(event));
+      });
+
+      expect(result.current.isInstallable).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isInstalled
+  // -------------------------------------------------------------------------
+
+  describe("isInstalled", () => {
+    it("detects standalone mode on mount", () => {
+      mockMatchMedia(true);
+      const { result } = renderHook(() => usePwaInstall());
+      expect(result.current.isInstalled).toBe(true);
+    });
+
+    it("is false when not in standalone mode", () => {
+      mockMatchMedia(false);
+      const { result } = renderHook(() => usePwaInstall());
+      expect(result.current.isInstalled).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // promptInstall
+  // -------------------------------------------------------------------------
+
+  describe("promptInstall", () => {
+    it("calls prompt() on the deferred event", () => {
+      const { result } = renderHook(() => usePwaInstall());
+
+      const { event, promptFn } = createMockBeforeInstallPromptEvent();
+      act(() => {
+        const handlers = eventListeners["beforeinstallprompt"] ?? [];
+        handlers.forEach((handler) => handler(event));
+      });
+
+      act(() => {
+        result.current.promptInstall();
+      });
+
+      expect(promptFn).toHaveBeenCalled();
+    });
+
+    it("is a no-op when no deferred event is available", () => {
+      const { result } = renderHook(() => usePwaInstall());
+
+      // Should not throw
+      act(() => {
+        result.current.promptInstall();
+      });
+    });
+
+    it("clears installable state after prompt is dismissed", async () => {
+      const { result } = renderHook(() => usePwaInstall());
+
+      const { event, userChoicePromise } =
+        createMockBeforeInstallPromptEvent();
+      act(() => {
+        const handlers = eventListeners["beforeinstallprompt"] ?? [];
+        handlers.forEach((handler) => handler(event));
+      });
+
+      expect(result.current.isInstallable).toBe(true);
+
+      act(() => {
+        result.current.promptInstall();
+      });
+
+      // Wait for userChoice to resolve
+      await act(async () => {
+        await userChoicePromise;
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.isInstallable).toBe(false);
+    });
+  });
+});

--- a/src/hooks/usePwaInstall.ts
+++ b/src/hooks/usePwaInstall.ts
@@ -1,0 +1,115 @@
+/**
+ * usePwaInstall — handles the PWA `beforeinstallprompt` event.
+ *
+ * Provides a typed API to:
+ *  - Detect whether the app is installable
+ *  - Prompt the user to install the PWA
+ *  - Track installation outcome
+ *
+ * The `beforeinstallprompt` event is fired when the browser determines the app
+ * meets the installability criteria (valid manifest, service worker, HTTPS, etc.).
+ * The event must be captured and its `prompt()` method called in response to a
+ * user gesture (click/tap).
+ *
+ * @see https://web.dev/articles/customize-installation
+ *
+ * @example
+ * ```tsx
+ * function InstallButton() {
+ *   const { isInstallable, promptInstall } = usePwaInstall();
+ *   if (!isInstallable) return null;
+ *   return <button onClick={promptInstall}>Install App</button>;
+ * }
+ * ```
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Extended BeforeInstallPromptEvent with the prompt() and userChoice APIs */
+interface BeforeInstallPromptEvent extends Event {
+  /** Call to show the native install prompt (must be called from a user gesture) */
+  prompt: () => Promise<void>;
+  /** Resolves with the user's choice after the prompt is dismissed */
+  userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+}
+
+/** Return type for the usePwaInstall hook */
+export interface UsePwaInstallResult {
+  /** Whether the app meets the installability criteria */
+  isInstallable: boolean;
+  /** Whether the PWA is already installed */
+  isInstalled: boolean;
+  /** Call this from a user gesture (e.g. click handler) to show the install prompt */
+  promptInstall: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Check if the app is running in standalone/display mode (i.e. installed) */
+function isRunningStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(display-mode: standalone)").matches;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function usePwaInstall(): UsePwaInstallResult {
+  const [isInstallable, setIsInstallable] = useState(false);
+  const [isInstalled, setIsInstalled] = useState(isRunningStandalone());
+  const deferredPromptRef = useRef<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    // Listen for beforeinstallprompt — fires when the app is installable
+    const handler = (e: Event) => {
+      // Prevent the default mini-infobar on Android Chrome
+      e.preventDefault();
+      deferredPromptRef.current = e as BeforeInstallPromptEvent;
+      setIsInstallable(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+
+    // Also detect if the app is already installed
+    const mq = window.matchMedia("(display-mode: standalone)");
+    setIsInstalled(mq.matches);
+
+    const onChange = (ev: MediaQueryListEvent) => setIsInstalled(ev.matches);
+    mq.addEventListener("change", onChange);
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handler);
+      mq.removeEventListener("change", onChange);
+    };
+  }, []);
+
+  const promptInstall = useCallback(() => {
+    const deferredPrompt = deferredPromptRef.current;
+    if (!deferredPrompt) return;
+
+    // Show the native install prompt
+    deferredPrompt.prompt();
+
+    // Wait for the user to respond to the prompt
+    deferredPrompt.userChoice.then((choiceResult) => {
+      if (choiceResult.outcome === "accepted") {
+        console.log("[PWA] User accepted the install prompt");
+        setIsInstalled(true);
+      } else {
+        console.log("[PWA] User dismissed the install prompt");
+      }
+      // Clear the deferred prompt so it can't be used again
+      deferredPromptRef.current = null;
+      setIsInstallable(false);
+    });
+  }, []);
+
+  return { isInstallable, isInstalled, promptInstall };
+}

--- a/src/hooks/usePwaInstall.ts
+++ b/src/hooks/usePwaInstall.ts
@@ -94,21 +94,35 @@ export function usePwaInstall(): UsePwaInstallResult {
     const deferredPrompt = deferredPromptRef.current;
     if (!deferredPrompt) return;
 
-    // Show the native install prompt
-    deferredPrompt.prompt();
+    // Clear the deferred event immediately to prevent re-entrant calls
+    deferredPromptRef.current = null;
+    setIsInstallable(false);
 
-    // Wait for the user to respond to the prompt
-    deferredPrompt.userChoice.then((choiceResult) => {
-      if (choiceResult.outcome === "accepted") {
-        console.log("[PWA] User accepted the install prompt");
-        setIsInstalled(true);
-      } else {
-        console.log("[PWA] User dismissed the install prompt");
+    // Use an async IIFE to handle prompt()/userChoice without changing the
+    // public `() => void` signature, while still catching rejections.
+    void (async () => {
+      try {
+        // Show the native install prompt
+        await deferredPrompt.prompt();
+
+        // Wait for the user to respond to the prompt
+        const choiceResult = await deferredPrompt.userChoice;
+        if (choiceResult.outcome === "accepted") {
+          console.log("[PWA] User accepted the install prompt");
+          setIsInstalled(true);
+        } else {
+          console.log("[PWA] User dismissed the install prompt");
+        }
+      } catch (error) {
+        // The browser may reject `prompt()` in unexpected states (e.g. if
+        // called without a genuine user gesture or if the prompt is already
+        // showing). Log at warn level — the UI has already been updated.
+        console.warn(
+          "[PWA] Install prompt failed:",
+          error instanceof Error ? error.message : String(error),
+        );
       }
-      // Clear the deferred prompt so it can't be used again
-      deferredPromptRef.current = null;
-      setIsInstallable(false);
-    });
+    })();
   }, []);
 
   return { isInstallable, isInstalled, promptInstall };


### PR DESCRIPTION
Integrates the new PwaInstallPrompt component into the App. This component displays a banner to encourage users to install the PWA when the browser fires the `beforeinstallprompt` event and the app is installable. It also includes tests for the component and the underlying `usePwaInstall` hook.

Issue: https://github.com/q3ik/real-bee/issues/40